### PR TITLE
[api] Fix: dịch lỗi API sang tiếng Việt cho người dùng (#62)

### DIFF
--- a/src/app/(dashboard)/materials/page.tsx
+++ b/src/app/(dashboard)/materials/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { Plus } from 'lucide-react'
+import { mapApiErrorVi } from '@/lib/api/client'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -113,7 +114,7 @@ function CreateMaterialDialog({ open, onOpenChange }: CreateDialogProps) {
           setErrors({})
         },
         onError: (err) => {
-          toast.error(err instanceof Error ? err.message : 'Tạo thất bại, thử lại')
+          toast.error(mapApiErrorVi(err, 'Tạo vật liệu thất bại, thử lại'))
         },
       },
     )

--- a/src/app/(dashboard)/plans/[id]/page.tsx
+++ b/src/app/(dashboard)/plans/[id]/page.tsx
@@ -4,6 +4,7 @@ import { use, useState } from 'react'
 import Link from 'next/link'
 import { toast } from 'sonner'
 import { ArrowLeft, ClipboardList } from 'lucide-react'
+import { mapApiErrorVi } from '@/lib/api/client'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -89,7 +90,7 @@ export default function PlanDetailPage({
         setApproveOpen(false)
       },
       onError: (err) => {
-        toast.error(err instanceof Error ? err.message : 'Duyệt thất bại')
+        toast.error(mapApiErrorVi(err, 'Duyệt thất bại'))
       },
     })
   }
@@ -101,7 +102,7 @@ export default function PlanDetailPage({
         setCancelOpen(false)
       },
       onError: (err) => {
-        toast.error(err instanceof Error ? err.message : 'Hủy thất bại')
+        toast.error(mapApiErrorVi(err, 'Hủy thất bại'))
       },
     })
   }

--- a/src/app/(dashboard)/plans/page.tsx
+++ b/src/app/(dashboard)/plans/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { toast } from 'sonner'
 import { ClipboardList, Plus } from 'lucide-react'
+import { mapApiErrorVi } from '@/lib/api/client'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -167,7 +168,7 @@ function CreatePlanDialog({ open, onOpenChange }: CreatePlanDialogProps) {
         setErrors({})
       },
       onError: (err) => {
-        toast.error(err instanceof Error ? err.message : 'Tạo kế hoạch thất bại, thử lại')
+        toast.error(mapApiErrorVi(err, 'Tạo kế hoạch thất bại, thử lại'))
       },
     })
   }
@@ -383,7 +384,7 @@ function PlansContent() {
         setApproveTarget(null)
       },
       onError: (err) => {
-        toast.error(err instanceof Error ? err.message : 'Duyệt thất bại')
+        toast.error(mapApiErrorVi(err, 'Duyệt thất bại'))
       },
     })
   }
@@ -396,7 +397,7 @@ function PlansContent() {
         setCancelTarget(null)
       },
       onError: (err) => {
-        toast.error(err instanceof Error ? err.message : 'Hủy thất bại')
+        toast.error(mapApiErrorVi(err, 'Hủy thất bại'))
       },
     })
   }

--- a/src/app/(dashboard)/pos/page.tsx
+++ b/src/app/(dashboard)/pos/page.tsx
@@ -26,6 +26,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { mapApiErrorVi } from '@/lib/api/client'
 import { usePOs, useCreatePO } from '@/lib/hooks/use-pos'
 import { useSKUs } from '@/lib/hooks/use-skus'
 import { usePageParams } from '@/lib/hooks/use-page-params'
@@ -149,7 +150,7 @@ function CreatePODialog({ open, onOpenChange }: CreatePODialogProps) {
         handleOpenChange(false)
       },
       onError: (err) => {
-        toast.error(err instanceof Error ? err.message : 'Tạo đơn hàng thất bại, thử lại')
+        toast.error(mapApiErrorVi(err, 'Tạo đơn hàng thất bại, thử lại'))
       },
     })
   }

