### PR TITLE
docs: add claude skills

### DIFF
--- a/.claude/skills/add-api-route/SKILL.md
+++ b/.claude/skills/add-api-route/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: add-api-route
+description: Use when adding a new API domain, new endpoint to an existing domain, or a new TanStack Query hook. Covers the 4-file pattern (api client + types + hook), query key conventions, mutation invalidation, and error handling.
+---
+
+# Add API Route & TanStack Query Hook
+
+## Pattern overview — 4 files per domain
+
+```
+src/
+├── types/api.ts                  ← 1. Add DTO types here (shared with all consumers)
+├── lib/api/<domain>.ts           ← 2. API functions (thin wrappers over apiClient)
+└── lib/hooks/use-<domain>.ts     ← 3. TanStack Query hooks (consumed by components)
+```
+
+The **`apiClient`** base is at `src/lib/api/client.ts` — import from there, never use `fetch` directly.
+
+---
+
+## Step 1 — Add types to `src/types/api.ts`
+
+Mirror the Go backend response types exactly. Use the naming convention from the backend `iface.go`:
+
+```typescript
+// src/types/api.ts — append new types here
+
+export interface MyEntity {
+  id: string
+  name: string
+  status: 'ACTIVE' | 'INACTIVE'
+  createdAt: string        // ISO string from Go time.Time
+}
+
+export interface CreateMyEntityInput {
+  name: string
+}
+
+// Reuse shared generics already in the file:
+// PaginatedResponse<T>, ApiError
+```
+
+**Rules:**
+- Dates from the Go API are always `string` (ISO 8601) — parse client-side when needed
+- Enums mirror the Go `const` block — use TypeScript string union, not `enum`
+- Never declare the same type in two places — always import from `@/types/api`
+
+---
+
+## Step 2 — Create `src/lib/api/<domain>.ts`
+
+```typescript
+// src/lib/api/my-domain.ts
+import type { MyEntity, CreateMyEntityInput, PaginatedResponse } from '@/types/api'
+import { apiClient } from './client'
+
+// ── Filter type for list endpoints ────────────────────────────────────────────
+export interface MyEntityFilter {
+  status?: string
+  page?: number
+  pageSize?: number
+}
+
+// ── API functions ─────────────────────────────────────────────────────────────
+export const myDomainApi = {
+  list: (filter: MyEntityFilter = {}) =>
+    apiClient.get<PaginatedResponse<MyEntity>>('/my-entities', {
+      params: filter as Record<string, string | number | boolean | undefined>,
+    }),
+
+  getById: (id: string) =>
+    apiClient.get<MyEntity>(`/my-entities/${id}`),
+
+  create: (input: CreateMyEntityInput) =>
+    apiClient.post<MyEntity>('/my-entities', input),
+
+  update: (id: string, input: Partial<CreateMyEntityInput>) =>
+    apiClient.put<MyEntity>(`/my-entities/${id}`, input),
+
+  delete: (id: string) =>
+    apiClient.delete<void>(`/my-entities/${id}`),
+}
+```
+
+**Rules:**
+- Export a single object `myDomainApi` — all functions are methods on it
+- Always import from `./client`, never create a new `fetch` call
+- Filter types are declared in the same file (not in `types/api.ts`)
+- Use explicit generics: `apiClient.get<MyEntity>(...)`
+
+---
+
+## Step 3 — Create `src/lib/hooks/use-<domain>.ts`
+
+```typescript
+// src/lib/hooks/use-my-domain.ts
+'use client'   // only if this file uses browser-only APIs; omit for pure hooks
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { myDomainApi, type MyEntityFilter } from '@/lib/api/my-domain'
+import type { ApiClientError } from '@/lib/api/client'
+
+// ── Query key constants ───────────────────────────────────────────────────────
+// Keep keys as constants — prevents typos and helps with invalidation
+export const MY_ENTITY_KEY = 'my-entities'
+
+// ── Read hooks ────────────────────────────────────────────────────────────────
+export function useMyEntities(filter: MyEntityFilter = {}) {
+  return useQuery({
+    queryKey: [MY_ENTITY_KEY, filter],
+    queryFn: () => myDomainApi.list(filter),
+  })
+}
+
+export function useMyEntity(id: string) {
+  return useQuery({
+    queryKey: [MY_ENTITY_KEY, id],
+    queryFn: () => myDomainApi.getById(id),
+    enabled: !!id,          // don't run if id is empty
+  })
+}
+
+// ── Mutation hooks ────────────────────────────────────────────────────────────
+export function useCreateMyEntity() {
+  const queryClient = useQueryClient()
+  return useMutation<MyEntity, ApiClientError, CreateMyEntityInput>({
+    mutationFn: myDomainApi.create,
+    onSuccess: () => {
+      // Invalidate the list so it refetches — always invalidate by root key
+      queryClient.invalidateQueries({ queryKey: [MY_ENTITY_KEY] })
+    },
+  })
+}
+
+export function useDeleteMyEntity() {
+  const queryClient = useQueryClient()
+  return useMutation<void, ApiClientError, string>({
+    mutationFn: (id) => myDomainApi.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [MY_ENTITY_KEY] })
+    },
+  })
+}
+```
+
+**Query key conventions:**
+| Pattern | Use |
+|---------|-----|
+| `[domain]` | All items in a domain (`invalidateQueries` invalidates everything) |
+| `[domain, filter]` | Filtered list (filter object is stable key part) |
+| `[domain, id]` | Single entity |
+| `[domain, id, 'lineage']` | Subresource of an entity |
+
+**Default query config** (set in `src/lib/providers.tsx`):
+- `staleTime: 30_000` (30 s) — data is fresh for 30 seconds
+- `gcTime: 5 * 60_000` (5 min) — cache entry lives 5 min after last observer
+- `retry: 1` — one automatic retry on failure
+- `refetchOnWindowFocus: false` — disable background refetch on tab switch
+
+---
+
+## Step 4 — Use the hook in a component
+
+```tsx
+'use client'
+
+import { useMyEntities, useCreateMyEntity } from '@/lib/hooks/use-my-domain'
+import { toast } from 'sonner'
+
+export function MyEntityList() {
+  const { data, isLoading, error } = useMyEntities({ status: 'ACTIVE' })
+  const createMutation = useCreateMyEntity()
+
+  if (isLoading) return <Skeleton className="h-10 w-full" />
+  if (error) return <p className="text-destructive">{error.message}</p>
+
+  const handleCreate = async () => {
+    try {
+      await createMutation.mutateAsync({ name: 'New entity' })
+      toast.success('Tạo thành công')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Lỗi không xác định')
+    }
+  }
+
+  return (
+    <ul>
+      {data?.data.map((item) => <li key={item.id}>{item.name}</li>)}
+    </ul>
+  )
+}
+```
+
+---
+
+## Error handling with `ApiClientError`
+
+```typescript
+import { ApiClientError } from '@/lib/api/client'
+
+try {
+  await myDomainApi.create(input)
+} catch (err) {
+  if (err instanceof ApiClientError) {
+    if (err.status === 422) {
+      // Validation error — err.details is Record<string, string>
+      console.log(err.details)
+    }
+    if (err.status === 409) {
+      toast.error('Đã tồn tại — không thể tạo trùng')
+    }
+  }
+}
+```
+
+Common Go backend status codes:
+- `400` Bad Request (invalid input)
+- `404` Not found → maps to Go `domain.ErrNotFound`
+- `409` Conflict (duplicate)
+- `422` Unprocessable (business rule violation)
+- `503` Backend unavailable

