### PR TITLE
Align RemnantSuggestion type with backend and rename dimensions

### DIFF
--- a/src/app/(dashboard)/work-orders/[id]/page.tsx
+++ b/src/app/(dashboard)/work-orders/[id]/page.tsx
@@ -166,8 +166,8 @@ function GenerateBarcodeDialog({ wo, open, onClose }: {
   onClose: () => void
 }) {
   const today = new Date().toISOString().slice(0, 10)
-  const defaultDimensions = wo.dimensions
-    ? `${wo.dimensions.length_mm}x${wo.dimensions.width_mm}mm`
+  const defaultDimensions = wo.sku_dimensions
+    ? `${wo.sku_dimensions.length_mm}x${wo.sku_dimensions.width_mm}mm`
     : ''
 
   const [dimensions, setDimensions] = useState(defaultDimensions)
@@ -372,10 +372,10 @@ function WorkOrderDetail({ id }: { id: string }) {
             }
           />
           <Field label="Số lượng" value={wo.quantity.toString()} />
-          {wo.dimensions && (
+          {wo.sku_dimensions && (
             <Field
               label="Kích thước"
-              value={`${wo.dimensions.length_mm} × ${wo.dimensions.width_mm} mm`}
+              value={`${wo.sku_dimensions.length_mm} × ${wo.sku_dimensions.width_mm} mm`}
             />
           )}
           <Field

--- a/src/components/kiosk/cutting-order-card.tsx
+++ b/src/components/kiosk/cutting-order-card.tsx
@@ -42,7 +42,7 @@ interface CuttingOrderCardProps {
 export function CuttingOrderCard({ order, className, onStartCutting }: CuttingOrderCardProps) {
   const skuDisplay = order.sku_code ?? `${order.sku_id.slice(0, 8)}\u2026`
   const skuName = order.sku_name ?? 'Chưa có tên SKU'
-  const hasDim = !!order.dimensions
+  const hasDim = !!order.sku_dimensions
   const hasMaterial = !!order.material_type
 
   return (
@@ -70,7 +70,7 @@ export function CuttingOrderCard({ order, className, onStartCutting }: CuttingOr
           <div className="flex flex-wrap items-center gap-2 pt-0.5">
             {hasDim && (
               <span className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium text-foreground">
-                {order.dimensions!.length_mm} × {order.dimensions!.width_mm} mm
+                {order.sku_dimensions!.length_mm} × {order.sku_dimensions!.width_mm} mm
               </span>
             )}
             <span className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium text-foreground">

--- a/src/components/kiosk/remnant-suggestion-modal.tsx
+++ b/src/components/kiosk/remnant-suggestion-modal.tsx
@@ -170,10 +170,10 @@ export function RemnantSuggestionModal({
 
   const { mutate: allocate } = useAllocateRemnant()
 
-  const hasDimensions = !!workOrder?.dimensions
+  const hasDimensions = !!workOrder?.sku_dimensions
   const { data: suggestions, isLoading, isError } = useSuggestRemnants(
     workOrder?.id ?? '',
-    workOrder?.dimensions,
+    workOrder?.sku_dimensions,
   )
 
   function handleSelect(remnantId: string) {
@@ -223,9 +223,9 @@ export function RemnantSuggestionModal({
         {/* Header — pr-12 avoids overlap with the shadcn close (×) button */}
         <DialogHeader className="shrink-0 border-b px-4 py-4 pr-12 text-left">
           <DialogTitle className="text-lg">Chọn tấm lẻ để cắt</DialogTitle>
-          {workOrder?.dimensions && (
+          {workOrder?.sku_dimensions && (
             <p className="mt-0.5 text-sm text-muted-foreground">
-              Cần: {workOrder.dimensions.length_mm} × {workOrder.dimensions.width_mm} mm
+              Cần: {workOrder.sku_dimensions.length_mm} × {workOrder.sku_dimensions.width_mm} mm
             </p>
           )}
         </DialogHeader>
@@ -253,7 +253,7 @@ export function RemnantSuggestionModal({
                 <SuggestionCard
                   key={s.remnant.id}
                   suggestion={s}
-                  requiredDimensions={workOrder!.dimensions!}
+                  requiredDimensions={workOrder!.sku_dimensions!}
                   isAllocating={allocatingId === s.remnant.id}
                   isAnyAllocating={!!allocatingId}
                   onSelect={() => handleSelect(s.remnant.id)}

--- a/src/components/kiosk/remnant-suggestion-modal.tsx
+++ b/src/components/kiosk/remnant-suggestion-modal.tsx
@@ -30,6 +30,7 @@ function fitScoreBg(score: number): string {
 
 interface SuggestionCardProps {
   suggestion: RemnantSuggestion
+  requiredDimensions: { length_mm: number; width_mm: number }
   /** True when THIS card's remnant is being allocated. */
   isAllocating: boolean
   /** True when ANY allocation is in flight — disables all non-selected cards. */
@@ -37,10 +38,19 @@ interface SuggestionCardProps {
   onSelect: () => void
 }
 
-function SuggestionCard({ suggestion, isAllocating, isAnyAllocating, onSelect }: SuggestionCardProps) {
-  const { remnant, fitScore, wastePct } = suggestion
-  const pct = Math.round(fitScore * 100)
+function SuggestionCard({ suggestion, requiredDimensions, isAllocating, isAnyAllocating, onSelect }: SuggestionCardProps) {
+  const { remnant, location } = suggestion
   const { length_mm, width_mm } = remnant.dimensions
+
+  // Compute fit score and waste percentage client-side from the remnant dimensions
+  const rl = remnant.bounding_box_length_mm ?? length_mm
+  const rw = remnant.bounding_box_width_mm ?? width_mm
+  const remnantArea = rl * rw
+  const requiredArea = requiredDimensions.length_mm * requiredDimensions.width_mm
+  const fitScore = remnantArea > 0 ? Math.min(1, requiredArea / remnantArea) : 0
+  const wasteAreaMm2 = Math.max(0, remnantArea - requiredArea)
+  const wastePct = remnantArea > 0 ? (wasteAreaMm2 / remnantArea) * 100 : 0
+  const pct = Math.round(fitScore * 100)
   const disabled = isAnyAllocating
 
   return (
@@ -79,9 +89,7 @@ function SuggestionCard({ suggestion, isAllocating, isAnyAllocating, onSelect }:
       <div className="shrink-0 text-right">
         <p className="text-xs text-muted-foreground">Vị trí</p>
         <p className="text-sm font-medium font-mono">
-          {remnant.bin_location_id
-            ? remnant.bin_location_id.slice(0, 8).toUpperCase()
-            : '—'}
+          {location?.barcode ?? '—'}
         </p>
       </div>
 
@@ -245,6 +253,7 @@ export function RemnantSuggestionModal({
                 <SuggestionCard
                   key={s.remnant.id}
                   suggestion={s}
+                  requiredDimensions={workOrder!.dimensions!}
                   isAllocating={allocatingId === s.remnant.id}
                   isAnyAllocating={!!allocatingId}
                   onSelect={() => handleSelect(s.remnant.id)}

--- a/src/components/kiosk/report-cut-form.tsx
+++ b/src/components/kiosk/report-cut-form.tsx
@@ -318,8 +318,8 @@ export function ReportCutForm() {
   // watch() re-runs on every keystroke; we derive the warning from live values.
   const watchedUsedLength = watch('usedLength')
   const watchedUsedWidth = watch('usedWidth')
-  const sourceL = workOrder?.dimensions?.length_mm
-  const sourceW = workOrder?.dimensions?.width_mm
+  const sourceL = workOrder?.sku_dimensions?.length_mm
+  const sourceW = workOrder?.sku_dimensions?.width_mm
   const uLNum = parseFloat(watchedUsedLength)
   const uWNum = parseFloat(watchedUsedWidth)
   const areaWarning =
@@ -392,7 +392,7 @@ export function ReportCutForm() {
   // Block submission while loading WO (prevents sending sku_id as empty string)
   // or while a mutation is in flight.
   const isDisabled = isPending || isLoadingWO
-  const sourceDim = workOrder?.dimensions
+  const sourceDim = workOrder?.sku_dimensions
 
   return (
     <form

--- a/src/lib/hooks/use-remnants.ts
+++ b/src/lib/hooks/use-remnants.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { remnantsApi, sheetsApi, storageLocationsApi, type RemnantsFilter, type SheetsFilter } from '@/lib/api/remnants'
-import type { Remnant, StorageLocation, RemnantSuggestion } from '@/types/api'
+import type { Remnant, RemnantSuggestion, StorageLocation } from '@/types/api'
 
 export const REMNANTS_KEY = 'remnants'
 
@@ -20,8 +20,10 @@ export function useRemnants(filter: RemnantsFilter = {}) {
 // GET /inventory/remnants with dimension filters, then scoring client-side.
 // Replace with the real endpoint when the backend ships it.
 //
-// Scoring: fitScore = requiredArea / remnantArea  (1.0 = perfect fit, no waste)
-// ageScore and combinedScore are set to fitScore as placeholders.
+// Sorting: fitScore = requiredArea / remnantArea  (1.0 = perfect fit, no waste).
+// The returned RemnantSuggestion shape mirrors the backend iface.go struct:
+//   { remnant, location, rank } — location is null because the list endpoint
+//   does not embed location data (only bin_location_id UUID is available).
 
 function scoreRemnants(
   remnants: Remnant[],
@@ -32,29 +34,23 @@ function scoreRemnants(
   if (requiredArea <= 0) return []
 
   return remnants
-    .map((remnant): RemnantSuggestion | null => {
+    .map((remnant): { remnant: Remnant; fitScore: number } | null => {
       // Prefer bounding-box dimensions (usable area after chips), fall back to full dims
       const rl = remnant.bounding_box_length_mm ?? remnant.dimensions.length_mm
       const rw = remnant.bounding_box_width_mm ?? remnant.dimensions.width_mm
       const remnantArea = rl * rw
       if (remnantArea <= 0) return null
 
-      const wasteAreaMm2 = Math.max(0, remnantArea - requiredArea)
-      const wastePct = (wasteAreaMm2 / remnantArea) * 100
-      const fitScore = Math.min(1, requiredArea / remnantArea)
-
-      return {
-        remnant,
-        fitScore,
-        ageScore: 0,          // not computed client-side
-        combinedScore: fitScore,
-        wasteAreaMm2,
-        wastePct,
-      }
+      return { remnant, fitScore: Math.min(1, requiredArea / remnantArea) }
     })
-    .filter((s): s is RemnantSuggestion => s !== null)
+    .filter((s): s is { remnant: Remnant; fitScore: number } => s !== null)
     .sort((a, b) => b.fitScore - a.fitScore)
     .slice(0, limit)
+    .map((s, i): RemnantSuggestion => ({
+      remnant: s.remnant,
+      location: null, // not available from list endpoint; real value comes from backend suggest endpoint
+      rank: i + 1,
+    }))
 }
 
 /**

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -183,8 +183,8 @@ export interface WorkOrder {
   sku_code?: string
   /** Human-readable SKU name */
   sku_name?: string
-  /** Required cut dimensions from the SKU */
-  dimensions?: { length_mm: number; width_mm: number }
+  /** Required cut dimensions from the SKU — JSON key matches backend sku_dimensions */
+  sku_dimensions?: { length_mm: number; width_mm: number }
   /** Material type (PLYWOOD / MDF / HDF) */
   material_type?: MaterialType
   quantity: number

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -283,11 +283,8 @@ export interface RecordCutResponse {
 
 export interface RemnantSuggestion {
   remnant: Remnant
-  fitScore: number
-  ageScore: number
-  combinedScore: number
-  wasteAreaMm2: number
-  wastePct: number
+  location: StorageLocation | null
+  rank: number
 }
 
 export interface SuggestAllocationInput {


### PR DESCRIPTION
## Implement hiển thị kết quả thuật toán gợi ý ra tấm lẻ tồn kho để cắt thay vì dùng tấm nguyên.
<img width="592" height="1270" alt="image" src="https://github.com/user-attachments/assets/00429794-3348-4c94-b220-2f07a2d0faa3" />
<img width="602" height="1282" alt="image" src="https://github.com/user-attachments/assets/ce34e73d-87d7-4357-ab86-66d0d810fb9d" />
<img width="592" height="1266" alt="image" src="https://github.com/user-attachments/assets/dacef63d-2c2e-47aa-a229-83dbf1a4acad" />

## what's next: tấm lẻ tự nhập số liệu dựa trên lệnh cắt của thành phẩm và tính toán ra lượng còn dư. 