### PR TITLE
[ci] setup staging CD pipeline for FE

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,202 @@
+name: "Staging CI/CD"
+
+# Trigger: mỗi khi có push vào branch dev (bao gồm cả merge PR)
+on:
+  push:
+    branches: [dev]
+
+# Đảm bảo chỉ có 1 deploy staging chạy tại 1 thời điểm.
+concurrency:
+  group: staging-fe-deploy
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────────────
+  # JOB 1: BUILD & PUSH IMAGE LÊN GHCR
+  # ─────────────────────────────────────────────────────────────────────────
+  build:
+    name: "🔨 Build & Push"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image_tag:  sha-${{ steps.vars.outputs.sha_short }}
+      full_image: ${{ env.REGISTRY }}/${{ steps.vars.outputs.image }}:sha-${{ steps.vars.outputs.sha_short }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set variables
+        id: vars
+        run: |
+          echo "image=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+          echo "sha_short=$(echo '${{ github.sha }}' | cut -c1-7)" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Tags:
+      #   ghcr.io/...:sha-a1b2c3d    ← immutable, dùng để deploy/rollback
+      #   ghcr.io/...:staging-latest ← floating, tracking bản mới nhất
+      - name: Extract Docker image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.vars.outputs.image }}
+          tags: |
+            type=sha,prefix=sha-,format=short
+            type=raw,value=staging-latest
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags:       ${{ steps.meta.outputs.tags }}
+          labels:     ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to:   type=gha,mode=max
+
+      # ── Thông báo Discord ─────────────────────────────────────────────────
+      - name: "[Discord] ✅ Build thành công"
+        if: success()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          SHORT="${GITHUB_SHA::7}"
+          MSG=$(echo '${{ github.event.head_commit.message }}' | head -1)
+          jq -cn \
+            --arg sha  "$SHORT" \
+            --arg msg  "$MSG" \
+            --arg tag  "${{ steps.meta.outputs.version }}" \
+            --arg who  "${{ github.actor }}" \
+            --arg url  "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{embeds:[{
+              title: "🔨 [FE] Build thành công — staging",
+              color: 3066993,
+              fields:[
+                {name:"Commit",   value:("`"+$sha+"` "+$msg), inline:false},
+                {name:"Image",    value:("`"+$tag+"`"),        inline:false},
+                {name:"Tác giả",  value:$who,                 inline:true},
+                {name:"Run log",  value:("[#${{ github.run_number }}]("+$url+")"), inline:true}
+              ]
+            }]}' \
+          | curl -sS -X POST "$DISCORD_WEBHOOK" \
+               -H "Content-Type: application/json" -d @-
+
+      - name: "[Discord] ❌ Build thất bại"
+        if: failure()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          SHORT="${GITHUB_SHA::7}"
+          MSG=$(echo '${{ github.event.head_commit.message }}' | head -1)
+          jq -cn \
+            --arg sha "$SHORT" \
+            --arg msg "$MSG" \
+            --arg who "${{ github.actor }}" \
+            --arg url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{embeds:[{
+              title: "❌ [FE] Build thất bại — staging",
+              color: 15158332,
+              fields:[
+                {name:"Commit",  value:("`"+$sha+"` "+$msg), inline:false},
+                {name:"Tác giả", value:$who,                 inline:true},
+                {name:"Log lỗi", value:("[#${{ github.run_number }}]("+$url+")"), inline:true}
+              ]
+            }]}' \
+          | curl -sS -X POST "$DISCORD_WEBHOOK" \
+               -H "Content-Type: application/json" -d @-
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # JOB 2: DEPLOY LÊN SERVER STAGING (chỉ chạy nếu build thành công)
+  # ─────────────────────────────────────────────────────────────────────────
+  deploy:
+    name: "🚀 Deploy Staging"
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: SSH → Deploy + Auto-rollback
+        id: ssh_deploy
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          FULL_IMAGE:  ${{ needs.build.outputs.full_image }}
+          GHCR_USER:   ${{ github.actor }}
+          GHCR_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
+        with:
+          host:     ${{ secrets.STAGING_HOST }}
+          username: root
+          password: ${{ secrets.STAGING_SSH_PASSWORD }}
+          port:     22
+          timeout:  180s
+          envs:     FULL_IMAGE,GHCR_USER,GHCR_TOKEN
+          script: |
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+            /opt/vwms-staging-fe/deploy-fe.sh "$FULL_IMAGE"
+
+      # ── Thông báo Discord ─────────────────────────────────────────────────
+      - name: "[Discord] 🚀 Deploy thành công"
+        if: success() && steps.ssh_deploy.outcome == 'success'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          SHORT="${GITHUB_SHA::7}"
+          MSG=$(echo '${{ github.event.head_commit.message }}' | head -1)
+          jq -cn \
+            --arg sha  "$SHORT" \
+            --arg msg  "$MSG" \
+            --arg tag  "${{ needs.build.outputs.image_tag }}" \
+            --arg who  "${{ github.actor }}" \
+            --arg run  "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{embeds:[{
+              title: "🚀 [FE] Deploy thành công — staging",
+              color: 3066993,
+              fields:[
+                {name:"Commit",  value:("`"+$sha+"` "+$msg), inline:false},
+                {name:"Image",   value:("`"+$tag+"`"),        inline:false},
+                {name:"Tác giả", value:$who,                  inline:true},
+                {name:"Run log", value:("[#${{ github.run_number }}]("+$run+")"), inline:false}
+              ]
+            }]}' \
+          | curl -sS -X POST "$DISCORD_WEBHOOK" \
+               -H "Content-Type: application/json" -d @-
+
+      - name: "[Discord] 💥 Deploy thất bại — Đã rollback"
+        if: failure() && steps.ssh_deploy.outcome == 'failure'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          SHORT="${GITHUB_SHA::7}"
+          MSG=$(echo '${{ github.event.head_commit.message }}' | head -1)
+          jq -cn \
+            --arg sha "$SHORT" \
+            --arg msg "$MSG" \
+            --arg tag "${{ needs.build.outputs.image_tag }}" \
+            --arg who "${{ github.actor }}" \
+            --arg run "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{embeds:[{
+              title: "💥 [FE] Deploy thất bại — đã rollback — staging",
+              color: 16744272,
+              description: "App đã được tự động rollback về version trước đó.",
+              fields:[
+                {name:"Commit lỗi", value:("`"+$sha+"` "+$msg), inline:false},
+                {name:"Image lỗi",  value:("`"+$tag+"`"),        inline:false},
+                {name:"Tác giả",    value:$who,                  inline:true},
+                {name:"Log lỗi",    value:("[#${{ github.run_number }}]("+$run+")"), inline:true}
+              ]
+            }]}' \
+          | curl -sS -X POST "$DISCORD_WEBHOOK" \
+               -H "Content-Type: application/json" -d @-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# ── Stage 1: deps ────────────────────────────────────────────────────────────
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+
+# ── Stage 2: builder ─────────────────────────────────────────────────────────
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN npm run build
+
+# ── Stage 3: runner ──────────────────────────────────────────────────────────
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Copy only what's needed to run
+COPY --from=builder /app/public       ./public
+COPY --from=builder /app/.next        ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/deploy/staging/.env.fe.staging.example
+++ b/deploy/staging/.env.fe.staging.example
@@ -1,0 +1,1 @@
+BACKEND_URL=http://10.8.0.1:8080