--- a/.claude/skills/add-page/SKILL.md
+++ b/.claude/skills/add-page/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: add-page
+description: Use when adding a new page or route — choosing the correct route group (kiosk/dashboard/auth), structuring the page file, adding loading.tsx and error.tsx siblings, and following responsive layout rules.
+---
+
+# Add a New Page
+
+## Route group decision tree
+
+```
+Is this for shop-floor workers on mobile?  →  (kiosk)
+Is this for managers on desktop/tablet?    →  (dashboard)
+Is this an auth screen (login/PIN)?        →  (auth)
+```
+
+Route groups don't appear in the URL:
+- `src/app/(kiosk)/my-page/page.tsx` → URL: `/my-page`
+- `src/app/(dashboard)/my-page/page.tsx` → URL: `/my-page`
+- `src/app/(auth)/my-page/page.tsx` → URL: `/my-page`
+
+---
+
+## Minimum file set for every new page
+
+```
+src/app/(group)/my-page/
+├── page.tsx        ← required — the page itself
+├── loading.tsx     ← required — Suspense skeleton shown while page loads
+└── error.tsx       ← recommended — recoverable per-route error boundary
+```
+
+---
+
+## Page template — server component (default)
+
+```tsx
+// src/app/(kiosk)/my-page/page.tsx
+import type { Metadata } from 'next'
+// Import shadcn components from @/components/ui/
+// Import kiosk components from @/components/kiosk/
+// Import dashboard components from @/components/dashboard/
+
+export const metadata: Metadata = { title: 'Tên màn hình' }
+
+export default function MyPage() {
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-xl font-bold">Tên màn hình</h1>
+      {/* page content */}
+    </div>
+  )
+}
+```
+
+**Rules for server components (default):**
+- Export `metadata` — always include `title`
+- No `'use client'` at the top unless you need state/effects
+- Data fetching happens in async sub-components or client components via TanStack Query
+
+---
+
+## Page template — client component (when state/hooks needed)
+
+```tsx
+'use client'
+
+import type { Metadata } from 'next'
+import { useMyEntities } from '@/lib/hooks/use-my-domain'
+
+// metadata can't be exported from 'use client' pages
+// Instead, export it from a parent layout or a separate server wrapper
+
+export default function MyClientPage() {
+  const { data, isLoading } = useMyEntities()
+  // ...
+}
+```
+
+If you need both metadata AND client hooks, split into a server wrapper + client component:
+```tsx
+// page.tsx (server) — exports metadata, renders the client component
+import type { Metadata } from 'next'
+import { MyPageContent } from './_components/my-page-content'   // client component
+
+export const metadata: Metadata = { title: 'My Page' }
+
+export default function MyPage() {
+  return <MyPageContent />
+}
+```
+
+---
+
+## loading.tsx template
+
+```tsx
+// src/app/(kiosk)/my-page/loading.tsx
+import { Skeleton } from '@/components/ui/skeleton'
+import { Card, CardContent } from '@/components/ui/card'
+
+export default function MyPageLoading() {
+  return (
+    <div className="space-y-4 p-4">
+      <Skeleton className="h-7 w-40" />          {/* page title */}
+      {[1, 2, 3].map((i) => (
+        <Card key={i}>
+          <CardContent className="p-4">
+            <Skeleton className="mb-2 h-5 w-32" />
+            <Skeleton className="h-4 w-48" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}
+```
+
+Mirror the visual structure of the actual page — same number of "cards", similar heights.
+
+---
+
+## error.tsx template
+
+```tsx
+// src/app/(kiosk)/my-page/error.tsx
+'use client'    // error boundaries must be client components
+
+import { useEffect } from 'react'
+import { Button } from '@/components/ui/button'
+
+export default function MyPageError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    // Optional: log to error reporting service
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="flex min-h-[40vh] flex-col items-center justify-center gap-4 p-4 text-center">
+      <p className="font-medium">Có lỗi xảy ra</p>
+      <p className="text-sm text-muted-foreground">{error.message}</p>
+      <Button onClick={reset}>Thử lại</Button>
+    </div>
+  )
+}
+```
+
+---
+
+## Layout rules by route group
+
+### (kiosk) pages — mobile-first
+
+```tsx
+// Outer wrapper: vertical stack with p-4 padding
+<div className="space-y-4 p-4">
+  <h1 className="text-xl font-bold">Tiêu đề</h1>
+
+  {/* Kiosk cards: touch-optimized */}
+  <Card>
+    <CardContent className="flex items-center justify-between p-4">
+      {/* content */}
+    </CardContent>
+  </Card>
+
+  {/* Primary action: always BigButton at bottom */}
+  <BigButton>Hành động chính</BigButton>
+</div>
+```
+
+Kiosk checklist:
+- [ ] Font size ≥ 16px for all interactive text
+- [ ] Touch targets ≥ 48px height for tappable items
+- [ ] Primary action uses `BigButton` (min-h: 56px, full-width)
+- [ ] Text labels in **Vietnamese** (worker-facing)
+- [ ] Pull-to-refresh via TanStack Query `refetchOnWindowFocus` or manual button
+- [ ] Skeleton loading in `loading.tsx` mirrors page structure
+
+### (dashboard) pages — desktop/tablet
+
+```tsx
+// Outer wrapper: responsive grid layout
+<div className="space-y-6">
+  <h1 className="text-2xl font-bold">Tiêu đề</h1>
+
+  {/* KPI row */}
+  <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    <StatCard title="Metric" value="123" icon={SomeIcon} />
+  </div>
+
+  {/* Alert banner if relevant */}
+  <AlertBanner status="GREEN" utilizationPct={8} message="..." />
+
+  {/* Data table */}
+  <div className="rounded-xl border bg-card shadow-sm">
+    <Table>...</Table>
+  </div>
+</div>
+```
+
+Dashboard checklist:
+- [ ] Title uses `text-2xl font-bold`
+- [ ] Stats use `StatCard` from `@/components/dashboard/stat-card`
+- [ ] Overflow alerts use `AlertBanner` from `@/components/dashboard/alert-banner`
+- [ ] Tables use shadcn `Table` components
+- [ ] Responsive: `sm:` and `lg:` breakpoints for grid columns
+
+---
+
+## Responsive breakpoints
+
+| Breakpoint | Width | Context |
+|------------|-------|---------|
+| base | 375 px | Mobile kiosk (shop floor) |
+| `sm:` | 640 px | — |
+| `md:` | 768 px | Tablet |
+| `lg:` | 1024 px | — |
+| `xl:` | 1280 px | Desktop dashboard |
+
+Always design base (mobile) first, then add `md:` / `lg:` overrides.
+
+---
+
+## Internal links
+
+Always use `next/link` for navigation — never `<a href>` for internal routes:
+
+```tsx
+import Link from 'next/link'
+
+<Link href="/cutting-orders" className="...">Lệnh cắt</Link>
+```
+
+For programmatic navigation in client components:
+
+```tsx
+'use client'
+import { useRouter } from 'next/navigation'
+
+const router = useRouter()
+router.push('/cutting-orders')
+```