--- a/src/app/(dashboard)/skus/page.tsx
+++ b/src/app/(dashboard)/skus/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { Plus, Pencil, FlaskConical, Trash2, Wrench } from 'lucide-react'
+import { mapApiErrorVi } from '@/lib/api/client'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -99,7 +100,7 @@ function CreateSKUDialog({ open, onOpenChange }: CreateSKUDialogProps) {
           onOpenChange(false)
         },
         onError: (err) => {
-          toast.error(err instanceof Error ? err.message : 'Tạo thất bại, thử lại')
+          toast.error(mapApiErrorVi(err, 'Tạo sản phẩm thất bại, thử lại'))
         },
       },
     )
@@ -299,7 +300,7 @@ function BOMEditorDialog({ sku, onClose }: BOMEditorDialogProps) {
           onClose()
         },
         onError: (err) => {
-          toast.error(err instanceof Error ? err.message : 'Lưu thất bại')
+          toast.error(mapApiErrorVi(err, 'Lưu BOM thất bại'))
         },
       },
     )

--- a/src/components/kiosk/remnant-store-client.tsx
+++ b/src/components/kiosk/remnant-store-client.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { CheckCircle2, Package, MapPin, RotateCcw } from 'lucide-react'
+import { mapApiErrorVi } from '@/lib/api/client'
 import { BigButton } from '@/components/kiosk/big-button'
 import { ScannerView } from '@/components/kiosk/scanner-view'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -164,8 +165,7 @@ export function RemnantStoreClient() {
           setStep('done')
         },
         onError: (err: unknown) => {
-          const msg = err instanceof Error ? err.message : 'Lỗi không xác định'
-          toast.error(`Nhập kho thất bại: ${msg}`)
+          toast.error(mapApiErrorVi(err, 'Nhập kho thất bại'))
           // Reset shelf scan so worker can try again with a different shelf
           setLocationBarcode('')
           setLocationLabel('')

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,4 +1,3 @@
-import type { ApiError } from '@/types/api'
 import { normalizeAuthToken } from '@/lib/auth/token'
 
 const BASE_URL =
@@ -53,11 +52,12 @@ async function request<T>(
   })
 
   if (!response.ok) {
-    const err: ApiError = await response.json().catch(() => ({
-      code: 'UNKNOWN',
-      message: `HTTP ${response.status}`,
-    }))
-    throw new ApiClientError(response.status, err.code, err.message, err.details)
+    // Backend httpkit.Error() sends { "error": "..." } — no "code" field.
+    // ApiError shape expects { code, message }, so we normalize both formats.
+    const body = await response.json().catch(() => null)
+    const code: string = body?.code ?? 'UNKNOWN'
+    const message: string = body?.message ?? body?.error ?? `HTTP ${response.status}`
+    throw new ApiClientError(response.status, code, message, body?.details)
   }
 
   // 204 No Content
@@ -84,3 +84,62 @@ export const apiClient = {
 }
 
 export { ApiClientError }
