### PR TITLE
[dashboard] feat: price input formatting + per-row validation + WO pagination

### DIFF
--- a/src/app/(dashboard)/pos/page.tsx
+++ b/src/app/(dashboard)/pos/page.tsx
@@ -62,15 +62,31 @@ function formatMoney(amount: number, currency: string) {
   return new Intl.NumberFormat('vi-VN', { style: 'currency', currency }).format(amount)
 }
 
+// ── Helpers — price formatting ────────────────────────────────────────────────
+
+/** Format a number with thousand-separators: 1500000 → "1,500,000" */
+function formatPrice(amount: number): string {
+  if (!amount) return ''
+  return amount.toLocaleString('en-US')
+}
+
+/** Parse a formatted price string back to a number: "1,500,000" → 1500000 */
+function parsePrice(raw: string): number {
+  const n = Number(raw.replace(/,/g, ''))
+  return isNaN(n) ? 0 : n
+}
+
 // ── Line item row draft ───────────────────────────────────────────────────────
 
 interface LineItemDraft extends CreateLineItemInput {
   _key: number
+  /** Display string for the price input — keeps formatted value while user types */
+  _priceDisplay: string
 }
 
 let _keyCounter = 0
 function emptyLine(): LineItemDraft {
-  return { _key: ++_keyCounter, sku_id: '', quantity: 1, selling_price: { amount: 0, currency: 'VND' } }
+  return { _key: ++_keyCounter, sku_id: '', quantity: 1, selling_price: { amount: 0, currency: 'VND' }, _priceDisplay: '' }
 }
 
 // ── Create PO Dialog ──────────────────────────────────────────────────────────
@@ -80,13 +96,15 @@ interface CreatePODialogProps {
   onOpenChange: (v: boolean) => void
 }
 
