### PR TITLE
[infra] Add quality gates to CI: tsc + build before deploy (#57)

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -15,10 +15,37 @@ env:
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────────
+  # JOB 0: QUALITY GATES — type-check + production build
+  # Fail-fast: chặn deploy nếu có type error hoặc build failure.
+  # ─────────────────────────────────────────────────────────────────────────
+  quality:
+    name: "🛡️ Quality Gates"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: TypeScript type-check
+        run: npx tsc --noEmit
+
+      - name: Next.js production build
+        run: npm run build
+
+  # ─────────────────────────────────────────────────────────────────────────
   # JOB 1: BUILD & PUSH IMAGE LÊN GHCR
   # ─────────────────────────────────────────────────────────────────────────
   build:
     name: "🔨 Build & Push"
+    needs: quality
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Adds a `quality` job to the staging CI pipeline that runs **before** Docker build
- Catches type errors (`tsc --noEmit`) and build failures (`npm run build`) before deploying
- Pipeline order: `quality` → `build` → `deploy`

This would have caught several Sprint 3 bugs before they hit staging:
- `dimensions` → `sku_dimensions` field rename (TypeScript error)
- Import mismatches and missing type exports

## Technical notes
- New job uses Node 20 to match Dockerfile base image
- `build` job now has `needs: quality` — if quality fails, no Docker image is built, no deploy happens
- No new secrets or env vars required

## Test plan
- [x] YAML syntax validated
- [x] Job dependency chain: `quality` → `build` → `deploy`
- [ ] Push a commit with a type error to verify CI catches it
- [ ] Push a clean commit to verify full pipeline succeeds

Closes #57

🤖 Generated with [Claude Code](https://claude.ai/claude-code)