+
+/**
+ * Maps an API error to a user-friendly Vietnamese message with actionable guidance.
+ * Use in every `onError` handler instead of showing raw `err.message`.
+ *
+ * @param err - The error caught by TanStack Query or try/catch
+ * @param fallback - Optional domain-specific fallback (e.g. "Tạo đơn hàng thất bại")
+ */
+export function mapApiErrorVi(err: unknown, fallback = 'Có lỗi xảy ra. Vui lòng thử lại.'): string {
+  if (!(err instanceof ApiClientError)) return fallback
+
+  const msg = (err.message ?? '').toLowerCase()
+
+  // Duplicate key (unique constraint violation from PostgreSQL)
+  if (msg.includes('duplicate key') || msg.includes('unique constraint') || msg.includes('already exists')) {
+    if (msg.includes('code')) return 'Mã này đã tồn tại. Vui lòng chọn mã khác.'
+    return 'Dữ liệu bị trùng. Vui lòng kiểm tra và nhập giá trị khác.'
+  }
+
+  // Not found
+  if (err.status === 404 || msg.includes('not found')) {
+    return 'Không tìm thấy dữ liệu. Có thể đã bị xóa hoặc chưa tồn tại.'
+  }
+
+  // Area conservation (inventory cuts)
+  if (err.status === 422 || msg.includes('area')) {
+    return 'Diện tích vượt quá tấm nguồn. Kiểm tra lại kích thước.'
+  }
+
+  // Precondition failed (state conflict)
+  if (err.status === 412 || msg.includes('no longer available') || msg.includes('precondition')) {
+    return 'Dữ liệu đã thay đổi. Vui lòng tải lại trang và thử lại.'
+  }
+
+  // Conflict (concurrent modification)
+  if (err.status === 409) {
+    return 'Thao tác bị xung đột. Vui lòng tải lại và thử lại.'
+  }
+
+  // Bad request (validation)
+  if (err.status === 400) {
+    return 'Dữ liệu nhập không hợp lệ. Kiểm tra lại các trường.'
+  }
+
+  // Auth
+  if (err.status === 401) {
+    return 'Phiên đăng nhập hết hạn. Vui lòng đăng nhập lại.'
+  }
+  if (err.status === 403) {
+    return 'Bạn không có quyền thực hiện thao tác này.'
+  }
+
+  // Server error
+  if (err.status >= 500) {
+    return 'Lỗi hệ thống. Vui lòng thử lại sau hoặc liên hệ quản trị viên.'
+  }
+
+  return fallback
+}

--- a/src/lib/hooks/use-barcode.ts
+++ b/src/lib/hooks/use-barcode.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { barcodeApi } from '@/lib/api/barcode'
-import { ApiClientError } from '@/lib/api/client'
+import { mapApiErrorVi } from '@/lib/api/client'
 import type { GenerateBarcodeInput, BarcodeRecord } from '@/types/api'
 
 export const BARCODES_KEY = 'barcodes'
@@ -43,11 +43,7 @@ export function useGenerateBarcode(opts?: { onSuccess?: (bc: BarcodeRecord) => v
       opts?.onSuccess?.(bc)
     },
     onError: (err: unknown) => {
-      if (err instanceof ApiClientError) {
-        toast.error(`Lỗi: ${err.message}`)
-      } else {
-        toast.error('Tạo barcode thất bại')
-      }
+      toast.error(mapApiErrorVi(err, 'Tạo barcode thất bại'))
     },
   })
 }

--- a/src/lib/hooks/use-scan.ts
+++ b/src/lib/hooks/use-scan.ts
@@ -2,7 +2,7 @@ import { useMutation } from '@tanstack/react-query'
 import { create } from 'zustand'
 import { toast } from 'sonner'
 import { barcodeApi } from '@/lib/api/barcode'
-import { ApiClientError } from '@/lib/api/client'
+import { mapApiErrorVi } from '@/lib/api/client'
 import type { ScanEvent, ScanCheckpoint } from '@/types/api'
 
 // ── Zustand scan-session store ────────────────────────────────────────────────
@@ -54,15 +54,7 @@ export function useRecordScan() {
     },
 
     onError: (err: unknown) => {
-      if (err instanceof ApiClientError) {
-        if (err.status === 404) {
-          toast.error('Mã không hợp lệ')
-        } else {
-          toast.error(`Lỗi: ${err.message}`)
-        }
-      } else {
-        toast.error('Lỗi không xác định')
-      }
+      toast.error(mapApiErrorVi(err, 'Quét mã thất bại'))
     },
   })
 }

--- a/src/lib/hooks/use-work-orders.ts
+++ b/src/lib/hooks/use-work-orders.ts
@@ -2,7 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { workOrdersApi, type WorkOrdersFilter } from '@/lib/api/work-orders'
 import type { CreateWOInput, AdvanceStatusInput, AssignWorkOrderInput } from '@/types/api'
-import type { ApiClientError } from '@/lib/api/client'
+import { mapApiErrorVi } from '@/lib/api/client'
 
 export const WORK_ORDERS_KEY = 'work-orders'
 export const CONSUMPTIONS_KEY = 'consumptions'