--- a/.claude/skills/add-shadcn-component/SKILL.md
+++ b/.claude/skills/add-shadcn-component/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: add-shadcn-component
+description: Use when adding a new shadcn/ui component to the project — running the CLI, placing files, writing wrappers, or creating custom CVA-based variants following the existing button/card/badge patterns.
+---
+
+# Add shadcn/ui Component
+
+## CLI — add an existing shadcn component
+
+```bash
+# Always use the latest CLI
+npx shadcn@latest add <component-name>
+```
+
+The component is placed automatically at **`src/components/ui/<component>.tsx`** (configured via `components.json`).
+
+Common components available:
+- `accordion` `alert-dialog` `avatar` `checkbox` `collapsible` `command`
+- `dropdown-menu` `form` `hover-card` `popover` `progress` `radio-group`
+- `scroll-area` `sheet` `slider` `switch` `tabs` `textarea` `toggle`
+- `tooltip`
+
+After adding, import from `@/components/ui/<component>`.
+
+## Project configuration (`components.json`)
+
+| Setting | Value |
+|---------|-------|
+| Style | `new-york` |
+| Base color | `neutral` |
+| CSS variables | `true` (oklch color space) |
+| Icon library | `lucide-react` |
+| Alias | `@/components/ui` |
+| Utils | `@/lib/utils` (exports `cn`) |
+
+## Golden rule — never modify generated files
+
+Do **not** edit files under `src/components/ui/` directly.
+Instead, create a **wrapper component** in `src/components/kiosk/`, `src/components/dashboard/`, or a new domain folder.
+
+```tsx
+// ✅ Correct — wrapper in src/components/kiosk/big-button.tsx
+import { Button, type buttonVariants } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+export function BigButton({ className, ...props }) {
+  return <Button className={cn('min-h-[56px] w-full text-lg', className)} {...props} />
+}
+
+// ❌ Wrong — editing src/components/ui/button.tsx directly
+```
+
+## Writing a custom component from scratch (CVA pattern)
+
+Follow the exact same pattern used in `src/components/ui/button.tsx`:
+
+```tsx
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'          // for asChild polymorphism
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+const myVariants = cva(
+  // 1. Base classes (always applied)
+  'inline-flex items-center rounded-md text-sm font-medium transition-all disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        primary: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+      },
+      size: {
+        default: 'h-9 px-4',
+        sm: 'h-8 px-3',
+        lg: 'h-11 px-6',
+      },
+    },
+    defaultVariants: { variant: 'primary', size: 'default' },
+  },
+)
+
+interface MyComponentProps
+  extends React.ComponentProps<'button'>,
+    VariantProps<typeof myVariants> {
+  asChild?: boolean   // allow rendering as a different element
+}
+
+function MyComponent({ className, variant, size, asChild = false, ...props }: MyComponentProps) {
+  const Comp = asChild ? Slot : 'button'
+  return (
+    <Comp
+      data-slot="my-component"          // data-slot for shadcn consistency
+      className={cn(myVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { MyComponent, myVariants }     // export both component AND variants
+```
+
+## CSS variables for colors
+
+Always reference design tokens — never hardcode hex/rgb values:
+
+```tsx
+// ✅ Uses CSS variables (respects dark mode automatically)
+className="bg-primary text-primary-foreground"
+className="bg-destructive text-white"
+className="border-border bg-card"
+className="text-muted-foreground"
+
+// ❌ Hardcoded — breaks dark mode
+className="bg-black text-white"
+```
+
+Available tokens: `--background`, `--foreground`, `--primary`, `--primary-foreground`, `--secondary`, `--muted`, `--accent`, `--destructive`, `--border`, `--ring`, `--card`, `--chart-1..5`, `--sidebar-*`
+
+## Sonner toast integration
+
+After a user action, always give feedback:
+
+```tsx
+import { toast } from 'sonner'
+
+toast.success('Tấm lẻ đã được nhập kho')
+toast.error('Không thể kết nối API')
+toast.loading('Đang xử lý...')
+```
+
+## Accessibility checklist
+
+- All interactive elements: `focus-visible:ring-[3px] focus-visible:ring-ring/50`
+- Disabled state: `disabled:pointer-events-none disabled:opacity-50`
+- Icons inside buttons: `aria-hidden="true"` + sr-only text if icon-only
+- Touch targets (kiosk): minimum `min-h-[48px] min-w-[48px]`