--- a/deploy/staging/deploy-fe.sh
+++ b/deploy/staging/deploy-fe.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# deploy-fe.sh — Chạy trên staging server, được gọi bởi GitHub Actions qua SSH
+#
+# Usage: /opt/vwms-staging-fe/deploy-fe.sh <full-image-path>
+# Ví dụ: /opt/vwms-staging-fe/deploy-fe.sh ghcr.io/giangdq202/vmarble-warehouse-client:sha-a1b2c3d
+#
+# Luồng:
+#   1. Lưu image hiện tại để rollback nếu cần
+#   2. Pull image mới
+#   3. Restart frontend container
+#   4. Health check tối đa 60s
+#   5a. OK    → Cập nhật state, exit 0
+#   5b. FAIL  → Rollback về image cũ, exit 1
+
+set -euo pipefail
+
+# ── Config ────────────────────────────────────────────────────────────────────
+DEPLOY_DIR="/opt/vwms-staging-fe"
+COMPOSE_FILE="${DEPLOY_DIR}/docker-compose.fe.staging.yml"
+ENV_FILE="${DEPLOY_DIR}/.env.fe.staging"
+STATE_FILE="${DEPLOY_DIR}/.last_good_image"
+HEALTH_URL="http://localhost:3000"
+HEALTH_RETRIES=12                               # 12 lần × 5s = 60s timeout
+HEALTH_INTERVAL=5
+
+# ── Input ─────────────────────────────────────────────────────────────────────
+NEW_IMAGE="${1:?[deploy-fe] Thiếu argument: full image path}"
+
+log() { echo "[deploy-fe $(date -u +%H:%M:%S)] $*"; }
+
+cd "$DEPLOY_DIR"
+
+# ── 1. Lưu image hiện tại cho rollback ────────────────────────────────────────
+PREV_IMAGE=$(cat "$STATE_FILE" 2>/dev/null || true)
+log "Image cũ   : ${PREV_IMAGE:-<chưa có>}"
+log "Image mới  : $NEW_IMAGE"
+
+# ── 2. Pull image mới từ GHCR ─────────────────────────────────────────────────
+log "Pulling $NEW_IMAGE ..."
+docker pull "$NEW_IMAGE"
+
+# ── 3. Restart frontend container ─────────────────────────────────────────────
+log "Khởi động lại frontend container ..."
+FE_IMAGE="$NEW_IMAGE" docker compose \
+    -f "$COMPOSE_FILE" \
+    --env-file "$ENV_FILE" \
+    up -d frontend
+
+# ── 4. Health check loop ───────────────────────────────────────────────────────
+log "Chờ health check ($HEALTH_URL) ..."
+IS_HEALTHY=false
+for i in $(seq 1 $HEALTH_RETRIES); do
+    sleep "$HEALTH_INTERVAL"
+    if curl -sf --max-time 3 "$HEALTH_URL" > /dev/null 2>&1; then
+        IS_HEALTHY=true
+        break
+    fi
+    log "  Lần thử ${i}/${HEALTH_RETRIES} — chưa ready ..."
+done
+
+# ── 5a. SUCCESS ────────────────────────────────────────────────────────────────
+if $IS_HEALTHY; then
+    log "✅ Deploy FE thành công: $NEW_IMAGE"
+    echo "$NEW_IMAGE" > "$STATE_FILE"
+    exit 0
+fi
+
+# ── 5b. FAILURE → ROLLBACK ────────────────────────────────────────────────────
+log "❌ Health check thất bại sau ${HEALTH_RETRIES} lần thử!"
+
+if [ -z "$PREV_IMAGE" ]; then
+    log "⚠️  Không có version cũ để rollback. Cần can thiệp thủ công!"
+    exit 1
+fi
+
+log "🔄 Đang rollback về: $PREV_IMAGE ..."
+FE_IMAGE="$PREV_IMAGE" docker compose \
+    -f "$COMPOSE_FILE" \
+    --env-file "$ENV_FILE" \
+    up -d frontend
+
+ROLLBACK_OK=false
+for i in $(seq 1 6); do
+    sleep 5
+    if curl -sf --max-time 3 "$HEALTH_URL" > /dev/null 2>&1; then
+        ROLLBACK_OK=true
+        break
+    fi
+done
+
+if $ROLLBACK_OK; then
+    log "↩️  Rollback thành công — đang chạy: $PREV_IMAGE"
+    echo "$PREV_IMAGE" > "$STATE_FILE"
+else
+    log "💥 NGHIÊM TRỌNG: Rollback cũng thất bại! Cần can thiệp thủ công ngay!"
+fi
+
+exit 1