@@ -31,8 +31,8 @@ export function useCreateWorkOrder() {
       queryClient.invalidateQueries({ queryKey: [WORK_ORDERS_KEY] })
       toast.success('Đã tạo lệnh sản xuất')
     },
-    onError: (err: ApiClientError) => {
-      toast.error(err.message ?? 'Tạo lệnh thất bại')
+    onError: (err) => {
+      toast.error(mapApiErrorVi(err, 'Tạo lệnh thất bại'))
     },
   })
 }
@@ -46,12 +46,8 @@ export function useAdvanceStatus() {
       queryClient.invalidateQueries({ queryKey: [WORK_ORDERS_KEY] })
       toast.success('Đã cập nhật trạng thái')
     },
-    onError: (err: ApiClientError) => {
-      if (err.status === 409) {
-        toast.error('Không thể chuyển trạng thái')
-      } else {
-        toast.error(err.message ?? 'Cập nhật thất bại')
-      }
+    onError: (err) => {
+      toast.error(mapApiErrorVi(err, 'Cập nhật trạng thái thất bại'))
     },
   })
 }
@@ -73,8 +69,8 @@ export function useAssignWorkOrder() {
       queryClient.invalidateQueries({ queryKey: [WORK_ORDERS_KEY] })
       toast.success('Đã phân công')
     },
-    onError: (err: ApiClientError) => {
-      toast.error(err.message ?? 'Phân công thất bại')
+    onError: (err) => {
+      toast.error(mapApiErrorVi(err, 'Phân công thất bại'))
     },
   })
 }


### PR DESCRIPTION
## Summary
- **Bug**: Lỗi API (trùng mã PO, not found, conflict...) hiện raw database error tiếng Anh cho user
- **Root cause**: `client.ts` parse sai format lỗi backend + tất cả `onError` handlers pass raw `err.message` 
- **Fix**: Normalize error parsing + thêm `mapApiErrorVi()` dùng chung

## Thay đổi chính

### 1. `client.ts` — fix error parsing
Backend trả `{"error": "..."}` nhưng client parse `body.code` + `body.message` → undefined.
Giờ normalize: `body?.message ?? body?.error ?? HTTP status`

### 2. `mapApiErrorVi()` — utility mới
Detect pattern lỗi phổ biến → Vietnamese + hành động:

| Pattern | Message hiện |
|---------|-------------|
| `duplicate key` / `unique constraint` | "Mã này đã tồn tại. Vui lòng chọn mã khác." |
| 404 / `not found` | "Không tìm thấy dữ liệu. Có thể đã bị xóa hoặc chưa tồn tại." |
| 412 / precondition | "Dữ liệu đã thay đổi. Vui lòng tải lại trang và thử lại." |
| 409 / conflict | "Thao tác bị xung đột. Vui lòng tải lại và thử lại." |
| 400 | "Dữ liệu nhập không hợp lệ. Kiểm tra lại các trường." |
| 401 | "Phiên đăng nhập hết hạn. Vui lòng đăng nhập lại." |
| 500+ | "Lỗi hệ thống. Vui lòng thử lại sau hoặc liên hệ quản trị viên." |

### 3. Cập nhật 12 `onError` handlers
- `pos/page.tsx`, `plans/page.tsx`, `plans/[id]/page.tsx`, `materials/page.tsx`, `skus/page.tsx`
- `use-work-orders.ts`, `use-barcode.ts`, `use-scan.ts`
- `remnant-store-client.tsx`

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — succeeds
- [x] Tạo PO trùng mã → toast: "Mã này đã tồn tại. Vui lòng chọn mã khác."
- [x] Tạo plan với PO không tồn tại → toast: "Không tìm thấy dữ liệu..."
- [x] Bất kỳ 500 error → toast: "Lỗi hệ thống..."
- [x] Không còn raw English/SQL error hiện cho user

Ref #62
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/f2cc755e-0465-4d52-9147-bb24d1a5aca2" />

🤖 Generated with [Claude Code](https://claude.ai/claude-code)