--- a/.claude/skills/kiosk-component/SKILL.md
+++ b/.claude/skills/kiosk-component/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: kiosk-component
+description: Use when building any component for the (kiosk) route group — shop-floor mobile UI for workers. Covers touch targets, BigButton, ScannerView, QR print, Vietnamese labels, and sonner toasts.
+---
+
+# Kiosk Component Guidelines
+
+The kiosk is a mobile-first PWA used by factory workers (Vietnamese speakers) on Android phones and tablets at the shop floor. Every component must be operable with one hand, gloves on, in a dusty/noisy environment.
+
+## Non-negotiable rules
+
+| Rule | Value |
+|------|-------|
+| Min touch target height | **48 px** (`min-h-[48px]`) |
+| Min touch target width | **48 px** |
+| Primary action button height | **56 px** (`BigButton` — `min-h-[56px]`) |
+| Base font size | **≥ 16 px** (avoids iOS auto-zoom on focus) |
+| Max steps to complete a task | **3 taps** |
+| UI language | **Vietnamese** |
+| Loading feedback | **Instant skeleton** (`loading.tsx`) |
+| Action feedback | **sonner toast** within 300 ms |
+
+---
+
+## `BigButton` — primary actions
+
+Import from `@/components/kiosk/big-button`. Use for every primary action (submit, confirm, scan, print).
+
+```tsx
+import { BigButton } from '@/components/kiosk/big-button'
+
+// Primary action
+<BigButton onClick={handleSubmit} disabled={isPending}>
+  {isPending ? 'Đang xử lý...' : 'Báo cáo kết quả'}
+</BigButton>
+
+// Danger action (e.g. discard)
+<BigButton variant="danger" onClick={handleCancel}>
+  Huỷ lệnh
+</BigButton>
+
+// Secondary action
+<BigButton variant="secondary">Bỏ qua</BigButton>
+```
+
+**Props**: `variant: 'primary' | 'secondary' | 'danger'` + all standard `<button>` props.
+
+Do **not** use `Button` from `@/components/ui/button` for primary kiosk actions — it's too small.
+
+---
+
+## `ScannerView` — QR / barcode scanning
+
+Import from `@/components/kiosk/scanner-view`. Always wrap in a `Card`.
+
+```tsx
+import { ScannerView } from '@/components/kiosk/scanner-view'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+<Card>
+  <CardHeader>
+    <CardTitle className="text-base">Quét mã QR tấm lẻ</CardTitle>
+  </CardHeader>
+  <CardContent>
+    <ScannerView
+      onScan={(code) => {
+        // code is the decoded QR string — parse JSON or use as ID
+        try {
+          const data = JSON.parse(code)
+          // e.g. { type: 'REMNANT', id: 'R-001', ... }
+          handleScan(data)
+        } catch {
+          // plain barcode string
+          handleScan({ id: code })
+        }
+      }}
+    />
+  </CardContent>
+</Card>
+```
+
+**Behaviour:**
+- Uses `html5-qrcode` (dynamically imported, no SSR issues)
+- Camera facing: `environment` (back camera)
+- Falls back to manual text input automatically if camera permission denied
+- `onScan` fires once per detected code
+
+**QR content format** (from Go backend):
+```json
+{ "type": "REMNANT" | "WIP", "id": "...", "sku": "...", "dimensions": {...}, "lot": "...", "location": "..." }
+```
+
+---
+
+## `LabelPreview` — print label preview
+
+Import from `@/components/kiosk/label-preview`.
+
+```tsx
+import { LabelPreview } from '@/components/kiosk/label-preview'
+import type { BarcodeRecord } from '@/types/api'
+
+// After RecordCut succeeds and returns barcodeIds, fetch the record:
+<LabelPreview barcode={barcodeRecord} size="small" />   // 50×30mm remnant label
+<LabelPreview barcode={barcodeRecord} size="large" />   // 100×70mm WIP label
+```
+
+Clicking the preview opens `window.print()` — browser print dialog.
+
+---
+
+## `BottomNav` — navigation (already in layout)
+
+The kiosk layout (`src/app/(kiosk)/layout.tsx`) already renders `BottomNav`. **Do not add another nav** inside page components.
+
+The bottom nav has 4 tabs:
+- `/cutting-orders` — Lệnh cắt
+- `/report-cut` — Báo cáo
+- `/remnant-list` — Kho tấm lẻ
+- `/scan` — Quét mã
+
+---
+
+## Toast notifications (sonner)
+
+Always give feedback immediately after user action:
+
+```tsx
+import { toast } from 'sonner'
+
+// After successful API call
+toast.success('Đã nhập kho tấm lẻ thành công')
+
+// After API error
+toast.error('Lỗi kết nối — vui lòng thử lại')
+
+// Loading state during mutation
+const toastId = toast.loading('Đang xử lý...')
+// then:
+toast.dismiss(toastId)
+toast.success('Hoàn thành')
+```
+
+---
+
+## Standard kiosk page structure
+
+```tsx
+import type { Metadata } from 'next'
+import { BigButton } from '@/components/kiosk/big-button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+export const metadata: Metadata = { title: 'Tên màn hình' }
+
+export default function KioskPage() {
+  return (
+    <div className="space-y-4 p-4">
+      {/* Page title */}
+      <h1 className="text-xl font-bold">Tên màn hình</h1>
+
+      {/* Content cards — each step in a separate card */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Bước 1 — ...</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {/* step content */}
+        </CardContent>
+      </Card>
+
+      {/* Optional: remnant suggestion list */}
+      {/* <RemnantSuggestionList /> */}
+
+      {/* Primary action — always at the bottom */}
+      <BigButton disabled={!isReady}>
+        Xác nhận
+      </BigButton>
+    </div>
+  )
+}
+```
+
+---
+
+## Form inputs on mobile
+
+Use `inputMode` to trigger the right mobile keyboard:
+
+```tsx
+<Input
+  type="number"
+  inputMode="numeric"    // numeric keypad (no minus sign)
+  placeholder="1200"
+  className="h-12 text-base"   // larger height + font for kiosk
+/>
+
+<Input
+  inputMode="decimal"    // numeric with decimal point
+  className="h-12 text-base"
+/>
+```
+
+---
+
+## Workflow patterns
+
+### Two-scan flow (scan remnant → scan location)
+
+```tsx
+const [remnantId, setRemnantId] = useState<string | null>(null)
+const [locationId, setLocationId] = useState<string | null>(null)
+const assignMutation = useAssignLocation()
+
+// Step 1: scan remnant
+<ScannerView onScan={(code) => setRemnantId(JSON.parse(code).id)} />
+
+// Step 2: scan location (visible only after step 1)
+{remnantId && (
+  <ScannerView onScan={(code) => setLocationId(JSON.parse(code).id)} />
+)}
+
+// Confirm button (enabled only when both scanned)
+<BigButton
+  disabled={!remnantId || !locationId || assignMutation.isPending}
+  onClick={() => assignMutation.mutate({ id: remnantId!, locationId: locationId! })}
+>
+  Xác nhận nhập kho
+</BigButton>
+```

