### PR TITLE
[kiosk] Display storage location barcode in SuggestionCard (#52)

### DIFF
--- a/src/components/kiosk/remnant-suggestion-modal.tsx
+++ b/src/components/kiosk/remnant-suggestion-modal.tsx
@@ -155,7 +155,7 @@ interface RemnantSuggestionModalProps {
 
 /**
  * Kiosk modal — shown when a worker starts a cutting order.
- * Fetches top-5 remnant suggestions (client-side Best Fit scoring) and lets
+ * Fetches top-5 remnant suggestions from backend (Best Fit + FIFO) and lets
  * the worker pick one or skip to use a full board.
  *
  * Tap count to select: 2 (open via card button + tap a suggestion = navigate)


### PR DESCRIPTION
## Summary
- `SuggestionCard` displays `suggestion.location?.barcode` (e.g. "A-01-03") with `—` fallback when remnant has no stocked location
- No more `bin_location_id` UUID prefix display — component already uses the `location` object from `RemnantSuggestion`
- Updated stale JSDoc comment: scoring is now server-side Best Fit + FIFO (not client-side)

## Route group affected
`(kiosk)` — remnant suggestion modal in cutting flow

## Technical notes
- `location` data comes from backend via `useSuggestRemnants` → `GET /inventory/remnants/suggestions`
- Backend LEFT JOINs `storage_locations` so `location` is non-null only when remnant is stocked to a bin
- Depends on PR #56 for the `remnantsApi.suggest()` wiring — without it, `location` will always be `null` (client-side scoring doesn't embed location)

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [ ] With PR #56 merged + backend running: modal shows real barcode labels for stocked remnants
- [ ] Remnants without bin_location show "—" fallback

Closes #52