--- a/deploy/staging/docker-compose.fe.staging.yml
+++ b/deploy/staging/docker-compose.fe.staging.yml
@@ -1,0 +1,21 @@
+# docker-compose.fe.staging.yml
+# Double Binding: localhost & VPN (same pattern as BE)
+
+services:
+  frontend:
+    image: ${FE_IMAGE:-ghcr.io/giangdq202/vmarble-warehouse-client:staging-latest}
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:3000:3000"
+      - "10.8.0.1:3000:3000"
+    environment:
+      # Next.js server-side proxy: forwards /api/proxy/* → BE
+      # Next.js container reaches BE via VPN IP (same server)
+      BACKEND_URL: ${BACKEND_URL:-http://10.8.0.1:8080}
+      NODE_ENV: production
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 15s


### PR DESCRIPTION
## Summary

- Thêm multi-stage `Dockerfile` (deps → builder → runner)
- Thêm `docker-compose.fe.staging.yml` với double-binding port 3000 (localhost + VPN `10.8.0.1`) — cùng pattern với BE
- Thêm `deploy-fe.sh`: pull image → restart container → health check 60s → auto-rollback nếu fail
- Thêm GitHub Actions workflow: push to `dev` → build & push GHCR → SSH deploy → Discord notification
- **Fix:** Pass `BACKEND_URL` làm Docker build ARG để bake đúng URL vào `routes-manifest.json`

## Root cause của bug 500

`next.config.ts` gọi `rewrites()` **tại build time** — Next.js evaluate config 1 lần duy nhất trong `npm run build` và freeze kết quả vào `.next/routes-manifest.json`. Khi `next start` chạy, server chỉ đọc manifest tĩnh đó, **không bao giờ** đọc lại `next.config.ts`.

File `.env` bị gitignore → không tồn tại trên CI runner → `process.env.BACKEND_URL = undefined` → fallback `http://localhost:8080` (loopback của chính container FE, không phải BE) → ECONNREFUSED → HTTP 500.

## Fix

Truyền `BACKEND_URL` làm `ARG` trong Dockerfile stage builder, đảm bảo giá trị đúng có mặt khi `npm run build` chạy và được bake vào `routes-manifest.json`.

```dockerfile
ARG BACKEND_URL=http://10.8.0.1:8080
ENV BACKEND_URL=$BACKEND_URL
RUN npm run build
```

## TODO (long-term fix)

Thay `rewrites()` trong `next.config.ts` bằng **Route Handlers**:
- `src/app/api/proxy/[...path]/route.ts`
- `src/app/api/auth/[...path]/route.ts`

Route Handlers chạy **per-request** trên Node.js server → đọc `process.env.BACKEND_URL` tại runtime → không cần build ARG → 1 image dùng được cho mọi environment.

## How it works

```
Push to dev
    ↓
GitHub Actions: docker build --build-arg BACKEND_URL=http://10.8.0.1:8080
    → npm run build bakes đúng URL vào routes-manifest.json
    → push ghcr.io/.../client:sha-xxxxxxx
    ↓
SSH → 163.61.182.158 → /opt/vwms-staging-fe/deploy-fe.sh
    ↓
FE live tại http://10.8.0.1:3000 (VPN only)
```

## Test plan

- [ ] Merge PR này vào `dev`
- [ ] Kiểm tra GitHub Actions chạy thành công
- [ ] Kiểm tra Discord nhận notification
- [ ] Truy cập `http://10.8.0.1:3000` qua VPN
- [ ] Login thành công (không còn 500)