-type FormErrors = Partial<Record<'code' | 'expected_delivery' | 'line_items', string>>
+type FormErrors = Partial<Record<'code' | 'expected_delivery', string>>
+type RowErrors = Record<number, { sku_id?: string; quantity?: string; price?: string }>
 
 function CreatePODialog({ open, onOpenChange }: CreatePODialogProps) {
   const [code, setCode] = useState('')
   const [expectedDelivery, setExpectedDelivery] = useState('')
   const [lines, setLines] = useState<LineItemDraft[]>([emptyLine()])
   const [errors, setErrors] = useState<FormErrors>({})
+  const [rowErrors, setRowErrors] = useState<RowErrors>({})
 
   const { mutate, isPending } = useCreatePO()
   // Load all SKUs for the picker (no pagination — catalog is small)
@@ -98,6 +116,7 @@ function CreatePODialog({ open, onOpenChange }: CreatePODialogProps) {
     setExpectedDelivery('')
     setLines([emptyLine()])
     setErrors({})
+    setRowErrors({})
   }
 
   function handleOpenChange(v: boolean) {
@@ -113,24 +132,40 @@ function CreatePODialog({ open, onOpenChange }: CreatePODialogProps) {
     setLines((l) => l.length > 1 ? l.filter((x) => x._key !== key) : l)
   }
 
-  function updateLine(key: number, patch: Partial<CreateLineItemInput>) {
+  function updateLine(key: number, patch: Partial<LineItemDraft>) {
     setLines((l) => l.map((x) => x._key === key ? { ...x, ...patch } : x))
-    setErrors((e) => ({ ...e, line_items: undefined }))
+    setRowErrors((e) => ({ ...e, [key]: {} }))
+  }
+
+  function handlePriceInput(key: number, raw: string) {
+    // Allow only digits and commas while typing; reformat on each keystroke
+    const digitsOnly = raw.replace(/[^0-9]/g, '')
+    const amount = Number(digitsOnly)
+    const display = digitsOnly ? Number(digitsOnly).toLocaleString('en-US') : ''
+    updateLine(key, { selling_price: { amount, currency: 'VND' }, _priceDisplay: display })
   }
 
   function validate(): boolean {
-    const next: FormErrors = {}
-    if (!code.trim()) next.code = 'Mã PO không được để trống'
-    if (!expectedDelivery) next.expected_delivery = 'Chọn ngày giao hàng dự kiến'
-    const lineInvalid = lines.some(
-      (l) => !l.sku_id || l.quantity <= 0 || l.selling_price.amount <= 0,
-    )
-    if (lineInvalid) next.line_items = 'Mỗi dòng cần chọn sản phẩm, số lượng ≥ 1 và đơn giá > 0'
-    const skuIds = lines.map((l) => l.sku_id).filter(Boolean)
-    if (new Set(skuIds).size !== skuIds.length)
-      next.line_items = 'Mỗi sản phẩm chỉ xuất hiện 1 lần trong đơn hàng'
-    setErrors(next)
-    return Object.keys(next).length === 0
+    const nextForm: FormErrors = {}
+    const nextRows: RowErrors = {}
+
+    if (!code.trim()) nextForm.code = 'Mã PO không được để trống'
+    if (!expectedDelivery) nextForm.expected_delivery = 'Chọn ngày giao hàng dự kiến'
+
+    const seenSkus = new Set<string>()
+    for (const l of lines) {
+      const rowErr: RowErrors[number] = {}
+      if (!l.sku_id) rowErr.sku_id = 'Chọn sản phẩm'
+      else if (seenSkus.has(l.sku_id)) rowErr.sku_id = 'Sản phẩm đã được chọn ở dòng khác'
+      if (l.sku_id) seenSkus.add(l.sku_id)
+      if (l.quantity < 1) rowErr.quantity = 'SL ≥ 1'
+      if (l.selling_price.amount <= 0) rowErr.price = 'Đơn giá > 0'
+      if (Object.keys(rowErr).length) nextRows[l._key] = rowErr
+    }
+
+    setErrors(nextForm)
+    setRowErrors(nextRows)
+    return Object.keys(nextForm).length === 0 && Object.keys(nextRows).length === 0
   }
 
   function handleSubmit() {
@@ -214,6 +249,7 @@ function CreatePODialog({ open, onOpenChange }: CreatePODialogProps) {
                     const usedSkuIds = new Set(
                       lines.filter((l) => l._key !== line._key).map((l) => l.sku_id),
                     )
+                    const re = rowErrors[line._key] ?? {}
                     return (
                       <TableRow key={line._key}>
                         {/* SKU picker */}
@@ -221,7 +257,7 @@ function CreatePODialog({ open, onOpenChange }: CreatePODialogProps) {
                           <select
                             value={line.sku_id}
                             onChange={(e) => updateLine(line._key, { sku_id: e.target.value })}
-                            className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                            className={`w-full rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring ${re.sku_id ? 'border-destructive' : 'border-input'}`}
                           >
                             <option value="">— Chọn sản phẩm —</option>
                             {skus.map((s) => (
@@ -234,6 +270,7 @@ function CreatePODialog({ open, onOpenChange }: CreatePODialogProps) {
                               </option>
                             ))}
                           </select>
+                          {re.sku_id && <p className="mt-1 text-xs text-destructive">{re.sku_id}</p>}
                         </TableCell>
 
                         {/* Quantity */}
@@ -245,23 +282,29 @@ function CreatePODialog({ open, onOpenChange }: CreatePODialogProps) {
                             onChange={(e) =>
                               updateLine(line._key, { quantity: Number(e.target.value) })
                             }
+                            className={re.quantity ? 'border-destructive' : ''}
                           />
+                          {re.quantity && <p className="mt-1 text-xs text-destructive">{re.quantity}</p>}
                         </TableCell>
 
-                        {/* Price */}
+                        {/* Price — text input with comma formatting */}
                         <TableCell>
                           <Input
-                            type="number"
-                            min={0}
-                            step={1000}
-                            value={line.selling_price.amount || ''}
-                            onChange={(e) =>
-                              updateLine(line._key, {
-                                selling_price: { amount: Number(e.target.value), currency: 'VND' },
-                              })
-                            }
-                            placeholder="1500000"
+                            type="text"
+                            inputMode="numeric"
+                            value={line._priceDisplay}
+                            onChange={(e) => handlePriceInput(line._key, e.target.value)}
+                            onBlur={() => {
+                              // Reformat on blur to clean up partial input
+                              const display = line.selling_price.amount
+                                ? formatPrice(line.selling_price.amount)
+                                : ''
+                              updateLine(line._key, { _priceDisplay: display })
+                            }}
+                            placeholder="1,500,000"
+                            className={re.price ? 'border-destructive' : ''}
                           />
+                          {re.price && <p className="mt-1 text-xs text-destructive">{re.price}</p>}
                         </TableCell>
 
                         {/* Remove */}
@@ -290,9 +333,6 @@ function CreatePODialog({ open, onOpenChange }: CreatePODialogProps) {
               Thêm sản phẩm
             </Button>
 
-            {errors.line_items && (
-              <p className="text-sm text-destructive">{errors.line_items}</p>
-            )}
           </div>
         </div>
 

--- a/src/app/(dashboard)/work-orders/page.tsx
+++ b/src/app/(dashboard)/work-orders/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { Suspense, useState, useMemo } from 'react'
 import Link from 'next/link'
 import { ClipboardCheck, Plus } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
@@ -48,6 +48,8 @@ import {
 import { usePlans } from '@/lib/hooks/use-plans'
 import { usePOs } from '@/lib/hooks/use-pos'
 import { useAvailableSheets } from '@/lib/hooks/use-remnants'
+import { usePageParams } from '@/lib/hooks/use-page-params'
+import { DataPagination } from '@/components/ui/data-pagination'
 import type {
   WorkOrderStatus,
   WorkOrder,
@@ -412,14 +414,19 @@ function WorkOrdersContent() {
   const [createOpen, setCreateOpen] = useState(false)
   const [advanceTarget, setAdvanceTarget] = useState<WorkOrder | null>(null)
 
+  const { page, limit, setPage } = usePageParams(15)
+
   const filter = {
     ...(statusFilter !== 'ALL' ? { status: statusFilter } : {}),
     ...(planFilter !== 'ALL' ? { plan_id: planFilter } : {}),
+    page,
+    limit,
   }
 
-  const { data, isLoading, isError } = useWorkOrders(filter)
+  const { data, isLoading, isFetching, isError } = useWorkOrders(filter)
   const workOrders = data?.items ?? []
   const totalItems = data?.total_items ?? 0
+  const totalPages = data?.total_pages ?? 1
 
   const { data: plansData } = usePlans({ limit: 200 })
   const allPlans = plansData?.items ?? []
@@ -454,7 +461,7 @@ function WorkOrdersContent() {
         <div className="flex flex-wrap gap-2">
           <Select
             value={statusFilter}
-            onValueChange={(v) => setStatusFilter(v as WorkOrderStatus | 'ALL')}
+            onValueChange={(v) => { setStatusFilter(v as WorkOrderStatus | 'ALL'); setPage(1) }}
           >
             <SelectTrigger className="w-44">
               <SelectValue />
@@ -471,7 +478,7 @@ function WorkOrdersContent() {
 
           <Select
             value={planFilter}
-            onValueChange={setPlanFilter}
+            onValueChange={(v) => { setPlanFilter(v); setPage(1) }}
           >
             <SelectTrigger className="w-52">
               <SelectValue />
@@ -494,7 +501,7 @@ function WorkOrdersContent() {
       </div>
 
       {/* Table */}
-      <div className="rounded-lg border">
+      <div className={`rounded-lg border transition-opacity ${isFetching && !isLoading ? 'opacity-60' : ''}`}>
         <div className="border-b px-4 py-3 text-sm font-medium text-muted-foreground">
           {isLoading ? 'Đang tải…' : `Tất cả lệnh sản xuất (${totalItems})`}
         </div>
@@ -576,6 +583,16 @@ function WorkOrdersContent() {
         )}
       </div>
 
+      {!isLoading && !isError && (
+        <DataPagination
+          currentPage={page}
+          totalPages={totalPages}
+          totalItems={totalItems}
+          limit={limit}
+          onPageChange={setPage}
+        />
+      )}
+
       <CreateWODialog open={createOpen} onOpenChange={setCreateOpen} />
 
       <AdvanceDialog
@@ -597,7 +614,9 @@ export default function WorkOrdersPage() {
         <ClipboardCheck className="size-6 text-muted-foreground" aria-hidden="true" />
         <h1 className="text-2xl font-bold">Lệnh sản xuất</h1>
       </div>
-      <WorkOrdersContent />
+      <Suspense fallback={<Skeleton className="h-64 w-full rounded-xl" />}>
+        <WorkOrdersContent />
+      </Suspense>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- **#62**: Input đơn giá trong modal tạo PO giờ format dấu phẩy tự động (`1,500,000`) và hiện error message riêng cho từng field/dòng
- **#66**: Danh sách lệnh sản xuất có phân trang URL-based, reset về trang 1 khi đổi filter, fade opacity khi đang refetch

**Route group affected**: `(dashboard)` — pos/page, work-orders/page

## Technical notes
- Price input: `type="text" inputMode="numeric"` + `formatPrice` / `parsePrice` helpers — commas stripped before submit, API payload không đổi
- Per-row validation: `RowErrors = Record<number, {sku_id?, quantity?, price?}>` — lỗi gắn với `line._key`, hiện inline dưới từng input
- WO pagination: tái dùng `usePageParams` + `DataPagination` đã có trong codebase (same pattern as POs page)
- `Suspense` wrap bắt buộc do `usePageParams` dùng `useSearchParams`
- New API types added: không
- New query keys: không
- Breaking changes: không

## Closes
- Closes #62
- Closes #66

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — succeeds
- [x] PO dialog: nhập `1500000` → hiện `1,500,000` trong input
- [x] PO dialog: submit với đơn giá rỗng → hiện "Đơn giá > 0" ngay dưới input đó
- [x] PO dialog: chọn trùng sản phẩm → hiện "Sản phẩm đã được chọn ở dòng khác"
- [x] PO dialog: submit thành công → API nhận số nguyên (không có dấu phẩy)
- [x] WO page: phân trang hiện ở cuối bảng
- [x] WO page: chuyển trang → URL cập nhật `?page=2`
- [x] WO page: đổi filter status → tự reset về trang 1
- [x] WO page: back/forward browser giữ đúng trang

Made with [Cursor](https://cursor.com)