--- a/.claude/skills/remnant-flow-domain/SKILL.md
+++ b/.claude/skills/remnant-flow-domain/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: remnant-flow-domain
+description: Use when implementing any feature related to remnant tracking, allocation, cutting records, costing, overflow alerts, or barcode/QR. Provides the business rules and API endpoints without requiring you to read the docs.
+---
+
+# Remnant Flow Domain Knowledge
+
+This system manages the "Remnant Flow" (Dòng chảy Vật tư dư) in a woodworking furniture workshop. Raw board sheets are CNC-cut into WIP products; leftover pieces become **remnants** tracked through the system.
+
+---
+
+## Core entities
+
+| Entity | Key fields | Notes |
+|--------|-----------|-------|
+| `BoardSheet` | `id`, `materialType`, `lengthMm`, `widthMm`, `thicknessMm`, `unitCost`, `status` | Raw plywood/MDF before cutting |
+| `Remnant` | `id`, `parentRemnantId`, `sourceBoardSheetId`, `status`, `boundingBoxLengthMm`, `boundingBoxWidthMm`, `binLocationId` | Leftover material |
+| `WorkOrder` | `id`, `sku`, `requiredLengthMm`, `requiredWidthMm`, `status` | Single cutting task |
+| `StorageLocation` | `id`, `zone`, `rack`, `shelf`, `barcode` | Physical bin location (e.g. A1-R2-S3) |
+
+All types are defined in `src/types/api.ts`.
+
+---
+
+## Remnant lifecycle
+
+```
+AVAILABLE ──allocate()──→ ALLOCATED ──recordCut()──→ USED
+                │
+                └──auto-release after 24h──→ AVAILABLE
+
+AVAILABLE ──recordCut() with no material left──→ DEPLETED
+```
+
+**State meanings:**
+- `AVAILABLE` — ready to be allocated or cut
+- `ALLOCATED` — reserved for a work order (locked, 24h auto-release)
+- `USED` — fully consumed, no longer in inventory
+- `DEPLETED` — cut down to zero usable area
+
+**Never display `USED` or `DEPLETED` remnants in the available inventory UI.**
+
+---
+
+## Attribute inheritance (Sprint 2)
+
+When a remnant is produced from a cut, it automatically inherits from its source:
+- `supplierCode` → from board sheet or parent remnant
+- `lotBatch` → same
+- `grainPattern` → same
+- `qualityGrade` → same
+- `materialType` → same
+
+The `boundingBoxLengthMm` and `boundingBoxWidthMm` represent the smallest axis-aligned rectangle that fits the usable area (not the actual ragged shape).
+
+---
+
+## Nested cutting (lineage chain)
+
+A remnant can itself be cut, producing child remnants:
+
+```
+BoardSheet ─── RecordCut ──→ WIP Products
+                           └→ Remnant A (parentRemnantId: null, sourceBoardSheetId: BS-01)
+                                  │
+                              RecordCut
+                                  │
+                                  └→ WIP Products
+                                   └→ Remnant A.1 (parentRemnantId: A, sourceBoardSheetId: BS-01)
+                                         │
+                                     RecordCut
+                                         └→ Remnant A.1.1 (parentRemnantId: A.1, ...)
+```
+
+**Area conservation rule**: at every cut, `used_area + remnant_area + waste_area = source_area`. The Go backend enforces this with `BR-K03`.
+
+---
+
+## Best Fit + FIFO allocation algorithm
+
+When suggesting a remnant for a work order:
+
+```
+fit_score  = required_area / bounding_box_area   // 1.0 = perfect fit, lower = more waste
+age_score  = days_in_stock / max_days_in_stock   // higher = older = prefer to use first
+
+combined_score = w1 * fit_score + w2 * age_score
+              = 0.6 * fit_score + 0.4 * age_score   // defaults (configurable)
+```
+
+**Display suggestion quality**: `wastePct = 1 - fit_score` → show as "% hao hụt".
+A good suggestion has `wastePct ≤ 10%`.
+
+---
+
+## Overflow alert
+
+```
+utilization = total_remnant_area_m2 / total_raw_stock_area_m2
+
+GREEN:  utilization ≤ 10%   → normal
+YELLOW: 10% < utilization ≤ 15% → warning
+RED:    utilization > 15%   → block new sheet issuance
+```
+
+When `status === 'RED'`:
+- `blockNewSheetIssue: true`
+- Show sticky `AlertBanner` at top of dashboard overview
+- `POST /inventory/issue-sheet` returns `422` with Vietnamese message
+
+---
+
+## Costing rules
+
+1. **Flat cut from board sheet**:
+   `remnant_value = (remnant_area / sheet_area) * sheet_unit_cost`
+
+2. **Nested remnant cut**:
+   `remnant_value = (remnant_area / parent_remnant_area) * parent_remnant_value`
+
+3. **Waste** is treated as overhead (absorbed by the PO) — not allocated to a specific SKU.
+
+4. **Remnant savings** = cost avoided by using remnant instead of issuing a new sheet.
+
+---
+
+## Key API endpoints
+
+| Endpoint | Method | When to call |
+|----------|--------|-------------|
+| `/remnants` | GET | List available remnants (filter by size, material, status) |
+| `/remnants/:id/lineage` | GET | Show parent/child tree for a remnant |
+| `/inventory/suggest-allocation` | POST | Get Best Fit + FIFO suggestions for a work order |
+| `/inventory/allocate` | POST | Lock a remnant for 24h |
+| `/inventory/release-allocation` | POST | Manually release a locked remnant |
+| `/inventory/record-cut` | POST | Record a completed cut (creates remnant + barcode) |
+| `/inventory/overflow-status` | GET | Get GREEN/YELLOW/RED status |
+| `/storage-locations` | CRUD | Manage bin locations |
+| `/remnants/:id/location` | PUT | Assign remnant to a bin location |
+| `/barcode/:id/qr` | GET | Get QR image (PNG) |
+| `/barcode/:id/label` | GET | Get printable PDF label |
+| `/barcode/batch-print` | POST | Batch print multiple labels |
+| `/barcode/scan` | POST | Record a checkpoint scan event |
+| `/dashboard/remnant-summary` | GET | KPIs: count, area, avg age |
+| `/dashboard/cutting-efficiency` | GET | Waste % by week/month |
+| `/costing/reports` | GET | Cost report by PO |
+
+All are under the base URL `NEXT_PUBLIC_API_URL` (default: `http://localhost:8080/api/v1`).
+All typed in `src/lib/api/remnants.ts`, `cutting-orders.ts`, `barcode.ts`, `dashboard.ts`.
+
+---
+
+## Scan checkpoints (3 fixed)
+
+| Checkpoint | Vietnamese label | When |
+|------------|-----------------|------|
+| `CNC_COMPLETE` | Hoàn thành CNC | After CNC machine finishes |
+| `FINISHING_COMPLETE` | Hoàn thành gia công | After sanding/finishing |
+| `WAREHOUSE_SHIP` | Xuất kho | When goods leave warehouse |
+
+Use `ScannerView` on the `/scan` kiosk page to capture these.
+
+---
+
+## QR code content format
+
+QR codes encode JSON:
+```json
+{
+  "type": "REMNANT" | "WIP",
+  "id": "uuid-here",
+  "sku": "SKU-001",
+  "dimensions": { "lengthMm": 800, "widthMm": 400, "thicknessMm": 18 },
+  "lot": "LOT-2026-03",
+  "location": "A1-R2-S3"
+}
+```
+
+Always `JSON.parse()` the scanned string — if it fails, treat as a plain barcode ID.
+
+---
+
+## Work order status machine
+
+```
+PLANNED ──approve──→ IN_CUTTING ──recordCut──→ IN_PROCESSING ──finish──→ COMPLETED
+```
+
+Only `IN_CUTTING` work orders appear in the kiosk "Lệnh cắt hôm nay" screen.
+Filter: `cuttingOrdersApi.list({ status: 'IN_CUTTING' })`.

--- a/.claude/skills/typescript-patterns/SKILL.md
+++ b/.claude/skills/typescript-patterns/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: typescript-patterns
+description: Use when writing TypeScript in this project — API DTOs, component prop types, hook generics, strict null handling, and avoiding common TS mistakes with the existing codebase patterns.
+---
+
+# TypeScript Patterns
+
+## Golden rule — import types, never re-declare
+
+All API DTOs are in **`src/types/api.ts`**. Import them everywhere:
+
+```typescript
+// ✅ Correct
+import type { Remnant, WorkOrder, PaginatedResponse } from '@/types/api'
+
+// ❌ Wrong — re-declaring inline creates divergence with the backend
+interface Remnant { id: string; ... }
+```
+
+If the type doesn't exist yet in `src/types/api.ts`, add it there — not locally.
+
+---
+
+## Component prop types — extend HTML elements
+
+Follow the `ComponentProps<>` pattern used in all shadcn components:
+
+```tsx
+import * as React from 'react'
+
+// ✅ Extend native HTML element props — gets all HTML attributes for free
+interface ButtonProps extends React.ComponentProps<'button'> {
+  variant?: 'primary' | 'danger'
+  isLoading?: boolean
+}
+
+// ✅ For custom wrapper components, extend the base component's props
+import type { buttonVariants } from '@/components/ui/button'
+import type { VariantProps } from 'class-variance-authority'
+
+interface MyButtonProps
+  extends React.ComponentProps<'button'>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+// ❌ Avoid manual prop declarations that duplicate HTML attrs
+interface BadButtonProps {
+  onClick: () => void    // too narrow — blocks onMouseDown, etc.
+  disabled: boolean
+  className: string
+}
+```
+
+---
+
+## TanStack Query generics
+
+Always specify the generic types for full type inference and better error handling:
+
+```typescript
+import { useQuery, useMutation } from '@tanstack/react-query'
+import type { Remnant, PaginatedResponse } from '@/types/api'
+import type { ApiClientError } from '@/lib/api/client'
+
+// useQuery<TData, TError>
+const { data } = useQuery<PaginatedResponse<Remnant>, ApiClientError>({
+  queryKey: ['remnants'],
+  queryFn: () => remnantsApi.list(),
+})
+// data is typed as PaginatedResponse<Remnant> | undefined
+
+// useMutation<TData, TError, TVariables>
+const mutation = useMutation<Remnant, ApiClientError, { id: string; locationId: string }>({
+  mutationFn: ({ id, locationId }) => remnantsApi.assignLocation(id, locationId),
+})
+```
+
+---
+
+## Strict null / undefined handling
+
+The project uses `"strict": true`. Always handle nullable values:
+
+```typescript
+// useQuery returns data as T | undefined until it resolves
+const { data } = useRemnants()
+
+// ✅ Optional chaining
+const count = data?.total ?? 0
+const items = data?.data ?? []
+
+// ✅ Early return in JSX
+if (!data) return <Skeleton />
+
+// ✅ Non-null assertion only when you KNOW a value is defined
+// (after a guard check above)
+const id = remnant!.id   // only after if (!remnant) return ...
+
+// ❌ Unsafe assertion without guard
+const id = data!.total   // will crash if data is undefined
+```
+
+---
+
+## `ApiClientError` — typed error handling
+
+```typescript
+import { ApiClientError } from '@/lib/api/client'
+
+// Pattern 1 — in mutation callbacks
+useMutation({
+  mutationFn: myApi.create,
+  onError: (err: ApiClientError) => {
+    if (err.status === 422) {
+      // err.details is Record<string, string> — field-level validation errors
+      const fieldErrors = err.details ?? {}
+      setErrors(fieldErrors)
+    } else {
+      toast.error(err.message)
+    }
+  },
+})
+
+// Pattern 2 — in try/catch
+try {
+  await myApi.create(input)
+} catch (err) {
+  if (err instanceof ApiClientError) {
+    // typed — err.status, err.code, err.message, err.details
+    if (err.status === 404) return toast.error('Không tìm thấy')
+    if (err.status === 409) return toast.error('Đã tồn tại')
+  }
+  // unknown errors — rethrow or show generic message
+  toast.error('Lỗi không xác định')
+}
+```
+
+---
+
+## Avoiding `any`
+
+```typescript
+// ❌ Never use any
+const data: any = await fetch(...)
+
+// ✅ Use unknown + type narrowing
+const raw: unknown = JSON.parse(qrCode)
+if (raw && typeof raw === 'object' && 'id' in raw) {
+  const id = (raw as { id: string }).id
+}
+
+// ✅ Or use a type assertion with a guard function
+function isQrPayload(v: unknown): v is QrPayload {
+  return typeof v === 'object' && v !== null && 'type' in v && 'id' in v
+}
+
+const parsed: unknown = JSON.parse(code)
+if (isQrPayload(parsed)) {
+  handleScan(parsed) // typed as QrPayload
+}
+```
+
+---
+
+## Zustand store typing
+
+Follow the pattern in `src/lib/hooks/use-scan.ts`:
+
+```typescript
+import { create } from 'zustand'
+
+interface MyStore {
+  // state
+  count: number
+  items: string[]
+  // actions
+  increment: () => void
+  addItem: (item: string) => void
+  reset: () => void
+}
+
+export const useMyStore = create<MyStore>((set) => ({
+  count: 0,
+  items: [],
+  increment: () => set((s) => ({ count: s.count + 1 })),
+  addItem: (item) => set((s) => ({ items: [...s.items, item] })),
+  reset: () => set({ count: 0, items: [] }),
+}))
+```
+
+---
+
+## `cn()` utility for conditional classes
+
+```typescript
+import { cn } from '@/lib/utils'   // combines clsx + tailwind-merge
+
+// Basic usage
+className={cn('base-class', conditionalClass && 'applied-if-truthy')}
+
+// With variants
+className={cn(
+  'flex items-center',
+  isActive && 'bg-primary text-primary-foreground',
+  isDisabled && 'opacity-50 pointer-events-none',
+  className,   // always allow override via props
+)}
+
+// tailwind-merge resolves conflicts automatically:
+cn('px-4 px-6')  // → 'px-6' (last wins)
+cn('text-sm', 'text-lg')  // → 'text-lg'
+```
+
+---
+
+## Common import paths
+
+```typescript
+// Types
+import type { Remnant, WorkOrder, BarcodeRecord } from '@/types/api'
+
+// API client
+import { apiClient, ApiClientError } from '@/lib/api/client'
+
+// Domain API functions
+import { remnantsApi } from '@/lib/api/remnants'
+import { cuttingOrdersApi } from '@/lib/api/cutting-orders'
+
+// Hooks
+import { useRemnants, useAllocateRemnant } from '@/lib/hooks/use-remnants'
+import { useRecordCut } from '@/lib/hooks/use-cutting-orders'
+
+// UI components
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+// Kiosk components
+import { BigButton } from '@/components/kiosk/big-button'
+import { ScannerView } from '@/components/kiosk/scanner-view'
+import { LabelPreview } from '@/components/kiosk/label-preview'
+
+// Dashboard components
+import { StatCard } from '@/components/dashboard/stat-card'
+import { AlertBanner } from '@/components/dashboard/alert-banner'
+
+// Utilities
+import { cn } from '@/lib/utils'
+import { toast } from 'sonner'
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,21 @@ Vmarble Warehouse Management System — **Remnant Flow MVP** for a woodworking f
 
 ---
 
+## Claude Skills
+
+Project-specific skills live in `.claude/skills/`. They are loaded on-demand based on relevance.
+
+| Skill | Trigger |
+|-------|---------|
+| `add-shadcn-component` | Adding UI components, shadcn CLI, CVA variants, wrapper pattern |
+| `add-api-route` | New API domain, endpoint, or TanStack Query hook |
+| `add-page` | New page/route — route group, metadata, loading/error siblings |
+| `kiosk-component` | Mobile kiosk components — BigButton, ScannerView, touch rules |
+| `remnant-flow-domain` | Business logic — remnant lifecycle, allocation, costing, overflow |
+| `typescript-patterns` | DTO imports, hook generics, strict null, `cn()`, error handling |
+
+---
+
 ## Commands
 
 ### Backend (Go)


### PR DESCRIPTION
File structure to create

     .claude/
     └── skills/
         ├── add-shadcn-component/
         │   └── SKILL.md
         ├── add-api-route/
         │   └── SKILL.md
         ├── add-page/
         │   └── SKILL.md
         ├── kiosk-component/
         │   └── SKILL.md
         ├── remnant-flow-domain/
         │   └── SKILL.md
         └── typescript-patterns/
             └── SKILL.md

     Key format rules

     - YAML frontmatter with name + description (description = discovery text, kept short)
     - Description written so Claude can determine relevance in ~100 tokens
     - Full instructions inside the markdown body (< 5k tokens each)
     - No scripts or resources needed (pure instruction skills)