### PR TITLE
[chore] setup .codex skills and next-task trigger

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,0 +1,320 @@
+---
+name: senior-workflow-frontend
+description: >
+  Use when starting ANY non-trivial issue or feature on the Next.js frontend —
+  covers the full Senior Engineer workflow: requirements clarification →
+  technical design → task breakdown → implement → self-QA → PR.
+  ALWAYS trigger this skill when the user says "implement", "add feature",
+  "build page", "add component", "create hook", "fix", "fix bug", "find root cause",
+  "plan and implement", "làm task tiếp theo", "task tiếp theo", or pastes a GitHub issue/ticket number.
+  Do NOT skip phases — Phase 5 (Self-QA) is the gate before PR and the phase
+  most commonly skipped; skipping it is the #1 source of rework.
+---
+
+# Senior Engineer Workflow — Next.js Frontend
+
+Run these 6 phases **in order**. Mark each one done before moving to the next.
+Phase 5 is mandatory — do not open a PR without completing it.
+
+---
+
+## Phase 1 — Requirements Clarification
+
+Before writing a single line of code, understand the *why*.
+
+**Questions to answer (ask the user if unclear):**
+- Who uses this screen?
+  - Worker on phone → `(kiosk)` route group, Vietnamese labels, touch targets ≥ 48px
+  - Manager on desktop → `(dashboard)` route group, responsive grid
+- What is the exact Definition of Done?
+  - Screen renders? Or also: loading state, error state, empty state, responsive at 375/768/1280px?
+- Adversarial edge cases to surface:
+  - "What if the API returns an empty array?"
+  - "What if the user taps the button twice before the mutation resolves?"
+  - "What if `data` is `undefined` on first render?" (TanStack Query always starts undefined)
+  - "Is the response a `PagedResult<T>` (`{ items, total_items }`) or a plain `T[]`?"
+  - "Are any date/optional fields missing in some API responses?"
+- Is there a Sprint issue number? (for commit/PR tagging)
+
+**Output of this phase:** a short bullet list — *Who / DoD / Edge cases identified*
+
+---
+
+## Phase 2 — Technical Design (Next.js Frontend)
+
+Design before coding. Answer these questions before opening any file.
+
+### Route & component tree
+```
+Worker on phone?     → (kiosk)/page-name/page.tsx
+Manager on desktop?  → (dashboard)/page-name/page.tsx
+```
+Component tree sketch:
+```
+page.tsx  (can be server component — exports metadata)
+  └── PageContent  ('use client' — owns state + data fetching)
+        ├── loading.tsx   (Skeleton that mirrors real layout)
+        ├── error.tsx     ('use client' — required directive)
+        └── domain components (pure, props only, no fetching)
+```
+
+### API alignment check — do this before writing any TypeScript
+Read the backend `iface.go` for the relevant module. Confirm:
+- Does the endpoint return `PagedResult<T>` or `T[]`?
+  - `PagedResult<T>` → `{ items: T[], total_items: number, ... }` — always unwrap `.items`
+  - Skipping this causes `TypeError: cannot read property 'filter' of undefined`
+- What are the exact JSON field names? Go uses `snake_case` — must match exactly in `src/types/api.ts`
+- Which fields are pointers in Go (`*string`, `*time.Time`)? These can be `null` — type them as `field?: string` or `field: string | null`
+- Are date fields always present or sometimes omitted? → type as `created_at?: string` and guard before formatting
+
+### State & data flow
+- Server state → TanStack Query `useQuery` / `useMutation`
+- Local UI state → `useState` in the component
+- Cross-component shared state (rare) → Zustand in `src/lib/hooks/`
+- Query key strategy: `[domain]` → `[domain, filter]` → `[domain, id]`
+- Which queries need `invalidateQueries` after a mutation? List them now.
+
+### Impact analysis
+- Does this touch existing cache keys? A mutation may need to invalidate more than one key.
+- New route? → needs `loading.tsx` + `error.tsx` siblings
+- New navigation entry? → update `side-nav.tsx` or `bottom-nav.tsx` AND `authorization.ts`
+- New API domain file? → follow 4-file pattern
+
+**Output of this phase:** component tree sketch, confirmed API shape + optional fields, query keys, list of mutations that invalidate
+
+---
+
+## Phase 3 — Task Breakdown
+
+Split into discrete tasks. Use TaskCreate to track them.
+
+Typical order for a new feature:
+1. Add/update types in `src/types/api.ts` (match backend iface.go exactly)
+2. Create `src/lib/api/<domain>.ts` (thin wrappers over `apiClient`)
+3. Create `src/lib/hooks/use-<domain>.ts` (TanStack Query hooks)
+4. Create `page.tsx` + `loading.tsx` + `error.tsx`
+5. Build presentational components (no fetch logic inside them)
+6. Wire data into page via hooks
+7. Handle all three states: loading / error / empty
+8. TypeScript check → ESLint → build
+
+**Rule:** Types must be correct before writing hooks. Hooks must be correct before writing UI. Never combine steps that should be sequential.
+
+---
+
+## Phase 4 — Implement
+
+### 4-file pattern for every new API domain
+```
+src/types/api.ts                      ← Step 1: DTOs (never declare types locally in a page)
+src/lib/api/<domain>.ts               ← Step 2: thin API wrappers over apiClient
+src/lib/hooks/use-<domain>.ts         ← Step 3: TanStack Query hooks
+src/app/(group)/page-name/page.tsx    ← Step 4: page + inline components
+```
+
+### Type safety rules
+```typescript
+// ✅ PagedResult: always unwrap .items
+const items = data?.items ?? []
+
+// ✅ Optional/nullable Go fields — guard before use
+plan.deadline ? formatDate(plan.deadline) : '—'
+
+// ✅ Dates are strings from Go — parse client-side, never trust format
+const d = new Date(entity.created_at)  // could be null if field is optional in Go
+
+// ✅ Nullable Go pointer fields (*string in Go → string | null in TS)
+supplier_code: string | null
+```
+
+### Hook patterns
+```typescript
+// Read hook — guard undefined at consumption site, not inside hook
+const { data, isLoading, error } = useMyEntities(filter)
+const items = data?.items ?? []   // never: data.items.filter(...)
+
+// Mutation — always invalidate on success, toast on error
+useMutation({
+  mutationFn: myApi.create,
+  onSuccess: () => {
+    queryClient.invalidateQueries({ queryKey: [MY_KEY] })
+    toast.success('Đã lưu')
+  },
+  onError: (err: ApiClientError) => toast.error(err.message),
+})
+```
+
+### Side effect rules — the #1 source of infinite loops
+**Never call `setState` or `setX` directly in the render body.**
+Any logic of the form "when X changes, update Y state" belongs in `useEffect`:
+```typescript
+// ❌ Causes infinite loop — new object created every render, condition always true
+const prevRef = { current: '' }
+if (someValue && prevRef.current !== someValue) {
+  prevRef.current = someValue
+  setOtherState(...)   // setState in render body → re-render → repeat forever
+}
+
+// ✅ Correct — runs after render, only when dependency changes
+useEffect(() => {
+  if (!someValue) return
+  setOtherState(derivedFrom(someValue))
+}, [someValue])
+```
+
+Use `useRef` for values that must persist across renders **without triggering a re-render** (e.g., scanner ref, previous value tracker). Declare refs with `useRef(initialValue)` — never as a plain object `{ current: '' }`.
+
+### Required states — every data-driven page must have all three
+```tsx
+if (isLoading) return <Skeleton ... />       // mirrors real layout structure
+if (error)     return <ErrorMessage ... />   // error.tsx must have 'use client'
+if (!items.length) return <EmptyState />     // specific empty message, not generic
+```
+
+### Kiosk-specific rules (if in `(kiosk)` route group)
+- All interactive elements: `min-h-[48px]` — no exceptions
+- Primary actions: `BigButton` from `@/components/kiosk/big-button`
+- All user-visible labels: Vietnamese
+- Font size: ≥ 16px for anything the user reads or taps
+- Action feedback: `toast.success()` / `toast.error()` within 300ms of mutation settling
+
+---
+
+## Phase 5 — Self-QA ⛔ DO NOT SKIP
+
+This is the gate before PR. Work through every section below in order — not just the ones that seem relevant. Most rework in this project comes from skipping this phase.
+
+### Step 5.1 — Run automated checks first
+These must all pass before anything else. Fix every error; do not move to 5.2 with failures.
+
+```bash
+npx tsc --noEmit        # 0 TypeScript errors — fix all, no exceptions
+npm run build           # Next.js production build must succeed
+```
+
+`npm run build` is the true gate. Turbopack and the production compiler catch different errors — a passing `tsc --noEmit` does not mean the build will pass.
+
+If lint reports `suggestCanonicalClasses` warnings (Tailwind v4), replace arbitrary values with canonical equivalents:
+```
+max-w-[375px]  →  max-w-93.75
+h-[48px]       →  h-12
+```
+
+### Step 5.2 — Read every changed file top to bottom
+
+Do not skim. For each changed file, ask yourself the questions below.
+
+#### Render body side effects
+- [ ] Does any code inside the component function (outside `useEffect`) call `setState`, `setX`, or any other state setter **conditionally or based on another state value**?
+  - If yes → it causes an infinite re-render loop. Move it to `useEffect`.
+- [ ] Is there a `useRef` declared as a plain object literal `{ current: ... }` instead of `useRef(...)`?
+  - Plain objects are re-created every render — they cannot track previous values.
+
+#### Import hygiene
+- [ ] Are all `import` statements at the **top of the file**, before any other code?
+  - ESLint `import/first` will fail if imports appear after variable declarations or JSX.
+- [ ] Any unused imports? → remove them.
+- [ ] Are imports grouped correctly: React/Next → third-party → `@/` aliases?
+
+#### TypeScript strictness
+- [ ] Any `any` type? → replace with `unknown` + type narrowing or the correct type.
+- [ ] `data!.field` (non-null assertion)? → replace with `data?.field ?? fallback`.
+- [ ] Optional Go field rendered directly without guard?
+  - `formatDate(plan.deadline)` where `deadline?: string` → `plan.deadline ? formatDate(plan.deadline) : '—'`
+- [ ] `useRef<HTMLElement>(null)` → must be `useRef<HTMLElement | null>(null)` in React 19.
+- [ ] Type declared locally inside a component or page file? → move to `src/types/api.ts`.
+
+#### Date handling
+- [ ] Every date field from the API — is it typed as optional (`string?`) if the backend Go field is a pointer or omitempty?
+- [ ] Is `formatDate` / `new Date()` called without a null/undefined guard?
+  - `new Date(undefined)` → `Invalid Date` — always guard first.
+- [ ] Is the date string from Go in the expected ISO 8601 format? Check with `console.log` if unsure.
+
+#### TanStack Query correctness
+- [ ] Every `useQuery` result used as an array — is it guarded with `?? []`?
+- [ ] Mutation `onSuccess` — does it invalidate **all** cache keys that depend on the mutated entity?
+  - E.g., creating a plan should invalidate both `['plans']` and potentially `['plan', id]`.
+- [ ] Query with a dependency param — does it have `enabled: !!param`?
+- [ ] Any query key that is a bare string literal (`'plans'`) instead of an exported constant?
+
+#### Component structure
+- [ ] Component longer than ~120 lines? → extract a named sub-component (not an inline arrow function).
+- [ ] Inline `style={}` for something Tailwind can express? → replace with `className`.
+- [ ] `fetch()` called directly instead of `apiClient`? → replace.
+- [ ] `'use client'` missing from a component that uses `useState`, `useEffect`, or browser APIs?
+- [ ] `error.tsx` missing `'use client'`? (Next.js requires it — the build will fail without it.)
+- [ ] `loading.tsx` skeleton — does it structurally match the real page? (same number of cards/rows)
+
+#### Storybook (if stories were added or modified)
+- [ ] All `import` statements at the top of the stories file?
+- [ ] Helper components used only in stories — are they named without a leading underscore (since they are used)?
+- [ ] Story covers the happy path AND the meaningful error/empty states?
+
+#### Navigation & routing
+- [ ] New route added → is it listed in `authorization.ts` so the middleware allows it?
+- [ ] New nav item added → does it appear in both `side-nav.tsx` (dashboard) or `bottom-nav.tsx` (kiosk) as appropriate?
+- [ ] Nav item points to the correct `href`?
+
+### Step 5.3 — Spot-check in the browser
+
+Before marking the task done, open the page and verify:
+- [ ] Renders correctly at 375px (mobile) — no horizontal scroll, no clipped text
+- [ ] Loading state shows before data arrives (add a 3G throttle in DevTools if needed)
+- [ ] Empty state shows when no data exists (test with an empty filter)
+- [ ] Error state shows when the API fails (temporarily break the URL to test)
+- [ ] All mutations show a success or error toast — no silent failures
+- [ ] Console has 0 errors and 0 warnings
+
+---
+
+## Phase 6 — PR
+
+### Commit message format
+```
+[area] verb: brief description
+
+- bullet detail 1
+- bullet detail 2
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+`area` is one of: `kiosk`, `dashboard`, `api`, `hooks`, `types`, or the feature name.
+
+Example:
+```
+[kiosk] fix: classify camera errors with user-facing guidance
+
+- Detect NotAllowedError, NotFoundError, insecure context separately
+- Show Vietnamese error banner with actionable instructions per error type
+- Move lineItems → rows sync into useEffect to prevent infinite re-render
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+### Branch rules
+- Feature branch from `dev`: `git checkout -b feat/area-brief-description dev`
+- Never push directly to `main` or `dev`
+- PR: feature → `dev` (approval optional)
+- `dev` → `main` requires 1 approval
+
+### PR body template
+```markdown
+## Summary
+- What was changed and why
+- Route group affected: (kiosk) / (dashboard) / shared
+
+## Technical notes
+- New API types added: yes/no — list them
+- New query keys: list them
+- Breaking changes: yes/no
+
+## Test plan
+- [ ] `npx tsc --noEmit` — 0 errors
+- [ ] `npm run lint` — clean
+- [ ] `npm run build` — succeeds
+- [ ] Renders at 375px / 768px / 1280px without layout issues
+- [ ] Loading / error / empty states all render correctly
+- [ ] All mutations show success/error toast
+- [ ] Tested manually: describe scenario
+```

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,320 +1,86 @@
----
-name: senior-workflow-frontend
-description: >
-  Use when starting ANY non-trivial issue or feature on the Next.js frontend —
-  covers the full Senior Engineer workflow: requirements clarification →
-  technical design → task breakdown → implement → self-QA → PR.
-  ALWAYS trigger this skill when the user says "implement", "add feature",
-  "build page", "add component", "create hook", "fix", "fix bug", "find root cause",
-  "plan and implement", "làm task tiếp theo", "task tiếp theo", or pastes a GitHub issue/ticket number.
-  Do NOT skip phases — Phase 5 (Self-QA) is the gate before PR and the phase
-  most commonly skipped; skipping it is the #1 source of rework.
----
+# Codex Agent Guide for Vmarble Warehouse Management Client
 
-# Senior Engineer Workflow — Next.js Frontend
+This file is the Codex-side operating guide, aligned with `CLAUDE.md`.
 
-Run these 6 phases **in order**. Mark each one done before moving to the next.
-Phase 5 is mandatory — do not open a PR without completing it.
+## Project scope
+- Frontend-only repository (Next.js + TypeScript).
+- Backend (Go) is in a separate repository; FE contracts must mirror backend `iface.go`.
 
----
+## Skill locations
+- Primary skills copied from project: `.codex/skills/`
+- Additional mirrored set: `.codex/agents/*/SKILL.md`
 
-## Phase 1 — Requirements Clarification
+## Mandatory trigger phrases
+Treat these as workflow triggers, not casual text:
+- "làm task tiếp theo"
+- "task tiếp theo"
+- "start next task"
 
-Before writing a single line of code, understand the *why*.
+When one of these appears, execute the automation workflow below.
 
-**Questions to answer (ask the user if unclear):**
-- Who uses this screen?
-  - Worker on phone → `(kiosk)` route group, Vietnamese labels, touch targets ≥ 48px
-  - Manager on desktop → `(dashboard)` route group, responsive grid
-- What is the exact Definition of Done?
-  - Screen renders? Or also: loading state, error state, empty state, responsive at 375/768/1280px?
-- Adversarial edge cases to surface:
-  - "What if the API returns an empty array?"
-  - "What if the user taps the button twice before the mutation resolves?"
-  - "What if `data` is `undefined` on first render?" (TanStack Query always starts undefined)
-  - "Is the response a `PagedResult<T>` (`{ items, total_items }`) or a plain `T[]`?"
-  - "Are any date/optional fields missing in some API responses?"
-- Is there a Sprint issue number? (for commit/PR tagging)
-
-**Output of this phase:** a short bullet list — *Who / DoD / Edge cases identified*
-
----
-
-## Phase 2 — Technical Design (Next.js Frontend)
-
-Design before coding. Answer these questions before opening any file.
-
-### Route & component tree
-```
-Worker on phone?     → (kiosk)/page-name/page.tsx
-Manager on desktop?  → (dashboard)/page-name/page.tsx
-```
-Component tree sketch:
-```
-page.tsx  (can be server component — exports metadata)
-  └── PageContent  ('use client' — owns state + data fetching)
-        ├── loading.tsx   (Skeleton that mirrors real layout)
-        ├── error.tsx     ('use client' — required directive)
-        └── domain components (pure, props only, no fetching)
-```
-
-### API alignment check — do this before writing any TypeScript
-Read the backend `iface.go` for the relevant module. Confirm:
-- Does the endpoint return `PagedResult<T>` or `T[]`?
-  - `PagedResult<T>` → `{ items: T[], total_items: number, ... }` — always unwrap `.items`
-  - Skipping this causes `TypeError: cannot read property 'filter' of undefined`
-- What are the exact JSON field names? Go uses `snake_case` — must match exactly in `src/types/api.ts`
-- Which fields are pointers in Go (`*string`, `*time.Time`)? These can be `null` — type them as `field?: string` or `field: string | null`
-- Are date fields always present or sometimes omitted? → type as `created_at?: string` and guard before formatting
-
-### State & data flow
-- Server state → TanStack Query `useQuery` / `useMutation`
-- Local UI state → `useState` in the component
-- Cross-component shared state (rare) → Zustand in `src/lib/hooks/`
-- Query key strategy: `[domain]` → `[domain, filter]` → `[domain, id]`
-- Which queries need `invalidateQueries` after a mutation? List them now.
-
-### Impact analysis
-- Does this touch existing cache keys? A mutation may need to invalidate more than one key.
-- New route? → needs `loading.tsx` + `error.tsx` siblings
-- New navigation entry? → update `side-nav.tsx` or `bottom-nav.tsx` AND `authorization.ts`
-- New API domain file? → follow 4-file pattern
-
-**Output of this phase:** component tree sketch, confirmed API shape + optional fields, query keys, list of mutations that invalidate
-
----
-
-## Phase 3 — Task Breakdown
-
-Split into discrete tasks. Use TaskCreate to track them.
-
-Typical order for a new feature:
-1. Add/update types in `src/types/api.ts` (match backend iface.go exactly)
-2. Create `src/lib/api/<domain>.ts` (thin wrappers over `apiClient`)
-3. Create `src/lib/hooks/use-<domain>.ts` (TanStack Query hooks)
-4. Create `page.tsx` + `loading.tsx` + `error.tsx`
-5. Build presentational components (no fetch logic inside them)
-6. Wire data into page via hooks
-7. Handle all three states: loading / error / empty
-8. TypeScript check → ESLint → build
-
-**Rule:** Types must be correct before writing hooks. Hooks must be correct before writing UI. Never combine steps that should be sequential.
-
----
-
-## Phase 4 — Implement
-
-### 4-file pattern for every new API domain
-```
-src/types/api.ts                      ← Step 1: DTOs (never declare types locally in a page)
-src/lib/api/<domain>.ts               ← Step 2: thin API wrappers over apiClient
-src/lib/hooks/use-<domain>.ts         ← Step 3: TanStack Query hooks
-src/app/(group)/page-name/page.tsx    ← Step 4: page + inline components
-```
-
-### Type safety rules
-```typescript
-// ✅ PagedResult: always unwrap .items
-const items = data?.items ?? []
-
-// ✅ Optional/nullable Go fields — guard before use
-plan.deadline ? formatDate(plan.deadline) : '—'
-
-// ✅ Dates are strings from Go — parse client-side, never trust format
-const d = new Date(entity.created_at)  // could be null if field is optional in Go
-
-// ✅ Nullable Go pointer fields (*string in Go → string | null in TS)
-supplier_code: string | null
-```
-
-### Hook patterns
-```typescript
-// Read hook — guard undefined at consumption site, not inside hook
-const { data, isLoading, error } = useMyEntities(filter)
-const items = data?.items ?? []   // never: data.items.filter(...)
-
-// Mutation — always invalidate on success, toast on error
-useMutation({
-  mutationFn: myApi.create,
-  onSuccess: () => {
-    queryClient.invalidateQueries({ queryKey: [MY_KEY] })
-    toast.success('Đã lưu')
-  },
-  onError: (err: ApiClientError) => toast.error(err.message),
-})
-```
-
-### Side effect rules — the #1 source of infinite loops
-**Never call `setState` or `setX` directly in the render body.**
-Any logic of the form "when X changes, update Y state" belongs in `useEffect`:
-```typescript
-// ❌ Causes infinite loop — new object created every render, condition always true
-const prevRef = { current: '' }
-if (someValue && prevRef.current !== someValue) {
-  prevRef.current = someValue
-  setOtherState(...)   // setState in render body → re-render → repeat forever
-}
-
-// ✅ Correct — runs after render, only when dependency changes
-useEffect(() => {
-  if (!someValue) return
-  setOtherState(derivedFrom(someValue))
-}, [someValue])
-```
-
-Use `useRef` for values that must persist across renders **without triggering a re-render** (e.g., scanner ref, previous value tracker). Declare refs with `useRef(initialValue)` — never as a plain object `{ current: '' }`.
-
-### Required states — every data-driven page must have all three
-```tsx
-if (isLoading) return <Skeleton ... />       // mirrors real layout structure
-if (error)     return <ErrorMessage ... />   // error.tsx must have 'use client'
-if (!items.length) return <EmptyState />     // specific empty message, not generic
-```
-
-### Kiosk-specific rules (if in `(kiosk)` route group)
-- All interactive elements: `min-h-[48px]` — no exceptions
-- Primary actions: `BigButton` from `@/components/kiosk/big-button`
-- All user-visible labels: Vietnamese
-- Font size: ≥ 16px for anything the user reads or taps
-- Action feedback: `toast.success()` / `toast.error()` within 300ms of mutation settling
-
----
-
-## Phase 5 — Self-QA ⛔ DO NOT SKIP
-
-This is the gate before PR. Work through every section below in order — not just the ones that seem relevant. Most rework in this project comes from skipping this phase.
-
-### Step 5.1 — Run automated checks first
-These must all pass before anything else. Fix every error; do not move to 5.2 with failures.
-
+## Automation workflow (for "làm task tiếp theo")
+1) **Fetch highest-priority open issue** (assigned to me):
 ```bash
-npx tsc --noEmit        # 0 TypeScript errors — fix all, no exceptions
-npm run build           # Next.js production build must succeed
+gh issue list --repo giangdq202/Vmarble-Warehouse-Management-Client \
+  --assignee @me --state open --json number,title,labels \
+  | jq 'sort_by(.labels[].name) | .[0]'
 ```
 
-`npm run build` is the true gate. Turbopack and the production compiler catch different errors — a passing `tsc --noEmit` does not mean the build will pass.
-
-If lint reports `suggestCanonicalClasses` warnings (Tailwind v4), replace arbitrary values with canonical equivalents:
-```
-max-w-[375px]  →  max-w-93.75
-h-[48px]       →  h-12
+2) **Read issue requirements + DoD**:
+```bash
+gh issue view <number> --repo giangdq202/Vmarble-Warehouse-Management-Client
 ```
 
-### Step 5.2 — Read every changed file top to bottom
+3) **Business audit gate**:
+- If task touches business/domain rules (BR-*, remnant lifecycle, costing, allocation), apply `business-auditor` guidance before coding.
 
-Do not skim. For each changed file, ask yourself the questions below.
+4) **Implementation workflow gate**:
+- Apply `senior-workflow-frontend` workflow (requirements → design → breakdown → implement → self-QA → PR).
+- Do not skip self-QA.
 
-#### Render body side effects
-- [ ] Does any code inside the component function (outside `useEffect`) call `setState`, `setX`, or any other state setter **conditionally or based on another state value**?
-  - If yes → it causes an infinite re-render loop. Move it to `useEffect`.
-- [ ] Is there a `useRef` declared as a plain object literal `{ current: ... }` instead of `useRef(...)`?
-  - Plain objects are re-created every render — they cannot track previous values.
+5) **Integration gate (hard rule)**:
+- If any change touches:
+  - `src/types/api.ts`
+  - `src/lib/api/*.ts`
+  - TanStack Query hooks calling backend
+- Then enforce `integration-architect` checks before finalizing PR.
 
-#### Import hygiene
-- [ ] Are all `import` statements at the **top of the file**, before any other code?
-  - ESLint `import/first` will fail if imports appear after variable declarations or JSX.
-- [ ] Any unused imports? → remove them.
-- [ ] Are imports grouped correctly: React/Next → third-party → `@/` aliases?
+## Frontend implementation constraints
+- Correct route group:
+  - Worker mobile UI → `(kiosk)`
+  - Manager desktop UI → `(dashboard)`
+- Kiosk UX:
+  - touch target >= 48px, readable text >= 16px
+  - use `BigButton` for primary actions
+  - Vietnamese user-facing labels
+- Data pages must handle loading/error/empty states.
 
-#### TypeScript strictness
-- [ ] Any `any` type? → replace with `unknown` + type narrowing or the correct type.
-- [ ] `data!.field` (non-null assertion)? → replace with `data?.field ?? fallback`.
-- [ ] Optional Go field rendered directly without guard?
-  - `formatDate(plan.deadline)` where `deadline?: string` → `plan.deadline ? formatDate(plan.deadline) : '—'`
-- [ ] `useRef<HTMLElement>(null)` → must be `useRef<HTMLElement | null>(null)` in React 19.
-- [ ] Type declared locally inside a component or page file? → move to `src/types/api.ts`.
+## API and typing constraints
+- API DTOs in `src/types/api.ts` must match backend JSON shape (`snake_case`).
+- For paged endpoints, always consume `data?.items ?? []`.
+- Guard optional/pointer fields from backend before rendering/formatting.
 
-#### Date handling
-- [ ] Every date field from the API — is it typed as optional (`string?`) if the backend Go field is a pointer or omitempty?
-- [ ] Is `formatDate` / `new Date()` called without a null/undefined guard?
-  - `new Date(undefined)` → `Invalid Date` — always guard first.
-- [ ] Is the date string from Go in the expected ISO 8601 format? Check with `console.log` if unsure.
-
-#### TanStack Query correctness
-- [ ] Every `useQuery` result used as an array — is it guarded with `?? []`?
-- [ ] Mutation `onSuccess` — does it invalidate **all** cache keys that depend on the mutated entity?
-  - E.g., creating a plan should invalidate both `['plans']` and potentially `['plan', id]`.
-- [ ] Query with a dependency param — does it have `enabled: !!param`?
-- [ ] Any query key that is a bare string literal (`'plans'`) instead of an exported constant?
-
-#### Component structure
-- [ ] Component longer than ~120 lines? → extract a named sub-component (not an inline arrow function).
-- [ ] Inline `style={}` for something Tailwind can express? → replace with `className`.
-- [ ] `fetch()` called directly instead of `apiClient`? → replace.
-- [ ] `'use client'` missing from a component that uses `useState`, `useEffect`, or browser APIs?
-- [ ] `error.tsx` missing `'use client'`? (Next.js requires it — the build will fail without it.)
-- [ ] `loading.tsx` skeleton — does it structurally match the real page? (same number of cards/rows)
-
-#### Storybook (if stories were added or modified)
-- [ ] All `import` statements at the top of the stories file?
-- [ ] Helper components used only in stories — are they named without a leading underscore (since they are used)?
-- [ ] Story covers the happy path AND the meaningful error/empty states?
-
-#### Navigation & routing
-- [ ] New route added → is it listed in `authorization.ts` so the middleware allows it?
-- [ ] New nav item added → does it appear in both `side-nav.tsx` (dashboard) or `bottom-nav.tsx` (kiosk) as appropriate?
-- [ ] Nav item points to the correct `href`?
-
-### Step 5.3 — Spot-check in the browser
-
-Before marking the task done, open the page and verify:
-- [ ] Renders correctly at 375px (mobile) — no horizontal scroll, no clipped text
-- [ ] Loading state shows before data arrives (add a 3G throttle in DevTools if needed)
-- [ ] Empty state shows when no data exists (test with an empty filter)
-- [ ] Error state shows when the API fails (temporarily break the URL to test)
-- [ ] All mutations show a success or error toast — no silent failures
-- [ ] Console has 0 errors and 0 warnings
-
----
-
-## Phase 6 — PR
-
-### Commit message format
+## Validation / QA gates
+Before PR, run:
+```bash
+npx tsc --noEmit
+npm run lint
+npm run build
 ```
-[area] verb: brief description
+If repository has known pre-existing lint debt, clearly separate:
+- errors introduced by this PR
+- pre-existing unrelated errors
 
-- bullet detail 1
-- bullet detail 2
+## Git / PR policy
+- Branch from `dev`.
+- Never push directly to `dev` or `main`.
+- Open PR from feature/chore branch to `dev`.
+- Use concise title format: `[area] brief description`.
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
-```
+## Practical trigger examples
+- "làm task tiếp theo"
+- "task tiếp theo"
+- "implement issue #67"
+- "fix bug ở kiosk report-cut"
 
-`area` is one of: `kiosk`, `dashboard`, `api`, `hooks`, `types`, or the feature name.
-
-Example:
-```
-[kiosk] fix: classify camera errors with user-facing guidance
-
-- Detect NotAllowedError, NotFoundError, insecure context separately
-- Show Vietnamese error banner with actionable instructions per error type
-- Move lineItems → rows sync into useEffect to prevent infinite re-render
-
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
-```
-
-### Branch rules
-- Feature branch from `dev`: `git checkout -b feat/area-brief-description dev`
-- Never push directly to `main` or `dev`
-- PR: feature → `dev` (approval optional)
-- `dev` → `main` requires 1 approval
-
-### PR body template
-```markdown
-## Summary
-- What was changed and why
-- Route group affected: (kiosk) / (dashboard) / shared
-
-## Technical notes
-- New API types added: yes/no — list them
-- New query keys: list them
-- Breaking changes: yes/no
-
-## Test plan
-- [ ] `npx tsc --noEmit` — 0 errors
-- [ ] `npm run lint` — clean
-- [ ] `npm run build` — succeeds
-- [ ] Renders at 375px / 768px / 1280px without layout issues
-- [ ] Loading / error / empty states all render correctly
-- [ ] All mutations show success/error toast
-- [ ] Tested manually: describe scenario
-```
+These should route into the same disciplined workflow above.

--- a/.codex/agents/add-api-route/SKILL.md
+++ b/.codex/agents/add-api-route/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: add-api-route
+description: Use when adding a new API domain, new endpoint to an existing domain, or a new TanStack Query hook. Covers the 4-file pattern (api client + types + hook), query key conventions, mutation invalidation, and error handling.
+---
+
+# Add API Route & TanStack Query Hook
+
+## Pattern overview — 4 files per domain
+
+```
+src/
+├── types/api.ts                  ← 1. Add DTO types here (shared with all consumers)
+├── lib/api/<domain>.ts           ← 2. API functions (thin wrappers over apiClient)
+└── lib/hooks/use-<domain>.ts     ← 3. TanStack Query hooks (consumed by components)
+```
+
+The **`apiClient`** base is at `src/lib/api/client.ts` — import from there, never use `fetch` directly.
+
+---
+
+## Step 1 — Add types to `src/types/api.ts`
+
+Mirror the Go backend response types exactly. Use the naming convention from the backend `iface.go`:
+
+```typescript
+// src/types/api.ts — append new types here
+
+export interface MyEntity {
+  id: string
+  name: string
+  status: 'ACTIVE' | 'INACTIVE'
+  created_at: string   // ISO string from Go time.Time — use snake_case to match JSON tags
+}
+
+export interface CreateMyEntityInput {
+  name: string
+}
+
+// Paginated list endpoints return PagedResult<T> (NOT PaginatedResponse — that is @deprecated).
+// Shape: { items: T[], total_items: number, total_pages: number, current_page: number, limit: number }
+// Always unwrap .items when rendering — never treat PagedResult<T> as T[].
+```
+
+**Rules:**
+- Dates from the Go API are always `string` (ISO 8601) — parse client-side when needed
+- Enums mirror the Go `const` block — use TypeScript string union, not `enum`
+- Field names are `snake_case` to match Go JSON tags — do NOT use `camelCase`
+- Never declare the same type in two places — always import from `@/types/api`
+- Use `PagedResult<T>` (not the `@deprecated PaginatedResponse<T>`) for paginated endpoints
+
+---
+
+## Step 2 — Create `src/lib/api/<domain>.ts`
+
+```typescript
+// src/lib/api/my-domain.ts
+import type { MyEntity, CreateMyEntityInput, PagedResult } from '@/types/api'
+import { apiClient } from './client'
+
+// ── Filter type for list endpoints ────────────────────────────────────────────
+export interface MyEntityFilter {
+  status?: string
+  page?: number
+  limit?: number
+}
+
+// ── API functions ─────────────────────────────────────────────────────────────
+export const myDomainApi = {
+  list: (filter: MyEntityFilter = {}) =>
+    apiClient.get<PagedResult<MyEntity>>('/my-entities', {
+      params: filter as Record<string, string | number | boolean | undefined>,
+    }),
+
+  getById: (id: string) =>
+    apiClient.get<MyEntity>(`/my-entities/${id}`),
+
+  create: (input: CreateMyEntityInput) =>
+    apiClient.post<MyEntity>('/my-entities', input),
+
+  update: (id: string, input: Partial<CreateMyEntityInput>) =>
+    apiClient.put<MyEntity>(`/my-entities/${id}`, input),
+
+  delete: (id: string) =>
+    apiClient.delete<void>(`/my-entities/${id}`),
+}
+```
+
+**Rules:**
+- Return type for paginated endpoints is always `PagedResult<T>` — never `T[]` or `PaginatedResponse<T>`
+- Export a single object `myDomainApi` — all functions are methods on it
+- Always import from `./client`, never create a new `fetch` call
+- Filter types are declared in the same file (not in `types/api.ts`)
+- Use explicit generics: `apiClient.get<PagedResult<MyEntity>>(...)`
+
+---
+
+## Step 3 — Create `src/lib/hooks/use-<domain>.ts`
+
+```typescript
+// src/lib/hooks/use-my-domain.ts
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { myDomainApi, type MyEntityFilter } from '@/lib/api/my-domain'
+import type { ApiClientError } from '@/lib/api/client'
+import type { MyEntity } from '@/types/api'
+
+// ── Query key constants ───────────────────────────────────────────────────────
+// Keep keys as constants — prevents typos and helps with invalidation
+export const MY_ENTITY_KEY = 'my-entities'
+
+// ── Read hooks ────────────────────────────────────────────────────────────────
+export function useMyEntities(filter: MyEntityFilter = {}) {
+  return useQuery({
+    queryKey: [MY_ENTITY_KEY, filter],
+    queryFn: () => myDomainApi.list(filter),
+    // data is PagedResult<MyEntity> — always access .items, never treat as array
+  })
+}
+
+export function useMyEntity(id: string) {
+  return useQuery({
+    queryKey: [MY_ENTITY_KEY, id],
+    queryFn: () => myDomainApi.getById(id),
+    enabled: !!id,          // don't run if id is empty
+  })
+}
+
+// ── Mutation hooks ────────────────────────────────────────────────────────────
+export function useCreateMyEntity() {
+  const queryClient = useQueryClient()
+  return useMutation<MyEntity, ApiClientError, CreateMyEntityInput>({
+    mutationFn: myDomainApi.create,
+    onSuccess: () => {
+      // Invalidate the list so it refetches — always invalidate by root key
+      queryClient.invalidateQueries({ queryKey: [MY_ENTITY_KEY] })
+    },
+  })
+}
+
+export function useDeleteMyEntity() {
+  const queryClient = useQueryClient()
+  return useMutation<void, ApiClientError, string>({
+    mutationFn: (id) => myDomainApi.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [MY_ENTITY_KEY] })
+    },
+  })
+}
+```
+
+**Query key conventions:**
+| Pattern | Use |
+|---------|-----|
+| `[domain]` | All items in a domain (`invalidateQueries` invalidates everything) |
+| `[domain, filter]` | Filtered list (filter object is stable key part) |
+| `[domain, id]` | Single entity |
+| `[domain, id, 'lineage']` | Subresource of an entity |
+
+**Default query config** (set in `src/lib/providers.tsx`):
+- `staleTime: 30_000` (30 s) — data is fresh for 30 seconds
+- `gcTime: 5 * 60_000` (5 min) — cache entry lives 5 min after last observer
+- `retry: 1` — one automatic retry on failure
+- `refetchOnWindowFocus: false` — disable background refetch on tab switch
+
+---
+
+## Step 4 — Use the hook in a component
+
+```tsx
+'use client'
+
+import { useMyEntities, useCreateMyEntity } from '@/lib/hooks/use-my-domain'
+import { toast } from 'sonner'
+
+export function MyEntityList() {
+  const { data, isLoading, error } = useMyEntities({ status: 'ACTIVE' })
+  const createMutation = useCreateMyEntity()
+
+  if (isLoading) return <Skeleton className="h-10 w-full" />
+  if (error) return <p className="text-destructive">{error.message}</p>
+
+  // IMPORTANT: data is PagedResult<MyEntity> — always unwrap .items
+  // data?.data.map(...)  ← WRONG — 'data' field doesn't exist on PagedResult
+  // data?.items.map(...) ← CORRECT
+  const items = data?.items ?? []
+
+  const handleCreate = async () => {
+    try {
+      await createMutation.mutateAsync({ name: 'New entity' })
+      toast.success('Tạo thành công')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Lỗi không xác định')
+    }
+  }
+
+  return (
+    <ul>
+      {items.map((item) => <li key={item.id}>{item.name}</li>)}
+    </ul>
+  )
+}
+```
+
+---
+
+## Error handling with `ApiClientError`
+
+```typescript
+import { ApiClientError } from '@/lib/api/client'
+
+try {
+  await myDomainApi.create(input)
+} catch (err) {
+  if (err instanceof ApiClientError) {
+    if (err.status === 422) {
+      // Validation error — err.details is Record<string, string>
+      console.log(err.details)
+    }
+    if (err.status === 409) {
+      toast.error('Đã tồn tại — không thể tạo trùng')
+    }
+  }
+}
+```
+
+Common Go backend status codes:
+- `400` Bad Request (invalid input)
+- `404` Not found → maps to Go `domain.ErrNotFound`
+- `409` Conflict (duplicate)
+- `422` Unprocessable (business rule violation)
+- `503` Backend unavailable

--- a/.codex/agents/add-page/SKILL.md
+++ b/.codex/agents/add-page/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: add-page
+description: Use when adding a new page or route — choosing the correct route group (kiosk/dashboard/auth), structuring the page file, adding loading.tsx and error.tsx siblings, and following responsive layout rules.
+---
+
+# Add a New Page
+
+## Route group decision tree
+
+```
+Is this for shop-floor workers on mobile?  →  (kiosk)
+Is this for managers on desktop/tablet?    →  (dashboard)
+Is this an auth screen (login/PIN)?        →  (auth)
+```
+
+Route groups don't appear in the URL:
+- `src/app/(kiosk)/my-page/page.tsx` → URL: `/my-page`
+- `src/app/(dashboard)/my-page/page.tsx` → URL: `/my-page`
+- `src/app/(auth)/my-page/page.tsx` → URL: `/my-page`
+
+---
+
+## Minimum file set for every new page
+
+```
+src/app/(group)/my-page/
+├── page.tsx        ← required — the page itself
+├── loading.tsx     ← required — Suspense skeleton shown while page loads
+└── error.tsx       ← recommended — recoverable per-route error boundary
+```
+
+---
+
+## Page template — server component (default)
+
+```tsx
+// src/app/(kiosk)/my-page/page.tsx
+import type { Metadata } from 'next'
+// Import shadcn components from @/components/ui/
+// Import kiosk components from @/components/kiosk/
+// Import dashboard components from @/components/dashboard/
+
+export const metadata: Metadata = { title: 'Tên màn hình' }
+
+export default function MyPage() {
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-xl font-bold">Tên màn hình</h1>
+      {/* page content */}
+    </div>
+  )
+}
+```
+
+**Rules for server components (default):**
+- Export `metadata` — always include `title`
+- No `'use client'` at the top unless you need state/effects
+- Data fetching happens in async sub-components or client components via TanStack Query
+
+---
+
+## Page template — client component (when state/hooks needed)
+
+```tsx
+'use client'
+
+import type { Metadata } from 'next'
+import { useMyEntities } from '@/lib/hooks/use-my-domain'
+
+// metadata can't be exported from 'use client' pages
+// Instead, export it from a parent layout or a separate server wrapper
+
+export default function MyClientPage() {
+  const { data, isLoading } = useMyEntities()
+  // ...
+}
+```
+
+If you need both metadata AND client hooks, split into a server wrapper + client component:
+```tsx
+// page.tsx (server) — exports metadata, renders the client component
+import type { Metadata } from 'next'
+import { MyPageContent } from './_components/my-page-content'   // client component
+
+export const metadata: Metadata = { title: 'My Page' }
+
+export default function MyPage() {
+  return <MyPageContent />
+}
+```
+
+---
+
+## loading.tsx template
+
+```tsx
+// src/app/(kiosk)/my-page/loading.tsx
+import { Skeleton } from '@/components/ui/skeleton'
+import { Card, CardContent } from '@/components/ui/card'
+
+export default function MyPageLoading() {
+  return (
+    <div className="space-y-4 p-4">
+      <Skeleton className="h-7 w-40" />          {/* page title */}
+      {[1, 2, 3].map((i) => (
+        <Card key={i}>
+          <CardContent className="p-4">
+            <Skeleton className="mb-2 h-5 w-32" />
+            <Skeleton className="h-4 w-48" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}
+```
+
+Mirror the visual structure of the actual page — same number of "cards", similar heights.
+
+---
+
+## error.tsx template
+
+```tsx
+// src/app/(kiosk)/my-page/error.tsx
+'use client'    // error boundaries must be client components
+
+import { useEffect } from 'react'
+import { Button } from '@/components/ui/button'
+
+export default function MyPageError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    // Optional: log to error reporting service
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="flex min-h-[40vh] flex-col items-center justify-center gap-4 p-4 text-center">
+      <p className="font-medium">Có lỗi xảy ra</p>
+      <p className="text-sm text-muted-foreground">{error.message}</p>
+      <Button onClick={reset}>Thử lại</Button>
+    </div>
+  )
+}
+```
+
+---
+
+## Layout rules by route group
+
+### (kiosk) pages — mobile-first
+
+```tsx
+// Outer wrapper: vertical stack with p-4 padding
+<div className="space-y-4 p-4">
+  <h1 className="text-xl font-bold">Tiêu đề</h1>
+
+  {/* Kiosk cards: touch-optimized */}
+  <Card>
+    <CardContent className="flex items-center justify-between p-4">
+      {/* content */}
+    </CardContent>
+  </Card>
+
+  {/* Primary action: always BigButton at bottom */}
+  <BigButton>Hành động chính</BigButton>
+</div>
+```
+
+Kiosk checklist:
+- [ ] Font size ≥ 16px for all interactive text
+- [ ] Touch targets ≥ 48px height for tappable items
+- [ ] Primary action uses `BigButton` (min-h: 56px, full-width)
+- [ ] Text labels in **Vietnamese** (worker-facing)
+- [ ] Pull-to-refresh via TanStack Query `refetchOnWindowFocus` or manual button
+- [ ] Skeleton loading in `loading.tsx` mirrors page structure
+
+### (dashboard) pages — desktop/tablet
+
+```tsx
+// Outer wrapper: responsive grid layout
+<div className="space-y-6">
+  <h1 className="text-2xl font-bold">Tiêu đề</h1>
+
+  {/* KPI row */}
+  <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    <StatCard title="Metric" value="123" icon={SomeIcon} />
+  </div>
+
+  {/* Alert banner if relevant */}
+  <AlertBanner status="GREEN" utilizationPct={8} message="..." />
+
+  {/* Data table */}
+  <div className="rounded-xl border bg-card shadow-sm">
+    <Table>...</Table>
+  </div>
+</div>
+```
+
+Dashboard checklist:
+- [ ] Title uses `text-2xl font-bold`
+- [ ] Stats use `StatCard` from `@/components/dashboard/stat-card`
+- [ ] Overflow alerts use `AlertBanner` from `@/components/dashboard/alert-banner`
+- [ ] Tables use shadcn `Table` components
+- [ ] Responsive: `sm:` and `lg:` breakpoints for grid columns
+
+---
+
+## Responsive breakpoints
+
+| Breakpoint | Width | Context |
+|------------|-------|---------|
+| base | 375 px | Mobile kiosk (shop floor) |
+| `sm:` | 640 px | — |
+| `md:` | 768 px | Tablet |
+| `lg:` | 1024 px | — |
+| `xl:` | 1280 px | Desktop dashboard |
+
+Always design base (mobile) first, then add `md:` / `lg:` overrides.
+
+---
+
+## Internal links
+
+Always use `next/link` for navigation — never `<a href>` for internal routes:
+
+```tsx
+import Link from 'next/link'
+
+<Link href="/cutting-orders" className="...">Lệnh cắt</Link>
+```
+
+For programmatic navigation in client components:
+
+```tsx
+'use client'
+import { useRouter } from 'next/navigation'
+
+const router = useRouter()
+router.push('/cutting-orders')
+```

--- a/.codex/agents/add-shadcn-component/SKILL.md
+++ b/.codex/agents/add-shadcn-component/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: add-shadcn-component
+description: Use when adding a new shadcn/ui component to the project — running the CLI, placing files, writing wrappers, or creating custom CVA-based variants following the existing button/card/badge patterns.
+---
+
+# Add shadcn/ui Component
+
+## CLI — add an existing shadcn component
+
+```bash
+# Always use the latest CLI
+npx shadcn@latest add <component-name>
+```
+
+The component is placed automatically at **`src/components/ui/<component>.tsx`** (configured via `components.json`).
+
+Common components available:
+- `accordion` `alert-dialog` `avatar` `checkbox` `collapsible` `command`
+- `dropdown-menu` `form` `hover-card` `popover` `progress` `radio-group`
+- `scroll-area` `sheet` `slider` `switch` `tabs` `textarea` `toggle`
+- `tooltip`
+
+After adding, import from `@/components/ui/<component>`.
+
+## Project configuration (`components.json`)
+
+| Setting | Value |
+|---------|-------|
+| Style | `new-york` |
+| Base color | `neutral` |
+| CSS variables | `true` (oklch color space) |
+| Icon library | `lucide-react` |
+| Alias | `@/components/ui` |
+| Utils | `@/lib/utils` (exports `cn`) |
+
+## Golden rule — never modify generated files
+
+Do **not** edit files under `src/components/ui/` directly.
+Instead, create a **wrapper component** in `src/components/kiosk/`, `src/components/dashboard/`, or a new domain folder.
+
+```tsx
+// ✅ Correct — wrapper in src/components/kiosk/big-button.tsx
+import { Button, type buttonVariants } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+export function BigButton({ className, ...props }) {
+  return <Button className={cn('min-h-[56px] w-full text-lg', className)} {...props} />
+}
+
+// ❌ Wrong — editing src/components/ui/button.tsx directly
+```
+
+## Writing a custom component from scratch (CVA pattern)
+
+Follow the exact same pattern used in `src/components/ui/button.tsx`:
+
+```tsx
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'          // for asChild polymorphism
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+const myVariants = cva(
+  // 1. Base classes (always applied)
+  'inline-flex items-center rounded-md text-sm font-medium transition-all disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        primary: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+      },
+      size: {
+        default: 'h-9 px-4',
+        sm: 'h-8 px-3',
+        lg: 'h-11 px-6',
+      },
+    },
+    defaultVariants: { variant: 'primary', size: 'default' },
+  },
+)
+
+interface MyComponentProps
+  extends React.ComponentProps<'button'>,
+    VariantProps<typeof myVariants> {
+  asChild?: boolean   // allow rendering as a different element
+}
+
+function MyComponent({ className, variant, size, asChild = false, ...props }: MyComponentProps) {
+  const Comp = asChild ? Slot : 'button'
+  return (
+    <Comp
+      data-slot="my-component"          // data-slot for shadcn consistency
+      className={cn(myVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { MyComponent, myVariants }     // export both component AND variants
+```
+
+## CSS variables for colors
+
+Always reference design tokens — never hardcode hex/rgb values:
+
+```tsx
+// ✅ Uses CSS variables (respects dark mode automatically)
+className="bg-primary text-primary-foreground"
+className="bg-destructive text-white"
+className="border-border bg-card"
+className="text-muted-foreground"
+
+// ❌ Hardcoded — breaks dark mode
+className="bg-black text-white"
+```
+
+Available tokens: `--background`, `--foreground`, `--primary`, `--primary-foreground`, `--secondary`, `--muted`, `--accent`, `--destructive`, `--border`, `--ring`, `--card`, `--chart-1..5`, `--sidebar-*`
+
+## Sonner toast integration
+
+After a user action, always give feedback:
+
+```tsx
+import { toast } from 'sonner'
+
+toast.success('Tấm lẻ đã được nhập kho')
+toast.error('Không thể kết nối API')
+toast.loading('Đang xử lý...')
+```
+
+## Accessibility checklist
+
+- All interactive elements: `focus-visible:ring-[3px] focus-visible:ring-ring/50`
+- Disabled state: `disabled:pointer-events-none disabled:opacity-50`
+- Icons inside buttons: `aria-hidden="true"` + sr-only text if icon-only
+- Touch targets (kiosk): minimum `min-h-[48px] min-w-[48px]`

--- a/.codex/agents/business-auditor/SKILL.md
+++ b/.codex/agents/business-auditor/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: business-auditor
+description: Use to verify if UI/UX and Frontend logic reflect the Vietnamese business rules.
+---
+
+# Business Auditor - UI & UX Validation (Frontend)
+
+Ensures the user flow and interface comply with `docs/backend-business-logic-vi.md`.
+
+## Core Principles
+1. **Terminology**: Use precise Vietnamese workshop terms (tấm lẻ, phôi, lệnh cắt, hao hụt, vị trí kho).
+2. **State Logic**: UI must reflect business states (e.g., `CONSUMED` remnants must not appear in `AVAILABLE` lists).
+
+## Audit Workflow
+
+### 1. Terminology Audit
+Ensure standard terms are used across all pages:
+- `Remnant` -> "Tấm lẻ"
+- `WorkOrder` -> "Lệnh cắt"
+- `BoardSheet` -> "Tấm nguyên"
+- `Bin Location` -> "Vị trí kho"
+
+### 2. UI Constraint Check
+- **BR-K01/K05**: When reporting a cut, FE must provide inputs for `boundingBoxLengthMm` and `boundingBoxWidthMm`.
+- **Overflow Alerts**: Verify the color logic (Red/Green) for remnant area utilization percentages.
+
+### 3. Integrated Validation
+- Before calling `recordCut` API, the FE should perform basic "Pre-checks" (e.g., dimensions must be positive numbers).
+
+## Pre-PR Checklist
+- [ ] Are all labels in correct Vietnamese?
+- [ ] Does the scan flow follow the correct sequence (Scan Material -> Scan Location)?
+- [ ] Is there an Alert Banner for significant area loss (>15% overflow)?

--- a/.codex/agents/docs-researcher.toml
+++ b/.codex/agents/docs-researcher.toml
@@ -1,0 +1,8 @@
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+
+developer_instructions = """
+Verify API and framework behavior against primary docs before implementation claims are finalized.
+Cite specific documentation/source references.
+"""

--- a/.codex/agents/explorer.toml
+++ b/.codex/agents/explorer.toml
@@ -1,0 +1,9 @@
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+
+developer_instructions = """
+Explore repository structure and implementation paths.
+Collect evidence with file paths and minimal assumptions.
+Do not edit files.
+"""

--- a/.codex/agents/integration-architect/SKILL.md
+++ b/.codex/agents/integration-architect/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: integration-architect
+description: Use to ensure absolute sync between Frontend and Backend. Checks API contracts, Type safety, and data flow.
+---
+
+# Integration Architect - Client-Server Sync
+
+Acts as the gatekeeper to ensure the Client never breaks due to Backend changes.
+
+## Contract Synchronization
+1. **Single Source of Types**: Always cross-reference `src/types/api.ts` with the Backend's `iface.go`.
+2. **Snake Case Consistency**: Use **snake_case** for all DTOs to match Go JSON tags, avoiding manual renaming errors.
+3. **Status Enums**: Ensure FE string unions (e.g., `AVAILABLE`, `IN_CUTTING`) match the Backend `internal/domain` constants 1:1.
+
+## Integration Checks
+- **Mutation Invalidation**: After actions like `allocateRemnant`, ensure the correct Query Keys are invalidated to prevent stale UI data.
+- **Scanner Payload**: Verify the JSON structure in QR codes matches between BE generation and FE `ScannerView` parsing.
+
+## Integration Checklist
+- [ ] Is the API base URL correctly configured for the environment?
+- [ ] Are Backend `BizError` messages displayed in a user-friendly way?
+- [ ] Are date strings from the API safely handled/formatted?
+
+---
+*Goal: Achieve end-to-end type safety from the Database to the UI Component.*

--- a/.codex/agents/kiosk-component/SKILL.md
+++ b/.codex/agents/kiosk-component/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: kiosk-component
+description: Use when building any component for the (kiosk) route group — shop-floor mobile UI for workers. Covers touch targets, BigButton, ScannerView, QR print, Vietnamese labels, and sonner toasts.
+---
+
+# Kiosk Component Guidelines
+
+The kiosk is a mobile-first PWA used by factory workers (Vietnamese speakers) on Android phones and tablets at the shop floor. Every component must be operable with one hand, gloves on, in a dusty/noisy environment.
+
+## Non-negotiable rules
+
+| Rule | Value |
+|------|-------|
+| Min touch target height | **48 px** (`min-h-[48px]`) |
+| Min touch target width | **48 px** |
+| Primary action button height | **56 px** (`BigButton` — `min-h-[56px]`) |
+| Base font size | **≥ 16 px** (avoids iOS auto-zoom on focus) |
+| Max steps to complete a task | **3 taps** |
+| UI language | **Vietnamese** |
+| Loading feedback | **Instant skeleton** (`loading.tsx`) |
+| Action feedback | **sonner toast** within 300 ms |
+
+---
+
+## `BigButton` — primary actions
+
+Import from `@/components/kiosk/big-button`. Use for every primary action (submit, confirm, scan, print).
+
+```tsx
+import { BigButton } from '@/components/kiosk/big-button'
+
+// Primary action
+<BigButton onClick={handleSubmit} disabled={isPending}>
+  {isPending ? 'Đang xử lý...' : 'Báo cáo kết quả'}
+</BigButton>
+
+// Danger action (e.g. discard)
+<BigButton variant="danger" onClick={handleCancel}>
+  Huỷ lệnh
+</BigButton>
+
+// Secondary action
+<BigButton variant="secondary">Bỏ qua</BigButton>
+```
+
+**Props**: `variant: 'primary' | 'secondary' | 'danger'` + all standard `<button>` props.
+
+Do **not** use `Button` from `@/components/ui/button` for primary kiosk actions — it's too small.
+
+---
+
+## `ScannerView` — QR / barcode scanning
+
+Import from `@/components/kiosk/scanner-view`. Always wrap in a `Card`.
+
+```tsx
+import { ScannerView } from '@/components/kiosk/scanner-view'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+<Card>
+  <CardHeader>
+    <CardTitle className="text-base">Quét mã QR tấm lẻ</CardTitle>
+  </CardHeader>
+  <CardContent>
+    <ScannerView
+      onScan={(code) => {
+        // code is the decoded QR string — parse JSON or use as ID
+        try {
+          const data = JSON.parse(code)
+          // e.g. { type: 'REMNANT', id: 'R-001', ... }
+          handleScan(data)
+        } catch {
+          // plain barcode string
+          handleScan({ id: code })
+        }
+      }}
+    />
+  </CardContent>
+</Card>
+```
+
+**Behaviour:**
+- Uses `html5-qrcode` (dynamically imported, no SSR issues)
+- Camera facing: `environment` (back camera)
+- Falls back to manual text input automatically if camera permission denied
+- `onScan` fires once per detected code
+
+**QR content format** (from Go backend):
+```json
+{ "type": "REMNANT" | "WIP", "id": "...", "sku": "...", "dimensions": {...}, "lot": "...", "location": "..." }
+```
+
+---
+
+## `LabelPreview` — print label preview
+
+Import from `@/components/kiosk/label-preview`.
+
+```tsx
+import { LabelPreview } from '@/components/kiosk/label-preview'
+import type { BarcodeRecord } from '@/types/api'
+
+// After RecordCut succeeds and returns barcodeIds, fetch the record:
+<LabelPreview barcode={barcodeRecord} size="small" />   // 50×30mm remnant label
+<LabelPreview barcode={barcodeRecord} size="large" />   // 100×70mm WIP label
+```
+
+Clicking the preview opens `window.print()` — browser print dialog.
+
+---
+
+## `BottomNav` — navigation (already in layout)
+
+The kiosk layout (`src/app/(kiosk)/layout.tsx`) already renders `BottomNav`. **Do not add another nav** inside page components.
+
+The bottom nav has 4 tabs:
+- `/cutting-orders` — Lệnh cắt
+- `/report-cut` — Báo cáo
+- `/remnant-list` — Kho tấm lẻ
+- `/scan` — Quét mã
+
+---
+
+## Toast notifications (sonner)
+
+Always give feedback immediately after user action:
+
+```tsx
+import { toast } from 'sonner'
+
+// After successful API call
+toast.success('Đã nhập kho tấm lẻ thành công')
+
+// After API error
+toast.error('Lỗi kết nối — vui lòng thử lại')
+
+// Loading state during mutation
+const toastId = toast.loading('Đang xử lý...')
+// then:
+toast.dismiss(toastId)
+toast.success('Hoàn thành')
+```
+
+---
+
+## Standard kiosk page structure
+
+```tsx
+import type { Metadata } from 'next'
+import { BigButton } from '@/components/kiosk/big-button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+export const metadata: Metadata = { title: 'Tên màn hình' }
+
+export default function KioskPage() {
+  return (
+    <div className="space-y-4 p-4">
+      {/* Page title */}
+      <h1 className="text-xl font-bold">Tên màn hình</h1>
+
+      {/* Content cards — each step in a separate card */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Bước 1 — ...</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {/* step content */}
+        </CardContent>
+      </Card>
+
+      {/* Optional: remnant suggestion list */}
+      {/* <RemnantSuggestionList /> */}
+
+      {/* Primary action — always at the bottom */}
+      <BigButton disabled={!isReady}>
+        Xác nhận
+      </BigButton>
+    </div>
+  )
+}
+```
+
+---
+
+## Form inputs on mobile
+
+Use `inputMode` to trigger the right mobile keyboard:
+
+```tsx
+<Input
+  type="number"
+  inputMode="numeric"    // numeric keypad (no minus sign)
+  placeholder="1200"
+  className="h-12 text-base"   // larger height + font for kiosk
+/>
+
+<Input
+  inputMode="decimal"    // numeric with decimal point
+  className="h-12 text-base"
+/>
+```
+
+---
+
+## Workflow patterns
+
+### Two-scan flow (scan remnant → scan location)
+
+```tsx
+const [remnantId, setRemnantId] = useState<string | null>(null)
+const [locationId, setLocationId] = useState<string | null>(null)
+const assignMutation = useAssignLocation()
+
+// Step 1: scan remnant
+<ScannerView onScan={(code) => setRemnantId(JSON.parse(code).id)} />
+
+// Step 2: scan location (visible only after step 1)
+{remnantId && (
+  <ScannerView onScan={(code) => setLocationId(JSON.parse(code).id)} />
+)}
+
+// Confirm button (enabled only when both scanned)
+<BigButton
+  disabled={!remnantId || !locationId || assignMutation.isPending}
+  onClick={() => assignMutation.mutate({ id: remnantId!, locationId: locationId! })}
+>
+  Xác nhận nhập kho
+</BigButton>
+```

--- a/.codex/agents/product-manager/SKILL.md
+++ b/.codex/agents/product-manager/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: product-manager
+description: Use to analyze the backlog from a user perspective (Kiosk/Dashboard), break down tasks, and manage FE issues.
+---
+
+# Product Manager - Frontend Backlog & UX
+
+Focuses on translating business rules into specific UI tasks and User Stories.
+
+## Key Responsibilities
+1. **UI Gap Analysis**: Compare spec with current screens. Identify missing pages, buttons, or feedback toasts.
+2. **Issue Automation**: Create FE issues with Responsive requirements (375/768/1280px).
+3. **Task Breakdown**: Sequence: Types -> API Client -> Hooks -> Components -> Pages.
+
+## FE Issue Workflow
+Draft FE issues in Vietnamese for the board:
+
+**Example Issue Title**: `3.6 [kiosk] Thêm màn hình báo cáo tấm lẻ dư (BR-K04)`
+**Example Issue Body**:
+```markdown
+## Tóm tắt
+Cần bổ sung màn hình cho phép thợ CNC nhập kích thước tấm lẻ sau khi cắt xong lệnh. 
+
+## Định nghĩa hoàn thành (DoD)
+- [ ] Tạo page mới tại (kiosk)/report-remnant/page.tsx.
+- [ ] Responsive tốt trên mobile (375px), touch target tối thiểu 48px.
+- [ ] Sử dụng BigButton cho hành động "Xác nhận nhập kho".
+- [ ] Hiển thị thông báo thành công (toast.success) sau khi gọi API thành công.
+```
+
+## Execution
+```bash
+gh issue create --title "[kiosk] Thêm màn hình báo cáo tấm lẻ dư (BR-K04)" --body "..."
+```
+
+---
+*Agent Tip: Prioritize "1-hand operation" for Kiosk tasks to accommodate workers on the shop floor.*

--- a/.codex/agents/remnant-flow-domain/SKILL.md
+++ b/.codex/agents/remnant-flow-domain/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: remnant-flow-domain
+description: Use when implementing any feature related to remnant tracking, allocation, cutting records, costing, overflow alerts, or barcode/QR. Provides the business rules and API endpoints without requiring you to read the docs.
+---
+
+# Remnant Flow Domain Knowledge
+
+This system manages the "Remnant Flow" (Dòng chảy Vật tư dư) in a woodworking furniture workshop. Raw board sheets are CNC-cut into WIP products; leftover pieces become **remnants** tracked through the system.
+
+---
+
+## Core entities
+
+| Entity | Key fields | Notes |
+|--------|-----------|-------|
+| `BoardSheet` | `id`, `materialType`, `lengthMm`, `widthMm`, `thicknessMm`, `unitCost`, `status` | Raw plywood/MDF before cutting |
+| `Remnant` | `id`, `parentRemnantId`, `sourceBoardSheetId`, `status`, `boundingBoxLengthMm`, `boundingBoxWidthMm`, `binLocationId` | Leftover material |
+| `WorkOrder` | `id`, `sku`, `requiredLengthMm`, `requiredWidthMm`, `status` | Single cutting task |
+| `StorageLocation` | `id`, `zone`, `rack`, `shelf`, `barcode` | Physical bin location (e.g. A1-R2-S3) |
+
+All types are defined in `src/types/api.ts`.
+
+---
+
+## Remnant lifecycle
+
+```
+AVAILABLE ──allocate()──→ ALLOCATED ──consumed by cut──→ CONSUMED
+    │
+    └──markWaste()──→ WASTE
+```
+
+**State meanings (match backend `domain.RemnantStatus` exactly):**
+- `AVAILABLE` — ready to be allocated or cut
+- `ALLOCATED` — reserved for a work order (locked)
+- `CONSUMED` — fully cut, no longer in inventory
+- `WASTE` — marked as unusable waste
+
+**Never display `CONSUMED` or `WASTE` remnants in the available inventory UI.**
+
+---
+
+## Attribute inheritance (Sprint 2)
+
+When a remnant is produced from a cut, it automatically inherits from its source:
+- `supplierCode` → from board sheet or parent remnant
+- `lotBatch` → same
+- `grainPattern` → same
+- `qualityGrade` → same
+- `materialType` → same
+
+The `boundingBoxLengthMm` and `boundingBoxWidthMm` represent the smallest axis-aligned rectangle that fits the usable area (not the actual ragged shape).
+
+---
+
+## Nested cutting (lineage chain)
+
+A remnant can itself be cut, producing child remnants:
+
+```
+BoardSheet ─── RecordCut ──→ WIP Products
+                           └→ Remnant A (parentRemnantId: null, sourceBoardSheetId: BS-01)
+                                  │
+                              RecordCut
+                                  │
+                                  └→ WIP Products
+                                   └→ Remnant A.1 (parentRemnantId: A, sourceBoardSheetId: BS-01)
+                                         │
+                                     RecordCut
+                                         └→ Remnant A.1.1 (parentRemnantId: A.1, ...)
+```
+
+**Area conservation rule**: at every cut, `used_area + remnant_area + waste_area = source_area`. The Go backend enforces this with `BR-K03`.
+
+---
+
+## Best Fit + FIFO allocation algorithm
+
+When suggesting a remnant for a work order:
+
+```
+fit_score  = required_area / bounding_box_area   // 1.0 = perfect fit, lower = more waste
+age_score  = days_in_stock / max_days_in_stock   // higher = older = prefer to use first
+
+combined_score = w1 * fit_score + w2 * age_score
+              = 0.6 * fit_score + 0.4 * age_score   // defaults (configurable)
+```
+
+**Display suggestion quality**: `wastePct = 1 - fit_score` → show as "% hao hụt".
+A good suggestion has `wastePct ≤ 10%`.
+
+---
+
+## Costing rules
+
+1. **Flat cut from board sheet**:
+   `remnant_value = (remnant_area / sheet_area) * sheet_unit_cost`
+
+2. **Nested remnant cut**:
+   `remnant_value = (remnant_area / parent_remnant_area) * parent_remnant_value`
+
+3. **Waste** is treated as overhead (absorbed by the PO) — not allocated to a specific SKU.
+
+4. **Remnant savings** = cost avoided by using remnant instead of issuing a new sheet.
+
+---
+
+## Key API endpoints
+
+These endpoints actually exist in the backend (verified against handler registrations):
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/inventory/lots` | POST | Receive stock — create lot + sheets |
+| `/inventory/lots` | GET | List inventory lots (paginated) |
+| `/inventory/sheets` | GET | List available board sheets (paginated) |
+| `/inventory/sheets/:id` | GET | Get single sheet |
+| `/inventory/sheets/:id/lineage` | GET | All remnants descended from this sheet |
+| `/inventory/cuts` | POST | Record a cut — creates CuttingRecord + optional Remnant |
+| `/inventory/remnants` | GET | List remnants (filter: min_length_mm, min_width_mm, status) |
+| `/inventory/remnants/:id/lineage` | GET | Lineage tree rooted at a remnant's parent board |
+| `/inventory/remnants/:id/allocate` | POST | Allocate remnant to a work order |
+| `/inventory/remnants/:id/waste` | POST | Mark remnant as WASTE |
+| `/storage-locations` | GET | List all active storage locations |
+| `/work-orders` | POST/GET | Create/list work orders |
+| `/work-orders/:id` | GET | Get single work order |
+| `/work-orders/:id/advance` | POST | Advance work order status |
+| `/work-orders/:id/consumptions` | POST/GET | Record/list material consumptions |
+| `/barcodes` | POST | Generate a barcode record |
+| `/barcodes/:id` | GET | Lookup barcode |
+| `/barcodes/:id/scans` | POST/GET | Record/list scan events |
+| `/costing/:workOrderID/compute` | POST | Compute costing for a work order |
+| `/costing/:workOrderID/finalize` | POST | Finalize (immutable) costing record |
+| `/costing/:workOrderID` | GET | Get costing record |
+| `/costing` | GET | List costing records |
+| `/materials` | POST/GET | Create/list materials |
+| `/skus` | POST/GET | Create/list SKUs |
+| `/plans` | POST/GET | Create/list production plans |
+| `/plans/:id/approve` | POST | Approve plan |
+| `/plans/:id/cancel` | POST | Cancel plan |
+| `/pos` | POST/GET | Create/list purchase orders |
+
+All under base URL `NEXT_PUBLIC_API_URL` (default: `http://localhost:8080/api/v1`).
+
+**Endpoints that do NOT exist** (were listed incorrectly in older docs):
+- ~~`/inventory/suggest-allocation`~~ — not implemented
+- ~~`/inventory/overflow-status`~~ — not implemented
+- ~~`/inventory/release-allocation`~~ — not implemented
+- ~~`/inventory/issue-sheet`~~ — not implemented
+- ~~`/remnants/:id/location`~~ — not implemented
+- ~~`/dashboard/remnant-summary`~~ — not implemented
+- ~~`/barcode/:id/qr`~~ — not implemented (barcodes, not barcode)
+- ~~`/barcode/batch-print`~~ — not implemented
+
+---
+
+## Scan checkpoints (3 fixed)
+
+| Checkpoint | Vietnamese label | When |
+|------------|-----------------|------|
+| `CNC_COMPLETE` | Hoàn thành CNC | After CNC machine finishes |
+| `FINISHING_COMPLETE` | Hoàn thành gia công | After sanding/finishing |
+| `WAREHOUSE_SHIP` | Xuất kho | When goods leave warehouse |
+
+Use `ScannerView` on the `/scan` kiosk page to capture these.
+
+---
+
+## QR code content format
+
+QR codes encode JSON:
+```json
+{
+  "type": "REMNANT" | "WIP",
+  "id": "uuid-here",
+  "sku": "SKU-001",
+  "dimensions": { "lengthMm": 800, "widthMm": 400, "thicknessMm": 18 },
+  "lot": "LOT-2026-03",
+  "location": "A1-R2-S3"
+}
+```
+
+Always `JSON.parse()` the scanned string — if it fails, treat as a plain barcode ID.
+
+---
+
+## Work order status machine
+
+```
+PLANNED ──approve──→ IN_CUTTING ──recordCut──→ IN_PROCESSING ──finish──→ COMPLETED
+```
+
+Only `IN_CUTTING` work orders appear in the kiosk "Lệnh cắt hôm nay" screen.
+Filter: `cuttingOrdersApi.list({ status: 'IN_CUTTING' })`.

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -1,0 +1,8 @@
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+
+developer_instructions = """
+Review pending changes for correctness, security, integration breakage, and missing tests.
+Report only actionable, high-signal issues.
+"""

--- a/.codex/agents/senior-workflow-frontend/SKILL.md
+++ b/.codex/agents/senior-workflow-frontend/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: senior-workflow-frontend
+description: >
+  Use when starting ANY non-trivial issue or feature on the Next.js frontend —
+  covers the full Senior Engineer workflow: requirements clarification →
+  technical design → task breakdown → implement → self-QA → PR.
+  ALWAYS trigger this skill when the user says "implement", "add feature",
+  "build page", "add component", "create hook", "fix", "fix bug", "find root cause",
+  "plan and implement", or pastes a GitHub issue/ticket number.
+  Do NOT skip phases — Phase 5 (Self-QA) is the gate before PR and the phase
+  most commonly skipped; skipping it is the #1 source of rework.
+---
+
+# Senior Engineer Workflow — Next.js Frontend
+
+Run these 6 phases **in order**. Mark each one done before moving to the next.
+Phase 5 is mandatory — do not open a PR without completing it.
+
+---
+
+## Phase 1 — Requirements Clarification
+
+Before writing a single line of code, understand the *why*.
+
+**Questions to answer (ask the user if unclear):**
+- Who uses this screen?
+  - Worker on phone → `(kiosk)` route group, Vietnamese labels, touch targets ≥ 48px
+  - Manager on desktop → `(dashboard)` route group, responsive grid
+- What is the exact Definition of Done?
+  - Screen renders? Or also: loading state, error state, empty state, responsive at 375/768/1280px?
+- Adversarial edge cases to surface:
+  - "What if the API returns an empty array?"
+  - "What if the user taps the button twice before the mutation resolves?"
+  - "What if `data` is `undefined` on first render?" (TanStack Query always starts undefined)
+  - "Is the response a `PagedResult<T>` (`{ items, total_items }`) or a plain `T[]`?"
+  - "Are any date/optional fields missing in some API responses?"
+- Is there a Sprint issue number? (for commit/PR tagging)
+
+**Output of this phase:** a short bullet list — *Who / DoD / Edge cases identified*
+
+---
+
+## Phase 2 — Technical Design (Next.js Frontend)
+
+Design before coding. Answer these questions before opening any file.
+
+### Route & component tree
+```
+Worker on phone?     → (kiosk)/page-name/page.tsx
+Manager on desktop?  → (dashboard)/page-name/page.tsx
+```
+Component tree sketch:
+```
+page.tsx  (can be server component — exports metadata)
+  └── PageContent  ('use client' — owns state + data fetching)
+        ├── loading.tsx   (Skeleton that mirrors real layout)
+        ├── error.tsx     ('use client' — required directive)
+        └── domain components (pure, props only, no fetching)
+```
+
+### API alignment check — do this before writing any TypeScript
+Read the backend `iface.go` for the relevant module. Confirm:
+- Does the endpoint return `PagedResult<T>` or `T[]`?
+  - `PagedResult<T>` → `{ items: T[], total_items: number, ... }` — always unwrap `.items`
+  - Skipping this causes `TypeError: cannot read property 'filter' of undefined`
+- What are the exact JSON field names? Go uses `snake_case` — must match exactly in `src/types/api.ts`
+- Which fields are pointers in Go (`*string`, `*time.Time`)? These can be `null` — type them as `field?: string` or `field: string | null`
+- Are date fields always present or sometimes omitted? → type as `created_at?: string` and guard before formatting
+
+### State & data flow
+- Server state → TanStack Query `useQuery` / `useMutation`
+- Local UI state → `useState` in the component
+- Cross-component shared state (rare) → Zustand in `src/lib/hooks/`
+- Query key strategy: `[domain]` → `[domain, filter]` → `[domain, id]`
+- Which queries need `invalidateQueries` after a mutation? List them now.
+
+### Impact analysis
+- Does this touch existing cache keys? A mutation may need to invalidate more than one key.
+- New route? → needs `loading.tsx` + `error.tsx` siblings
+- New navigation entry? → update `side-nav.tsx` or `bottom-nav.tsx` AND `authorization.ts`
+- New API domain file? → follow 4-file pattern
+
+**Output of this phase:** component tree sketch, confirmed API shape + optional fields, query keys, list of mutations that invalidate
+
+---
+
+## Phase 3 — Task Breakdown
+
+Split into discrete tasks. Use TaskCreate to track them.
+
+Typical order for a new feature:
+1. Add/update types in `src/types/api.ts` (match backend iface.go exactly)
+2. Create `src/lib/api/<domain>.ts` (thin wrappers over `apiClient`)
+3. Create `src/lib/hooks/use-<domain>.ts` (TanStack Query hooks)
+4. Create `page.tsx` + `loading.tsx` + `error.tsx`
+5. Build presentational components (no fetch logic inside them)
+6. Wire data into page via hooks
+7. Handle all three states: loading / error / empty
+8. TypeScript check → ESLint → build
+
+**Rule:** Types must be correct before writing hooks. Hooks must be correct before writing UI. Never combine steps that should be sequential.
+
+---
+
+## Phase 4 — Implement
+
+### 4-file pattern for every new API domain
+```
+src/types/api.ts                      ← Step 1: DTOs (never declare types locally in a page)
+src/lib/api/<domain>.ts               ← Step 2: thin API wrappers over apiClient
+src/lib/hooks/use-<domain>.ts         ← Step 3: TanStack Query hooks
+src/app/(group)/page-name/page.tsx    ← Step 4: page + inline components
+```
+
+### Type safety rules
+```typescript
+// ✅ PagedResult: always unwrap .items
+const items = data?.items ?? []
+
+// ✅ Optional/nullable Go fields — guard before use
+plan.deadline ? formatDate(plan.deadline) : '—'
+
+// ✅ Dates are strings from Go — parse client-side, never trust format
+const d = new Date(entity.created_at)  // could be null if field is optional in Go
+
+// ✅ Nullable Go pointer fields (*string in Go → string | null in TS)
+supplier_code: string | null
+```
+
+### Hook patterns
+```typescript
+// Read hook — guard undefined at consumption site, not inside hook
+const { data, isLoading, error } = useMyEntities(filter)
+const items = data?.items ?? []   // never: data.items.filter(...)
+
+// Mutation — always invalidate on success, toast on error
+useMutation({
+  mutationFn: myApi.create,
+  onSuccess: () => {
+    queryClient.invalidateQueries({ queryKey: [MY_KEY] })
+    toast.success('Đã lưu')
+  },
+  onError: (err: ApiClientError) => toast.error(err.message),
+})
+```
+
+### Side effect rules — the #1 source of infinite loops
+**Never call `setState` or `setX` directly in the render body.**
+Any logic of the form "when X changes, update Y state" belongs in `useEffect`:
+```typescript
+// ❌ Causes infinite loop — new object created every render, condition always true
+const prevRef = { current: '' }
+if (someValue && prevRef.current !== someValue) {
+  prevRef.current = someValue
+  setOtherState(...)   // setState in render body → re-render → repeat forever
+}
+
+// ✅ Correct — runs after render, only when dependency changes
+useEffect(() => {
+  if (!someValue) return
+  setOtherState(derivedFrom(someValue))
+}, [someValue])
+```
+
+Use `useRef` for values that must persist across renders **without triggering a re-render** (e.g., scanner ref, previous value tracker). Declare refs with `useRef(initialValue)` — never as a plain object `{ current: '' }`.
+
+### Required states — every data-driven page must have all three
+```tsx
+if (isLoading) return <Skeleton ... />       // mirrors real layout structure
+if (error)     return <ErrorMessage ... />   // error.tsx must have 'use client'
+if (!items.length) return <EmptyState />     // specific empty message, not generic
+```
+
+### Kiosk-specific rules (if in `(kiosk)` route group)
+- All interactive elements: `min-h-[48px]` — no exceptions
+- Primary actions: `BigButton` from `@/components/kiosk/big-button`
+- All user-visible labels: Vietnamese
+- Font size: ≥ 16px for anything the user reads or taps
+- Action feedback: `toast.success()` / `toast.error()` within 300ms of mutation settling
+
+---
+
+## Phase 5 — Self-QA ⛔ DO NOT SKIP
+
+This is the gate before PR. Work through every section below in order — not just the ones that seem relevant. Most rework in this project comes from skipping this phase.
+
+### Step 5.1 — Run automated checks first
+These must all pass before anything else. Fix every error; do not move to 5.2 with failures.
+
+```bash
+npx tsc --noEmit        # 0 TypeScript errors — fix all, no exceptions
+npm run build           # Next.js production build must succeed
+```
+
+`npm run build` is the true gate. Turbopack and the production compiler catch different errors — a passing `tsc --noEmit` does not mean the build will pass.
+
+If lint reports `suggestCanonicalClasses` warnings (Tailwind v4), replace arbitrary values with canonical equivalents:
+```
+max-w-[375px]  →  max-w-93.75
+h-[48px]       →  h-12
+```
+
+### Step 5.2 — Read every changed file top to bottom
+
+Do not skim. For each changed file, ask yourself the questions below.
+
+#### Render body side effects
+- [ ] Does any code inside the component function (outside `useEffect`) call `setState`, `setX`, or any other state setter **conditionally or based on another state value**?
+  - If yes → it causes an infinite re-render loop. Move it to `useEffect`.
+- [ ] Is there a `useRef` declared as a plain object literal `{ current: ... }` instead of `useRef(...)`?
+  - Plain objects are re-created every render — they cannot track previous values.
+
+#### Import hygiene
+- [ ] Are all `import` statements at the **top of the file**, before any other code?
+  - ESLint `import/first` will fail if imports appear after variable declarations or JSX.
+- [ ] Any unused imports? → remove them.
+- [ ] Are imports grouped correctly: React/Next → third-party → `@/` aliases?
+
+#### TypeScript strictness
+- [ ] Any `any` type? → replace with `unknown` + type narrowing or the correct type.
+- [ ] `data!.field` (non-null assertion)? → replace with `data?.field ?? fallback`.
+- [ ] Optional Go field rendered directly without guard?
+  - `formatDate(plan.deadline)` where `deadline?: string` → `plan.deadline ? formatDate(plan.deadline) : '—'`
+- [ ] `useRef<HTMLElement>(null)` → must be `useRef<HTMLElement | null>(null)` in React 19.
+- [ ] Type declared locally inside a component or page file? → move to `src/types/api.ts`.
+
+#### Date handling
+- [ ] Every date field from the API — is it typed as optional (`string?`) if the backend Go field is a pointer or omitempty?
+- [ ] Is `formatDate` / `new Date()` called without a null/undefined guard?
+  - `new Date(undefined)` → `Invalid Date` — always guard first.
+- [ ] Is the date string from Go in the expected ISO 8601 format? Check with `console.log` if unsure.
+
+#### TanStack Query correctness
+- [ ] Every `useQuery` result used as an array — is it guarded with `?? []`?
+- [ ] Mutation `onSuccess` — does it invalidate **all** cache keys that depend on the mutated entity?
+  - E.g., creating a plan should invalidate both `['plans']` and potentially `['plan', id]`.
+- [ ] Query with a dependency param — does it have `enabled: !!param`?
+- [ ] Any query key that is a bare string literal (`'plans'`) instead of an exported constant?
+
+#### Component structure
+- [ ] Component longer than ~120 lines? → extract a named sub-component (not an inline arrow function).
+- [ ] Inline `style={}` for something Tailwind can express? → replace with `className`.
+- [ ] `fetch()` called directly instead of `apiClient`? → replace.
+- [ ] `'use client'` missing from a component that uses `useState`, `useEffect`, or browser APIs?
+- [ ] `error.tsx` missing `'use client'`? (Next.js requires it — the build will fail without it.)
+- [ ] `loading.tsx` skeleton — does it structurally match the real page? (same number of cards/rows)
+
+#### Storybook (if stories were added or modified)
+- [ ] All `import` statements at the top of the stories file?
+- [ ] Helper components used only in stories — are they named without a leading underscore (since they are used)?
+- [ ] Story covers the happy path AND the meaningful error/empty states?
+
+#### Navigation & routing
+- [ ] New route added → is it listed in `authorization.ts` so the middleware allows it?
+- [ ] New nav item added → does it appear in both `side-nav.tsx` (dashboard) or `bottom-nav.tsx` (kiosk) as appropriate?
+- [ ] Nav item points to the correct `href`?
+
+### Step 5.3 — Spot-check in the browser
+
+Before marking the task done, open the page and verify:
+- [ ] Renders correctly at 375px (mobile) — no horizontal scroll, no clipped text
+- [ ] Loading state shows before data arrives (add a 3G throttle in DevTools if needed)
+- [ ] Empty state shows when no data exists (test with an empty filter)
+- [ ] Error state shows when the API fails (temporarily break the URL to test)
+- [ ] All mutations show a success or error toast — no silent failures
+- [ ] Console has 0 errors and 0 warnings
+
+---
+
+## Phase 6 — PR
+
+### Commit message format
+```
+[area] verb: brief description
+
+- bullet detail 1
+- bullet detail 2
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+`area` is one of: `kiosk`, `dashboard`, `api`, `hooks`, `types`, or the feature name.
+
+Example:
+```
+[kiosk] fix: classify camera errors with user-facing guidance
+
+- Detect NotAllowedError, NotFoundError, insecure context separately
+- Show Vietnamese error banner with actionable instructions per error type
+- Move lineItems → rows sync into useEffect to prevent infinite re-render
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+### Branch rules
+- Feature branch from `dev`: `git checkout -b feat/area-brief-description dev`
+- Never push directly to `main` or `dev`
+- PR: feature → `dev` (approval optional)
+- `dev` → `main` requires 1 approval
+
+### PR body template
+```markdown
+## Summary
+- What was changed and why
+- Route group affected: (kiosk) / (dashboard) / shared
+
+## Technical notes
+- New API types added: yes/no — list them
+- New query keys: list them
+- Breaking changes: yes/no
+
+## Test plan
+- [ ] `npx tsc --noEmit` — 0 errors
+- [ ] `npm run lint` — clean
+- [ ] `npm run build` — succeeds
+- [ ] Renders at 375px / 768px / 1280px without layout issues
+- [ ] Loading / error / empty states all render correctly
+- [ ] All mutations show success/error toast
+- [ ] Tested manually: describe scenario
+```

--- a/.codex/agents/senior-workflow/SKILL.md
+++ b/.codex/agents/senior-workflow/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: senior-workflow
+description: >
+  Use when starting ANY non-trivial issue or feature on the Next.js frontend —
+  covers the full Senior Engineer workflow: requirements clarification →
+  technical design → task breakdown → implement + test → self-QA → PR.
+  ALWAYS trigger this skill when the user says "implement", "add feature",
+  "build page", "add component", "create hook", "fix", "fix bug", "find root cause" or pastes a GitHub issue/ticket.
+  Do NOT skip phases — especially Phase 5 (Self-QA) which is the most commonly
+  forgotten step before submitting code.
+---
+
+# Senior Engineer Workflow — Next.js Frontend
+
+Run these 6 phases **in order**. Mark each one done before moving to the next.
+Never skip Phase 5 — it is the gate before PR.
+
+---
+
+## Phase 1 — Requirements Clarification
+
+Before writing a single line of code, understand the *why*.
+
+**Questions to answer (ask the user if unclear):**
+- Who uses this screen — worker on mobile kiosk or manager on desktop dashboard?
+  - Kiosk → `(kiosk)` route group, Vietnamese labels, touch targets ≥ 48px
+  - Dashboard → `(dashboard)` route group, desktop/responsive grid
+- What is the exact Definition of Done?
+  - Screen renders? Or also: loading state, error state, empty state, edge cases?
+- Adversarial edge cases to surface:
+  - "What if the API returns an empty array?"
+  - "What if the user taps the button twice before the mutation resolves?"
+  - "What if `data` is `undefined` on first render?" (TanStack Query)
+  - "Is the response a `PagedResult<T>` or a plain `T[]`?" ← common type mismatch bug
+- Is there a Sprint issue number? (for commit/PR tagging)
+
+**Output of this phase:** a short bullet list: *Who / DoD / Edge cases identified*
+
+---
+
+## Phase 2 — Technical Design (Next.js Frontend)
+
+Design before coding. Answer these questions before opening any file.
+
+### Route & component tree decision
+```
+Worker on phone?      → (kiosk)/page-name/page.tsx
+Manager on desktop?   → (dashboard)/page-name/page.tsx
+```
+Component tree sketch:
+```
+page.tsx (server component — exports metadata)
+  └── PageContent.tsx ('use client' — data fetching + state)
+        ├── LoadingSkeleton (loading.tsx)
+        ├── ErrorBoundary (error.tsx)
+        └── DomainCard / DomainTable / etc.
+```
+
+### API alignment check
+Before writing types, read the backend `iface.go` for the relevant module.
+Key questions:
+- Does the endpoint return `PagedResult<T>` or `T[]`?
+  - `PagedResult<T>` has `{ items: T[], total_items: N, ... }` — must unwrap `.items`
+  - Forgetting this causes `TypeError: x.filter is not a function` at runtime
+- What are the exact field names? (Go uses `snake_case`, must match exactly in `src/types/api.ts`)
+- Are there nullable fields (`*string` in Go → `string | null` or `string | undefined` in TS)?
+
+### State & data flow
+- Server state (from API) → TanStack Query `useQuery` / `useMutation`
+- UI-only state → `useState` in the component
+- Global shared state (rare) → Zustand store in `src/lib/hooks/`
+- Query key strategy: `[domain]` → `[domain, filter]` → `[domain, id]`
+- Which queries need `invalidateQueries` after a mutation?
+
+### Impact analysis
+- Does this touch existing TanStack Query cache keys? (mutation might need to invalidate more)
+- Does this add a new route? → needs `loading.tsx` + `error.tsx` siblings
+- Does this add a new `src/lib/api/*.ts` file? → follow 4-file pattern
+- Is there a real-time need? → `refetchInterval` or `refetchOnWindowFocus`
+
+**Output of this phase:** component tree, confirmed API shape, query keys, state decisions
+
+---
+
+## Phase 3 — Task Breakdown
+
+Split into sub-tasks of 2–4 hours each. Create a TodoList.
+
+Typical order for a new feature:
+1. Add/update types in `src/types/api.ts`
+2. Create `src/lib/api/<domain>.ts` (API functions)
+3. Create `src/lib/hooks/use-<domain>.ts` (TanStack Query hooks)
+4. Create page files: `page.tsx` + `loading.tsx` + `error.tsx`
+5. Build presentational components (no data fetching logic inside)
+6. Wire data into page via hooks
+7. Handle empty state, error state, loading state
+8. TypeScript check + lint
+
+**Rule:** Types must be correct before writing hooks. Hooks must be correct before writing UI.
+
+---
+
+## Phase 4 — Implement & Test (Next.js Frontend)
+
+### 4-file pattern for every new API domain
+
+```
+src/types/api.ts           ← Step 1: add DTOs (never re-declare locally)
+src/lib/api/<domain>.ts    ← Step 2: thin API wrappers over apiClient
+src/lib/hooks/use-<domain>.ts  ← Step 3: TanStack Query hooks
+src/app/(group)/page/page.tsx  ← Step 4: page + components
+```
+
+### Type safety rules
+```typescript
+// ✅ Always use PagedResult generic when endpoint is paginated
+apiClient.get<PagedResult<Remnant>>('/inventory/remnants', { params: { limit: 1000 } })
+  .then(res => res.items)  // ← always unwrap .items
+
+// ✅ Dates are strings from Go — parse client-side
+const date = new Date(remnant.created_at)
+
+// ✅ Nullable Go fields (*string) → string | null in TS
+supplier_code: string | null
+```
+
+### Hook patterns
+```typescript
+// Read hook — always guard undefined
+const { data, isLoading, error } = useMyEntities(filter)
+const items = data ?? []   // never data.filter() without ?? []
+
+// Mutation — always invalidate on success
+useMutation({
+  mutationFn: myApi.create,
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: [MY_ENTITY_KEY] }),
+  onError: (err: ApiClientError) => toast.error(err.message),
+})
+```
+
+### Required states — all three must exist for every data-driven page
+```tsx
+if (isLoading) return <Skeleton ... />          // loading state
+if (error) return <ErrorMessage ... />          // error state
+if (items.length === 0) return <EmptyState />   // empty state
+```
+
+### Kiosk-specific rules (if in `(kiosk)` route group)
+- All interactive elements: `min-h-[48px]`
+- Primary actions: `BigButton` from `@/components/kiosk/big-button` (not `Button`)
+- All labels: Vietnamese
+- Font size: ≥ 16px for all text the user reads/taps
+- Action feedback: `toast.success()` / `toast.error()` within 300ms
+
+---
+
+## Phase 5 — Self-QA & Refactor ⛔ DO NOT SKIP
+
+This phase is the gate before PR. Run through **all** of these.
+
+### Type mismatch checklist (most common bugs)
+- [ ] API returns `PagedResult<T>` but code treats it as `T[]`? → add `.then(res => res.items)`
+- [ ] Used `data!.items` without null guard? → change to `data?.items ?? []`
+- [ ] `useRef<HTMLDivElement>(null)` typed as `RefObject<HTMLDivElement>`? → must be `RefObject<HTMLDivElement | null>` in React 19
+- [ ] Hook file has `'use client'` at top unnecessarily? → remove if no browser APIs used
+
+### Code smell checklist
+- [ ] Component over 100 lines? → extract sub-component
+- [ ] Inline style for something Tailwind can do? → replace with className
+- [ ] `any` type anywhere? → replace with `unknown` + narrowing or proper type
+- [ ] `fetch()` called directly instead of `apiClient`? → replace
+- [ ] Same type declared in two places? → consolidate to `src/types/api.ts`
+- [ ] Query key as bare string `"remnants"`? → use exported constant `REMNANT_KEY`
+- [ ] Missing `enabled: !!id` on query that depends on a param?
+
+### Silly bug checklist
+- [ ] `data?.filter(...)` but `data` could be `undefined` → `(data ?? []).filter(...)`
+- [ ] Mutation called without `await` inside async function?
+- [ ] `toast.loading()` shown but never dismissed on error path?
+- [ ] `loading.tsx` structure doesn't match actual page (different number of cards)?
+- [ ] `error.tsx` missing `'use client'` directive?
+- [ ] Double padding: layout has `p-4` AND page wrapper has `p-4`?
+
+### Automated checks (must all pass before PR)
+```bash
+npx tsc --noEmit       # 0 TypeScript errors
+npm run lint           # 0 ESLint warnings/errors
+npm run build          # next build succeeds — ALWAYS run this last
+```
+
+**Rule: `npm run build` is MANDATORY after every implement/fix task.** TypeScript errors
+caught by `tsc --noEmit` may differ from the build-time checker Turbopack uses.
+Only a passing `npm run build` is the true gate.
+
+If `tsc --noEmit` finds errors → fix all of them, no exceptions.
+
+---
+
+## Phase 6 — PR
+
+### Commit message format
+```
+[area] verb: brief description
+
+- bullet point detail 1
+- bullet point detail 2
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+```
+
+Where `area` is: `kiosk`, `dashboard`, `api`, `hooks`, `types`, or the feature name.
+
+Example:
+```
+[kiosk] feat: add pull-to-refresh on cutting orders page
+
+- Attach touch listeners at document level (not child div)
+- Read window.scrollY for scroll position check
+- Default threshold: 72px with rubber-band damping
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+```
+
+### Branch rules
+- Feature branch from `dev`: `git checkout -b feat/area-brief-description dev`
+- Never push directly to `main` or `dev`
+- PR: feature → `dev` (approval optional)
+- `dev` → `main` requires 1 approval
+
+### PR body template
+```markdown
+## Summary
+- What was changed and why
+- Route group affected: (kiosk) / (dashboard) / shared
+
+## Technical notes
+- New API types added: yes/no
+- New query keys: list them
+- Breaking changes: yes/no
+
+## Test plan
+- [ ] `npx tsc --noEmit` — 0 errors
+- [ ] `npm run lint` — clean
+- [ ] `npm run build` — succeeds
+- [ ] Tested at 375px width (mobile kiosk) if applicable
+- [ ] Loading / error / empty states all render correctly
+- [ ] Tested manually: describe scenario
+```

--- a/.codex/agents/typescript-patterns/SKILL.md
+++ b/.codex/agents/typescript-patterns/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: typescript-patterns
+description: Use when writing TypeScript in this project — API DTOs, component prop types, hook generics, strict null handling, and avoiding common TS mistakes with the existing codebase patterns.
+---
+
+# TypeScript Patterns
+
+## Golden rule — import types, never re-declare
+
+All API DTOs are in **`src/types/api.ts`**. Import them everywhere:
+
+```typescript
+// ✅ Correct
+import type { Remnant, WorkOrder, PaginatedResponse } from '@/types/api'
+
+// ❌ Wrong — re-declaring inline creates divergence with the backend
+interface Remnant { id: string; ... }
+```
+
+If the type doesn't exist yet in `src/types/api.ts`, add it there — not locally.
+
+---
+
+## Component prop types — extend HTML elements
+
+Follow the `ComponentProps<>` pattern used in all shadcn components:
+
+```tsx
+import * as React from 'react'
+
+// ✅ Extend native HTML element props — gets all HTML attributes for free
+interface ButtonProps extends React.ComponentProps<'button'> {
+  variant?: 'primary' | 'danger'
+  isLoading?: boolean
+}
+
+// ✅ For custom wrapper components, extend the base component's props
+import type { buttonVariants } from '@/components/ui/button'
+import type { VariantProps } from 'class-variance-authority'
+
+interface MyButtonProps
+  extends React.ComponentProps<'button'>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+// ❌ Avoid manual prop declarations that duplicate HTML attrs
+interface BadButtonProps {
+  onClick: () => void    // too narrow — blocks onMouseDown, etc.
+  disabled: boolean
+  className: string
+}
+```
+
+---
+
+## TanStack Query generics
+
+Always specify the generic types for full type inference and better error handling:
+
+```typescript
+import { useQuery, useMutation } from '@tanstack/react-query'
+import type { Remnant, PaginatedResponse } from '@/types/api'
+import type { ApiClientError } from '@/lib/api/client'
+
+// useQuery<TData, TError>
+const { data } = useQuery<PaginatedResponse<Remnant>, ApiClientError>({
+  queryKey: ['remnants'],
+  queryFn: () => remnantsApi.list(),
+})
+// data is typed as PaginatedResponse<Remnant> | undefined
+
+// useMutation<TData, TError, TVariables>
+const mutation = useMutation<Remnant, ApiClientError, { id: string; locationId: string }>({
+  mutationFn: ({ id, locationId }) => remnantsApi.assignLocation(id, locationId),
+})
+```
+
+---
+
+## Strict null / undefined handling
+
+The project uses `"strict": true`. Always handle nullable values:
+
+```typescript
+// useQuery returns data as T | undefined until it resolves
+const { data } = useRemnants()
+
+// ✅ Optional chaining
+const count = data?.total ?? 0
+const items = data?.data ?? []
+
+// ✅ Early return in JSX
+if (!data) return <Skeleton />
+
+// ✅ Non-null assertion only when you KNOW a value is defined
+// (after a guard check above)
+const id = remnant!.id   // only after if (!remnant) return ...
+
+// ❌ Unsafe assertion without guard
+const id = data!.total   // will crash if data is undefined
+```
+
+---
+
+## `ApiClientError` — typed error handling
+
+```typescript
+import { ApiClientError } from '@/lib/api/client'
+
+// Pattern 1 — in mutation callbacks
+useMutation({
+  mutationFn: myApi.create,
+  onError: (err: ApiClientError) => {
+    if (err.status === 422) {
+      // err.details is Record<string, string> — field-level validation errors
+      const fieldErrors = err.details ?? {}
+      setErrors(fieldErrors)
+    } else {
+      toast.error(err.message)
+    }
+  },
+})
+
+// Pattern 2 — in try/catch
+try {
+  await myApi.create(input)
+} catch (err) {
+  if (err instanceof ApiClientError) {
+    // typed — err.status, err.code, err.message, err.details
+    if (err.status === 404) return toast.error('Không tìm thấy')
+    if (err.status === 409) return toast.error('Đã tồn tại')
+  }
+  // unknown errors — rethrow or show generic message
+  toast.error('Lỗi không xác định')
+}
+```
+
+---
+
+## Avoiding `any`
+
+```typescript
+// ❌ Never use any
+const data: any = await fetch(...)
+
+// ✅ Use unknown + type narrowing
+const raw: unknown = JSON.parse(qrCode)
+if (raw && typeof raw === 'object' && 'id' in raw) {
+  const id = (raw as { id: string }).id
+}
+
+// ✅ Or use a type assertion with a guard function
+function isQrPayload(v: unknown): v is QrPayload {
+  return typeof v === 'object' && v !== null && 'type' in v && 'id' in v
+}
+
+const parsed: unknown = JSON.parse(code)
+if (isQrPayload(parsed)) {
+  handleScan(parsed) // typed as QrPayload
+}
+```
+
+---
+
+## Zustand store typing
+
+Follow the pattern in `src/lib/hooks/use-scan.ts`:
+
+```typescript
+import { create } from 'zustand'
+
+interface MyStore {
+  // state
+  count: number
+  items: string[]
+  // actions
+  increment: () => void
+  addItem: (item: string) => void
+  reset: () => void
+}
+
+export const useMyStore = create<MyStore>((set) => ({
+  count: 0,
+  items: [],
+  increment: () => set((s) => ({ count: s.count + 1 })),
+  addItem: (item) => set((s) => ({ items: [...s.items, item] })),
+  reset: () => set({ count: 0, items: [] }),
+}))
+```
+
+---
+
+## `cn()` utility for conditional classes
+
+```typescript
+import { cn } from '@/lib/utils'   // combines clsx + tailwind-merge
+
+// Basic usage
+className={cn('base-class', conditionalClass && 'applied-if-truthy')}
+
+// With variants
+className={cn(
+  'flex items-center',
+  isActive && 'bg-primary text-primary-foreground',
+  isDisabled && 'opacity-50 pointer-events-none',
+  className,   // always allow override via props
+)}
+
+// tailwind-merge resolves conflicts automatically:
+cn('px-4 px-6')  // → 'px-6' (last wins)
+cn('text-sm', 'text-lg')  // → 'text-lg'
+```
+
+---
+
+## Common import paths
+
+```typescript
+// Types
+import type { Remnant, WorkOrder, BarcodeRecord } from '@/types/api'
+
+// API client
+import { apiClient, ApiClientError } from '@/lib/api/client'
+
+// Domain API functions
+import { remnantsApi } from '@/lib/api/remnants'
+import { cuttingOrdersApi } from '@/lib/api/cutting-orders'
+
+// Hooks
+import { useRemnants, useAllocateRemnant } from '@/lib/hooks/use-remnants'
+import { useRecordCut } from '@/lib/hooks/use-cutting-orders'
+
+// UI components
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+// Kiosk components
+import { BigButton } from '@/components/kiosk/big-button'
+import { ScannerView } from '@/components/kiosk/scanner-view'
+import { LabelPreview } from '@/components/kiosk/label-preview'
+
+// Dashboard components
+import { StatCard } from '@/components/dashboard/stat-card'
+import { AlertBanner } from '@/components/dashboard/alert-banner'
+
+// Utilities
+import { cn } from '@/lib/utils'
+import { toast } from 'sonner'
+```

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,9 @@
+# Local Codex setup generated from project skills.
+# Reference structure: everything-claude-code/.codex
+
+[project]
+name = "Vmarble-Warehouse-Management-Client"
+
+[agents]
+default_instructions_file = ".codex/AGENTS.md"
+agents_dir = ".codex/agents"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,9 +1,41 @@
-# Local Codex setup generated from project skills.
-# Reference structure: everything-claude-code/.codex
+#:schema https://developers.openai.com/codex/config-schema.json
+
+# Codex project-local config for Vmarble
+
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+web_search = "live"
+
+persistent_instructions = "Follow .codex/AGENTS.md and project CLAUDE.md. Enforce automation workflow for 'làm task tiếp theo'."
 
 [project]
 name = "Vmarble-Warehouse-Management-Client"
 
+[features]
+multi_agent = true
+
 [agents]
-default_instructions_file = ".codex/AGENTS.md"
-agents_dir = ".codex/agents"
+max_threads = 4
+max_depth = 1
+
+[agents.explorer]
+description = "Read-only codebase explorer for evidence gathering before implementation"
+config_file = "agents/explorer.toml"
+
+[agents.reviewer]
+description = "Reviewer focusing on correctness, integration, and security"
+config_file = "agents/reviewer.toml"
+
+[agents.docs_researcher]
+description = "Documentation and contract verifier"
+config_file = "agents/docs-researcher.toml"
+
+[profiles.strict]
+approval_policy = "on-request"
+sandbox_mode = "read-only"
+web_search = "cached"
+
+[profiles.yolo]
+approval_policy = "never"
+sandbox_mode = "workspace-write"
+web_search = "live"

--- a/.codex/skills/add-api-route/SKILL.md
+++ b/.codex/skills/add-api-route/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: add-api-route
+description: Use when adding a new API domain, new endpoint to an existing domain, or a new TanStack Query hook. Covers the 4-file pattern (api client + types + hook), query key conventions, mutation invalidation, and error handling.
+---
+
+# Add API Route & TanStack Query Hook
+
+## Pattern overview — 4 files per domain
+
+```
+src/
+├── types/api.ts                  ← 1. Add DTO types here (shared with all consumers)
+├── lib/api/<domain>.ts           ← 2. API functions (thin wrappers over apiClient)
+└── lib/hooks/use-<domain>.ts     ← 3. TanStack Query hooks (consumed by components)
+```
+
+The **`apiClient`** base is at `src/lib/api/client.ts` — import from there, never use `fetch` directly.
+
+---
+
+## Step 1 — Add types to `src/types/api.ts`
+
+Mirror the Go backend response types exactly. Use the naming convention from the backend `iface.go`:
+
+```typescript
+// src/types/api.ts — append new types here
+
+export interface MyEntity {
+  id: string
+  name: string
+  status: 'ACTIVE' | 'INACTIVE'
+  created_at: string   // ISO string from Go time.Time — use snake_case to match JSON tags
+}
+
+export interface CreateMyEntityInput {
+  name: string
+}
+
+// Paginated list endpoints return PagedResult<T> (NOT PaginatedResponse — that is @deprecated).
+// Shape: { items: T[], total_items: number, total_pages: number, current_page: number, limit: number }
+// Always unwrap .items when rendering — never treat PagedResult<T> as T[].
+```
+
+**Rules:**
+- Dates from the Go API are always `string` (ISO 8601) — parse client-side when needed
+- Enums mirror the Go `const` block — use TypeScript string union, not `enum`
+- Field names are `snake_case` to match Go JSON tags — do NOT use `camelCase`
+- Never declare the same type in two places — always import from `@/types/api`
+- Use `PagedResult<T>` (not the `@deprecated PaginatedResponse<T>`) for paginated endpoints
+
+---
+
+## Step 2 — Create `src/lib/api/<domain>.ts`
+
+```typescript
+// src/lib/api/my-domain.ts
+import type { MyEntity, CreateMyEntityInput, PagedResult } from '@/types/api'
+import { apiClient } from './client'
+
+// ── Filter type for list endpoints ────────────────────────────────────────────
+export interface MyEntityFilter {
+  status?: string
+  page?: number
+  limit?: number
+}
+
+// ── API functions ─────────────────────────────────────────────────────────────
+export const myDomainApi = {
+  list: (filter: MyEntityFilter = {}) =>
+    apiClient.get<PagedResult<MyEntity>>('/my-entities', {
+      params: filter as Record<string, string | number | boolean | undefined>,
+    }),
+
+  getById: (id: string) =>
+    apiClient.get<MyEntity>(`/my-entities/${id}`),
+
+  create: (input: CreateMyEntityInput) =>
+    apiClient.post<MyEntity>('/my-entities', input),
+
+  update: (id: string, input: Partial<CreateMyEntityInput>) =>
+    apiClient.put<MyEntity>(`/my-entities/${id}`, input),
+
+  delete: (id: string) =>
+    apiClient.delete<void>(`/my-entities/${id}`),
+}
+```
+
+**Rules:**
+- Return type for paginated endpoints is always `PagedResult<T>` — never `T[]` or `PaginatedResponse<T>`
+- Export a single object `myDomainApi` — all functions are methods on it
+- Always import from `./client`, never create a new `fetch` call
+- Filter types are declared in the same file (not in `types/api.ts`)
+- Use explicit generics: `apiClient.get<PagedResult<MyEntity>>(...)`
+
+---
+
+## Step 3 — Create `src/lib/hooks/use-<domain>.ts`
+
+```typescript
+// src/lib/hooks/use-my-domain.ts
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { myDomainApi, type MyEntityFilter } from '@/lib/api/my-domain'
+import type { ApiClientError } from '@/lib/api/client'
+import type { MyEntity } from '@/types/api'
+
+// ── Query key constants ───────────────────────────────────────────────────────
+// Keep keys as constants — prevents typos and helps with invalidation
+export const MY_ENTITY_KEY = 'my-entities'
+
+// ── Read hooks ────────────────────────────────────────────────────────────────
+export function useMyEntities(filter: MyEntityFilter = {}) {
+  return useQuery({
+    queryKey: [MY_ENTITY_KEY, filter],
+    queryFn: () => myDomainApi.list(filter),
+    // data is PagedResult<MyEntity> — always access .items, never treat as array
+  })
+}
+
+export function useMyEntity(id: string) {
+  return useQuery({
+    queryKey: [MY_ENTITY_KEY, id],
+    queryFn: () => myDomainApi.getById(id),
+    enabled: !!id,          // don't run if id is empty
+  })
+}
+
+// ── Mutation hooks ────────────────────────────────────────────────────────────
+export function useCreateMyEntity() {
+  const queryClient = useQueryClient()
+  return useMutation<MyEntity, ApiClientError, CreateMyEntityInput>({
+    mutationFn: myDomainApi.create,
+    onSuccess: () => {
+      // Invalidate the list so it refetches — always invalidate by root key
+      queryClient.invalidateQueries({ queryKey: [MY_ENTITY_KEY] })
+    },
+  })
+}
+
+export function useDeleteMyEntity() {
+  const queryClient = useQueryClient()
+  return useMutation<void, ApiClientError, string>({
+    mutationFn: (id) => myDomainApi.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [MY_ENTITY_KEY] })
+    },
+  })
+}
+```
+
+**Query key conventions:**
+| Pattern | Use |
+|---------|-----|
+| `[domain]` | All items in a domain (`invalidateQueries` invalidates everything) |
+| `[domain, filter]` | Filtered list (filter object is stable key part) |
+| `[domain, id]` | Single entity |
+| `[domain, id, 'lineage']` | Subresource of an entity |
+
+**Default query config** (set in `src/lib/providers.tsx`):
+- `staleTime: 30_000` (30 s) — data is fresh for 30 seconds
+- `gcTime: 5 * 60_000` (5 min) — cache entry lives 5 min after last observer
+- `retry: 1` — one automatic retry on failure
+- `refetchOnWindowFocus: false` — disable background refetch on tab switch
+
+---
+
+## Step 4 — Use the hook in a component
+
+```tsx
+'use client'
+
+import { useMyEntities, useCreateMyEntity } from '@/lib/hooks/use-my-domain'
+import { toast } from 'sonner'
+
+export function MyEntityList() {
+  const { data, isLoading, error } = useMyEntities({ status: 'ACTIVE' })
+  const createMutation = useCreateMyEntity()
+
+  if (isLoading) return <Skeleton className="h-10 w-full" />
+  if (error) return <p className="text-destructive">{error.message}</p>
+
+  // IMPORTANT: data is PagedResult<MyEntity> — always unwrap .items
+  // data?.data.map(...)  ← WRONG — 'data' field doesn't exist on PagedResult
+  // data?.items.map(...) ← CORRECT
+  const items = data?.items ?? []
+
+  const handleCreate = async () => {
+    try {
+      await createMutation.mutateAsync({ name: 'New entity' })
+      toast.success('Tạo thành công')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Lỗi không xác định')
+    }
+  }
+
+  return (
+    <ul>
+      {items.map((item) => <li key={item.id}>{item.name}</li>)}
+    </ul>
+  )
+}
+```
+
+---
+
+## Error handling with `ApiClientError`
+
+```typescript
+import { ApiClientError } from '@/lib/api/client'
+
+try {
+  await myDomainApi.create(input)
+} catch (err) {
+  if (err instanceof ApiClientError) {
+    if (err.status === 422) {
+      // Validation error — err.details is Record<string, string>
+      console.log(err.details)
+    }
+    if (err.status === 409) {
+      toast.error('Đã tồn tại — không thể tạo trùng')
+    }
+  }
+}
+```
+
+Common Go backend status codes:
+- `400` Bad Request (invalid input)
+- `404` Not found → maps to Go `domain.ErrNotFound`
+- `409` Conflict (duplicate)
+- `422` Unprocessable (business rule violation)
+- `503` Backend unavailable

--- a/.codex/skills/add-page/SKILL.md
+++ b/.codex/skills/add-page/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: add-page
+description: Use when adding a new page or route — choosing the correct route group (kiosk/dashboard/auth), structuring the page file, adding loading.tsx and error.tsx siblings, and following responsive layout rules.
+---
+
+# Add a New Page
+
+## Route group decision tree
+
+```
+Is this for shop-floor workers on mobile?  →  (kiosk)
+Is this for managers on desktop/tablet?    →  (dashboard)
+Is this an auth screen (login/PIN)?        →  (auth)
+```
+
+Route groups don't appear in the URL:
+- `src/app/(kiosk)/my-page/page.tsx` → URL: `/my-page`
+- `src/app/(dashboard)/my-page/page.tsx` → URL: `/my-page`
+- `src/app/(auth)/my-page/page.tsx` → URL: `/my-page`
+
+---
+
+## Minimum file set for every new page
+
+```
+src/app/(group)/my-page/
+├── page.tsx        ← required — the page itself
+├── loading.tsx     ← required — Suspense skeleton shown while page loads
+└── error.tsx       ← recommended — recoverable per-route error boundary
+```
+
+---
+
+## Page template — server component (default)
+
+```tsx
+// src/app/(kiosk)/my-page/page.tsx
+import type { Metadata } from 'next'
+// Import shadcn components from @/components/ui/
+// Import kiosk components from @/components/kiosk/
+// Import dashboard components from @/components/dashboard/
+
+export const metadata: Metadata = { title: 'Tên màn hình' }
+
+export default function MyPage() {
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-xl font-bold">Tên màn hình</h1>
+      {/* page content */}
+    </div>
+  )
+}
+```
+
+**Rules for server components (default):**
+- Export `metadata` — always include `title`
+- No `'use client'` at the top unless you need state/effects
+- Data fetching happens in async sub-components or client components via TanStack Query
+
+---
+
+## Page template — client component (when state/hooks needed)
+
+```tsx
+'use client'
+
+import type { Metadata } from 'next'
+import { useMyEntities } from '@/lib/hooks/use-my-domain'
+
+// metadata can't be exported from 'use client' pages
+// Instead, export it from a parent layout or a separate server wrapper
+
+export default function MyClientPage() {
+  const { data, isLoading } = useMyEntities()
+  // ...
+}
+```
+
+If you need both metadata AND client hooks, split into a server wrapper + client component:
+```tsx
+// page.tsx (server) — exports metadata, renders the client component
+import type { Metadata } from 'next'
+import { MyPageContent } from './_components/my-page-content'   // client component
+
+export const metadata: Metadata = { title: 'My Page' }
+
+export default function MyPage() {
+  return <MyPageContent />
+}
+```
+
+---
+
+## loading.tsx template
+
+```tsx
+// src/app/(kiosk)/my-page/loading.tsx
+import { Skeleton } from '@/components/ui/skeleton'
+import { Card, CardContent } from '@/components/ui/card'
+
+export default function MyPageLoading() {
+  return (
+    <div className="space-y-4 p-4">
+      <Skeleton className="h-7 w-40" />          {/* page title */}
+      {[1, 2, 3].map((i) => (
+        <Card key={i}>
+          <CardContent className="p-4">
+            <Skeleton className="mb-2 h-5 w-32" />
+            <Skeleton className="h-4 w-48" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}
+```
+
+Mirror the visual structure of the actual page — same number of "cards", similar heights.
+
+---
+
+## error.tsx template
+
+```tsx
+// src/app/(kiosk)/my-page/error.tsx
+'use client'    // error boundaries must be client components
+
+import { useEffect } from 'react'
+import { Button } from '@/components/ui/button'
+
+export default function MyPageError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    // Optional: log to error reporting service
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="flex min-h-[40vh] flex-col items-center justify-center gap-4 p-4 text-center">
+      <p className="font-medium">Có lỗi xảy ra</p>
+      <p className="text-sm text-muted-foreground">{error.message}</p>
+      <Button onClick={reset}>Thử lại</Button>
+    </div>
+  )
+}
+```
+
+---
+
+## Layout rules by route group
+
+### (kiosk) pages — mobile-first
+
+```tsx
+// Outer wrapper: vertical stack with p-4 padding
+<div className="space-y-4 p-4">
+  <h1 className="text-xl font-bold">Tiêu đề</h1>
+
+  {/* Kiosk cards: touch-optimized */}
+  <Card>
+    <CardContent className="flex items-center justify-between p-4">
+      {/* content */}
+    </CardContent>
+  </Card>
+
+  {/* Primary action: always BigButton at bottom */}
+  <BigButton>Hành động chính</BigButton>
+</div>
+```
+
+Kiosk checklist:
+- [ ] Font size ≥ 16px for all interactive text
+- [ ] Touch targets ≥ 48px height for tappable items
+- [ ] Primary action uses `BigButton` (min-h: 56px, full-width)
+- [ ] Text labels in **Vietnamese** (worker-facing)
+- [ ] Pull-to-refresh via TanStack Query `refetchOnWindowFocus` or manual button
+- [ ] Skeleton loading in `loading.tsx` mirrors page structure
+
+### (dashboard) pages — desktop/tablet
+
+```tsx
+// Outer wrapper: responsive grid layout
+<div className="space-y-6">
+  <h1 className="text-2xl font-bold">Tiêu đề</h1>
+
+  {/* KPI row */}
+  <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    <StatCard title="Metric" value="123" icon={SomeIcon} />
+  </div>
+
+  {/* Alert banner if relevant */}
+  <AlertBanner status="GREEN" utilizationPct={8} message="..." />
+
+  {/* Data table */}
+  <div className="rounded-xl border bg-card shadow-sm">
+    <Table>...</Table>
+  </div>
+</div>
+```
+
+Dashboard checklist:
+- [ ] Title uses `text-2xl font-bold`
+- [ ] Stats use `StatCard` from `@/components/dashboard/stat-card`
+- [ ] Overflow alerts use `AlertBanner` from `@/components/dashboard/alert-banner`
+- [ ] Tables use shadcn `Table` components
+- [ ] Responsive: `sm:` and `lg:` breakpoints for grid columns
+
+---
+
+## Responsive breakpoints
+
+| Breakpoint | Width | Context |
+|------------|-------|---------|
+| base | 375 px | Mobile kiosk (shop floor) |
+| `sm:` | 640 px | — |
+| `md:` | 768 px | Tablet |
+| `lg:` | 1024 px | — |
+| `xl:` | 1280 px | Desktop dashboard |
+
+Always design base (mobile) first, then add `md:` / `lg:` overrides.
+
+---
+
+## Internal links
+
+Always use `next/link` for navigation — never `<a href>` for internal routes:
+
+```tsx
+import Link from 'next/link'
+
+<Link href="/cutting-orders" className="...">Lệnh cắt</Link>
+```
+
+For programmatic navigation in client components:
+
+```tsx
+'use client'
+import { useRouter } from 'next/navigation'
+
+const router = useRouter()
+router.push('/cutting-orders')
+```

--- a/.codex/skills/add-shadcn-component/SKILL.md
+++ b/.codex/skills/add-shadcn-component/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: add-shadcn-component
+description: Use when adding a new shadcn/ui component to the project — running the CLI, placing files, writing wrappers, or creating custom CVA-based variants following the existing button/card/badge patterns.
+---
+
+# Add shadcn/ui Component
+
+## CLI — add an existing shadcn component
+
+```bash
+# Always use the latest CLI
+npx shadcn@latest add <component-name>
+```
+
+The component is placed automatically at **`src/components/ui/<component>.tsx`** (configured via `components.json`).
+
+Common components available:
+- `accordion` `alert-dialog` `avatar` `checkbox` `collapsible` `command`
+- `dropdown-menu` `form` `hover-card` `popover` `progress` `radio-group`
+- `scroll-area` `sheet` `slider` `switch` `tabs` `textarea` `toggle`
+- `tooltip`
+
+After adding, import from `@/components/ui/<component>`.
+
+## Project configuration (`components.json`)
+
+| Setting | Value |
+|---------|-------|
+| Style | `new-york` |
+| Base color | `neutral` |
+| CSS variables | `true` (oklch color space) |
+| Icon library | `lucide-react` |
+| Alias | `@/components/ui` |
+| Utils | `@/lib/utils` (exports `cn`) |
+
+## Golden rule — never modify generated files
+
+Do **not** edit files under `src/components/ui/` directly.
+Instead, create a **wrapper component** in `src/components/kiosk/`, `src/components/dashboard/`, or a new domain folder.
+
+```tsx
+// ✅ Correct — wrapper in src/components/kiosk/big-button.tsx
+import { Button, type buttonVariants } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+export function BigButton({ className, ...props }) {
+  return <Button className={cn('min-h-[56px] w-full text-lg', className)} {...props} />
+}
+
+// ❌ Wrong — editing src/components/ui/button.tsx directly
+```
+
+## Writing a custom component from scratch (CVA pattern)
+
+Follow the exact same pattern used in `src/components/ui/button.tsx`:
+
+```tsx
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'          // for asChild polymorphism
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+const myVariants = cva(
+  // 1. Base classes (always applied)
+  'inline-flex items-center rounded-md text-sm font-medium transition-all disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        primary: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+      },
+      size: {
+        default: 'h-9 px-4',
+        sm: 'h-8 px-3',
+        lg: 'h-11 px-6',
+      },
+    },
+    defaultVariants: { variant: 'primary', size: 'default' },
+  },
+)
+
+interface MyComponentProps
+  extends React.ComponentProps<'button'>,
+    VariantProps<typeof myVariants> {
+  asChild?: boolean   // allow rendering as a different element
+}
+
+function MyComponent({ className, variant, size, asChild = false, ...props }: MyComponentProps) {
+  const Comp = asChild ? Slot : 'button'
+  return (
+    <Comp
+      data-slot="my-component"          // data-slot for shadcn consistency
+      className={cn(myVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { MyComponent, myVariants }     // export both component AND variants
+```
+
+## CSS variables for colors
+
+Always reference design tokens — never hardcode hex/rgb values:
+
+```tsx
+// ✅ Uses CSS variables (respects dark mode automatically)
+className="bg-primary text-primary-foreground"
+className="bg-destructive text-white"
+className="border-border bg-card"
+className="text-muted-foreground"
+
+// ❌ Hardcoded — breaks dark mode
+className="bg-black text-white"
+```
+
+Available tokens: `--background`, `--foreground`, `--primary`, `--primary-foreground`, `--secondary`, `--muted`, `--accent`, `--destructive`, `--border`, `--ring`, `--card`, `--chart-1..5`, `--sidebar-*`
+
+## Sonner toast integration
+
+After a user action, always give feedback:
+
+```tsx
+import { toast } from 'sonner'
+
+toast.success('Tấm lẻ đã được nhập kho')
+toast.error('Không thể kết nối API')
+toast.loading('Đang xử lý...')
+```
+
+## Accessibility checklist
+
+- All interactive elements: `focus-visible:ring-[3px] focus-visible:ring-ring/50`
+- Disabled state: `disabled:pointer-events-none disabled:opacity-50`
+- Icons inside buttons: `aria-hidden="true"` + sr-only text if icon-only
+- Touch targets (kiosk): minimum `min-h-[48px] min-w-[48px]`

--- a/.codex/skills/business-auditor/SKILL.md
+++ b/.codex/skills/business-auditor/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: business-auditor
+description: Use to verify if UI/UX and Frontend logic reflect the Vietnamese business rules.
+---
+
+# Business Auditor - UI & UX Validation (Frontend)
+
+Ensures the user flow and interface comply with `docs/backend-business-logic-vi.md`.
+
+## Core Principles
+1. **Terminology**: Use precise Vietnamese workshop terms (tấm lẻ, phôi, lệnh cắt, hao hụt, vị trí kho).
+2. **State Logic**: UI must reflect business states (e.g., `CONSUMED` remnants must not appear in `AVAILABLE` lists).
+
+## Audit Workflow
+
+### 1. Terminology Audit
+Ensure standard terms are used across all pages:
+- `Remnant` -> "Tấm lẻ"
+- `WorkOrder` -> "Lệnh cắt"
+- `BoardSheet` -> "Tấm nguyên"
+- `Bin Location` -> "Vị trí kho"
+
+### 2. UI Constraint Check
+- **BR-K01/K05**: When reporting a cut, FE must provide inputs for `boundingBoxLengthMm` and `boundingBoxWidthMm`.
+- **Overflow Alerts**: Verify the color logic (Red/Green) for remnant area utilization percentages.
+
+### 3. Integrated Validation
+- Before calling `recordCut` API, the FE should perform basic "Pre-checks" (e.g., dimensions must be positive numbers).
+
+## Pre-PR Checklist
+- [ ] Are all labels in correct Vietnamese?
+- [ ] Does the scan flow follow the correct sequence (Scan Material -> Scan Location)?
+- [ ] Is there an Alert Banner for significant area loss (>15% overflow)?

--- a/.codex/skills/integration-architect/SKILL.md
+++ b/.codex/skills/integration-architect/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: integration-architect
+description: Use to ensure absolute sync between Frontend and Backend. Checks API contracts, Type safety, and data flow.
+---
+
+# Integration Architect - Client-Server Sync
+
+Acts as the gatekeeper to ensure the Client never breaks due to Backend changes.
+
+## Contract Synchronization
+1. **Single Source of Types**: Always cross-reference `src/types/api.ts` with the Backend's `iface.go`.
+2. **Snake Case Consistency**: Use **snake_case** for all DTOs to match Go JSON tags, avoiding manual renaming errors.
+3. **Status Enums**: Ensure FE string unions (e.g., `AVAILABLE`, `IN_CUTTING`) match the Backend `internal/domain` constants 1:1.
+
+## Integration Checks
+- **Mutation Invalidation**: After actions like `allocateRemnant`, ensure the correct Query Keys are invalidated to prevent stale UI data.
+- **Scanner Payload**: Verify the JSON structure in QR codes matches between BE generation and FE `ScannerView` parsing.
+
+## Integration Checklist
+- [ ] Is the API base URL correctly configured for the environment?
+- [ ] Are Backend `BizError` messages displayed in a user-friendly way?
+- [ ] Are date strings from the API safely handled/formatted?
+
+---
+*Goal: Achieve end-to-end type safety from the Database to the UI Component.*

--- a/.codex/skills/kiosk-component/SKILL.md
+++ b/.codex/skills/kiosk-component/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: kiosk-component
+description: Use when building any component for the (kiosk) route group — shop-floor mobile UI for workers. Covers touch targets, BigButton, ScannerView, QR print, Vietnamese labels, and sonner toasts.
+---
+
+# Kiosk Component Guidelines
+
+The kiosk is a mobile-first PWA used by factory workers (Vietnamese speakers) on Android phones and tablets at the shop floor. Every component must be operable with one hand, gloves on, in a dusty/noisy environment.
+
+## Non-negotiable rules
+
+| Rule | Value |
+|------|-------|
+| Min touch target height | **48 px** (`min-h-[48px]`) |
+| Min touch target width | **48 px** |
+| Primary action button height | **56 px** (`BigButton` — `min-h-[56px]`) |
+| Base font size | **≥ 16 px** (avoids iOS auto-zoom on focus) |
+| Max steps to complete a task | **3 taps** |
+| UI language | **Vietnamese** |
+| Loading feedback | **Instant skeleton** (`loading.tsx`) |
+| Action feedback | **sonner toast** within 300 ms |
+
+---
+
+## `BigButton` — primary actions
+
+Import from `@/components/kiosk/big-button`. Use for every primary action (submit, confirm, scan, print).
+
+```tsx
+import { BigButton } from '@/components/kiosk/big-button'
+
+// Primary action
+<BigButton onClick={handleSubmit} disabled={isPending}>
+  {isPending ? 'Đang xử lý...' : 'Báo cáo kết quả'}
+</BigButton>
+
+// Danger action (e.g. discard)
+<BigButton variant="danger" onClick={handleCancel}>
+  Huỷ lệnh
+</BigButton>
+
+// Secondary action
+<BigButton variant="secondary">Bỏ qua</BigButton>
+```
+
+**Props**: `variant: 'primary' | 'secondary' | 'danger'` + all standard `<button>` props.
+
+Do **not** use `Button` from `@/components/ui/button` for primary kiosk actions — it's too small.
+
+---
+
+## `ScannerView` — QR / barcode scanning
+
+Import from `@/components/kiosk/scanner-view`. Always wrap in a `Card`.
+
+```tsx
+import { ScannerView } from '@/components/kiosk/scanner-view'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+<Card>
+  <CardHeader>
+    <CardTitle className="text-base">Quét mã QR tấm lẻ</CardTitle>
+  </CardHeader>
+  <CardContent>
+    <ScannerView
+      onScan={(code) => {
+        // code is the decoded QR string — parse JSON or use as ID
+        try {
+          const data = JSON.parse(code)
+          // e.g. { type: 'REMNANT', id: 'R-001', ... }
+          handleScan(data)
+        } catch {
+          // plain barcode string
+          handleScan({ id: code })
+        }
+      }}
+    />
+  </CardContent>
+</Card>
+```
+
+**Behaviour:**
+- Uses `html5-qrcode` (dynamically imported, no SSR issues)
+- Camera facing: `environment` (back camera)
+- Falls back to manual text input automatically if camera permission denied
+- `onScan` fires once per detected code
+
+**QR content format** (from Go backend):
+```json
+{ "type": "REMNANT" | "WIP", "id": "...", "sku": "...", "dimensions": {...}, "lot": "...", "location": "..." }
+```
+
+---
+
+## `LabelPreview` — print label preview
+
+Import from `@/components/kiosk/label-preview`.
+
+```tsx
+import { LabelPreview } from '@/components/kiosk/label-preview'
+import type { BarcodeRecord } from '@/types/api'
+
+// After RecordCut succeeds and returns barcodeIds, fetch the record:
+<LabelPreview barcode={barcodeRecord} size="small" />   // 50×30mm remnant label
+<LabelPreview barcode={barcodeRecord} size="large" />   // 100×70mm WIP label
+```
+
+Clicking the preview opens `window.print()` — browser print dialog.
+
+---
+
+## `BottomNav` — navigation (already in layout)
+
+The kiosk layout (`src/app/(kiosk)/layout.tsx`) already renders `BottomNav`. **Do not add another nav** inside page components.
+
+The bottom nav has 4 tabs:
+- `/cutting-orders` — Lệnh cắt
+- `/report-cut` — Báo cáo
+- `/remnant-list` — Kho tấm lẻ
+- `/scan` — Quét mã
+
+---
+
+## Toast notifications (sonner)
+
+Always give feedback immediately after user action:
+
+```tsx
+import { toast } from 'sonner'
+
+// After successful API call
+toast.success('Đã nhập kho tấm lẻ thành công')
+
+// After API error
+toast.error('Lỗi kết nối — vui lòng thử lại')
+
+// Loading state during mutation
+const toastId = toast.loading('Đang xử lý...')
+// then:
+toast.dismiss(toastId)
+toast.success('Hoàn thành')
+```
+
+---
+
+## Standard kiosk page structure
+
+```tsx
+import type { Metadata } from 'next'
+import { BigButton } from '@/components/kiosk/big-button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+export const metadata: Metadata = { title: 'Tên màn hình' }
+
+export default function KioskPage() {
+  return (
+    <div className="space-y-4 p-4">
+      {/* Page title */}
+      <h1 className="text-xl font-bold">Tên màn hình</h1>
+
+      {/* Content cards — each step in a separate card */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Bước 1 — ...</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {/* step content */}
+        </CardContent>
+      </Card>
+
+      {/* Optional: remnant suggestion list */}
+      {/* <RemnantSuggestionList /> */}
+
+      {/* Primary action — always at the bottom */}
+      <BigButton disabled={!isReady}>
+        Xác nhận
+      </BigButton>
+    </div>
+  )
+}
+```
+
+---
+
+## Form inputs on mobile
+
+Use `inputMode` to trigger the right mobile keyboard:
+
+```tsx
+<Input
+  type="number"
+  inputMode="numeric"    // numeric keypad (no minus sign)
+  placeholder="1200"
+  className="h-12 text-base"   // larger height + font for kiosk
+/>
+
+<Input
+  inputMode="decimal"    // numeric with decimal point
+  className="h-12 text-base"
+/>
+```
+
+---
+
+## Workflow patterns
+
+### Two-scan flow (scan remnant → scan location)
+
+```tsx
+const [remnantId, setRemnantId] = useState<string | null>(null)
+const [locationId, setLocationId] = useState<string | null>(null)
+const assignMutation = useAssignLocation()
+
+// Step 1: scan remnant
+<ScannerView onScan={(code) => setRemnantId(JSON.parse(code).id)} />
+
+// Step 2: scan location (visible only after step 1)
+{remnantId && (
+  <ScannerView onScan={(code) => setLocationId(JSON.parse(code).id)} />
+)}
+
+// Confirm button (enabled only when both scanned)
+<BigButton
+  disabled={!remnantId || !locationId || assignMutation.isPending}
+  onClick={() => assignMutation.mutate({ id: remnantId!, locationId: locationId! })}
+>
+  Xác nhận nhập kho
+</BigButton>
+```

--- a/.codex/skills/product-manager/SKILL.md
+++ b/.codex/skills/product-manager/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: product-manager
+description: Use to analyze the backlog from a user perspective (Kiosk/Dashboard), break down tasks, and manage FE issues.
+---
+
+# Product Manager - Frontend Backlog & UX
+
+Focuses on translating business rules into specific UI tasks and User Stories.
+
+## Key Responsibilities
+1. **UI Gap Analysis**: Compare spec with current screens. Identify missing pages, buttons, or feedback toasts.
+2. **Issue Automation**: Create FE issues with Responsive requirements (375/768/1280px).
+3. **Task Breakdown**: Sequence: Types -> API Client -> Hooks -> Components -> Pages.
+
+## FE Issue Workflow
+Draft FE issues in Vietnamese for the board:
+
+**Example Issue Title**: `3.6 [kiosk] Thêm màn hình báo cáo tấm lẻ dư (BR-K04)`
+**Example Issue Body**:
+```markdown
+## Tóm tắt
+Cần bổ sung màn hình cho phép thợ CNC nhập kích thước tấm lẻ sau khi cắt xong lệnh. 
+
+## Định nghĩa hoàn thành (DoD)
+- [ ] Tạo page mới tại (kiosk)/report-remnant/page.tsx.
+- [ ] Responsive tốt trên mobile (375px), touch target tối thiểu 48px.
+- [ ] Sử dụng BigButton cho hành động "Xác nhận nhập kho".
+- [ ] Hiển thị thông báo thành công (toast.success) sau khi gọi API thành công.
+```
+
+## Execution
+```bash
+gh issue create --title "[kiosk] Thêm màn hình báo cáo tấm lẻ dư (BR-K04)" --body "..."
+```
+
+---
+*Agent Tip: Prioritize "1-hand operation" for Kiosk tasks to accommodate workers on the shop floor.*

--- a/.codex/skills/remnant-flow-domain/SKILL.md
+++ b/.codex/skills/remnant-flow-domain/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: remnant-flow-domain
+description: Use when implementing any feature related to remnant tracking, allocation, cutting records, costing, overflow alerts, or barcode/QR. Provides the business rules and API endpoints without requiring you to read the docs.
+---
+
+# Remnant Flow Domain Knowledge
+
+This system manages the "Remnant Flow" (Dòng chảy Vật tư dư) in a woodworking furniture workshop. Raw board sheets are CNC-cut into WIP products; leftover pieces become **remnants** tracked through the system.
+
+---
+
+## Core entities
+
+| Entity | Key fields | Notes |
+|--------|-----------|-------|
+| `BoardSheet` | `id`, `materialType`, `lengthMm`, `widthMm`, `thicknessMm`, `unitCost`, `status` | Raw plywood/MDF before cutting |
+| `Remnant` | `id`, `parentRemnantId`, `sourceBoardSheetId`, `status`, `boundingBoxLengthMm`, `boundingBoxWidthMm`, `binLocationId` | Leftover material |
+| `WorkOrder` | `id`, `sku`, `requiredLengthMm`, `requiredWidthMm`, `status` | Single cutting task |
+| `StorageLocation` | `id`, `zone`, `rack`, `shelf`, `barcode` | Physical bin location (e.g. A1-R2-S3) |
+
+All types are defined in `src/types/api.ts`.
+
+---
+
+## Remnant lifecycle
+
+```
+AVAILABLE ──allocate()──→ ALLOCATED ──consumed by cut──→ CONSUMED
+    │
+    └──markWaste()──→ WASTE
+```
+
+**State meanings (match backend `domain.RemnantStatus` exactly):**
+- `AVAILABLE` — ready to be allocated or cut
+- `ALLOCATED` — reserved for a work order (locked)
+- `CONSUMED` — fully cut, no longer in inventory
+- `WASTE` — marked as unusable waste
+
+**Never display `CONSUMED` or `WASTE` remnants in the available inventory UI.**
+
+---
+
+## Attribute inheritance (Sprint 2)
+
+When a remnant is produced from a cut, it automatically inherits from its source:
+- `supplierCode` → from board sheet or parent remnant
+- `lotBatch` → same
+- `grainPattern` → same
+- `qualityGrade` → same
+- `materialType` → same
+
+The `boundingBoxLengthMm` and `boundingBoxWidthMm` represent the smallest axis-aligned rectangle that fits the usable area (not the actual ragged shape).
+
+---
+
+## Nested cutting (lineage chain)
+
+A remnant can itself be cut, producing child remnants:
+
+```
+BoardSheet ─── RecordCut ──→ WIP Products
+                           └→ Remnant A (parentRemnantId: null, sourceBoardSheetId: BS-01)
+                                  │
+                              RecordCut
+                                  │
+                                  └→ WIP Products
+                                   └→ Remnant A.1 (parentRemnantId: A, sourceBoardSheetId: BS-01)
+                                         │
+                                     RecordCut
+                                         └→ Remnant A.1.1 (parentRemnantId: A.1, ...)
+```
+
+**Area conservation rule**: at every cut, `used_area + remnant_area + waste_area = source_area`. The Go backend enforces this with `BR-K03`.
+
+---
+
+## Best Fit + FIFO allocation algorithm
+
+When suggesting a remnant for a work order:
+
+```
+fit_score  = required_area / bounding_box_area   // 1.0 = perfect fit, lower = more waste
+age_score  = days_in_stock / max_days_in_stock   // higher = older = prefer to use first
+
+combined_score = w1 * fit_score + w2 * age_score
+              = 0.6 * fit_score + 0.4 * age_score   // defaults (configurable)
+```
+
+**Display suggestion quality**: `wastePct = 1 - fit_score` → show as "% hao hụt".
+A good suggestion has `wastePct ≤ 10%`.
+
+---
+
+## Costing rules
+
+1. **Flat cut from board sheet**:
+   `remnant_value = (remnant_area / sheet_area) * sheet_unit_cost`
+
+2. **Nested remnant cut**:
+   `remnant_value = (remnant_area / parent_remnant_area) * parent_remnant_value`
+
+3. **Waste** is treated as overhead (absorbed by the PO) — not allocated to a specific SKU.
+
+4. **Remnant savings** = cost avoided by using remnant instead of issuing a new sheet.
+
+---
+
+## Key API endpoints
+
+These endpoints actually exist in the backend (verified against handler registrations):
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/inventory/lots` | POST | Receive stock — create lot + sheets |
+| `/inventory/lots` | GET | List inventory lots (paginated) |
+| `/inventory/sheets` | GET | List available board sheets (paginated) |
+| `/inventory/sheets/:id` | GET | Get single sheet |
+| `/inventory/sheets/:id/lineage` | GET | All remnants descended from this sheet |
+| `/inventory/cuts` | POST | Record a cut — creates CuttingRecord + optional Remnant |
+| `/inventory/remnants` | GET | List remnants (filter: min_length_mm, min_width_mm, status) |
+| `/inventory/remnants/:id/lineage` | GET | Lineage tree rooted at a remnant's parent board |
+| `/inventory/remnants/:id/allocate` | POST | Allocate remnant to a work order |
+| `/inventory/remnants/:id/waste` | POST | Mark remnant as WASTE |
+| `/storage-locations` | GET | List all active storage locations |
+| `/work-orders` | POST/GET | Create/list work orders |
+| `/work-orders/:id` | GET | Get single work order |
+| `/work-orders/:id/advance` | POST | Advance work order status |
+| `/work-orders/:id/consumptions` | POST/GET | Record/list material consumptions |
+| `/barcodes` | POST | Generate a barcode record |
+| `/barcodes/:id` | GET | Lookup barcode |
+| `/barcodes/:id/scans` | POST/GET | Record/list scan events |
+| `/costing/:workOrderID/compute` | POST | Compute costing for a work order |
+| `/costing/:workOrderID/finalize` | POST | Finalize (immutable) costing record |
+| `/costing/:workOrderID` | GET | Get costing record |
+| `/costing` | GET | List costing records |
+| `/materials` | POST/GET | Create/list materials |
+| `/skus` | POST/GET | Create/list SKUs |
+| `/plans` | POST/GET | Create/list production plans |
+| `/plans/:id/approve` | POST | Approve plan |
+| `/plans/:id/cancel` | POST | Cancel plan |
+| `/pos` | POST/GET | Create/list purchase orders |
+
+All under base URL `NEXT_PUBLIC_API_URL` (default: `http://localhost:8080/api/v1`).
+
+**Endpoints that do NOT exist** (were listed incorrectly in older docs):
+- ~~`/inventory/suggest-allocation`~~ — not implemented
+- ~~`/inventory/overflow-status`~~ — not implemented
+- ~~`/inventory/release-allocation`~~ — not implemented
+- ~~`/inventory/issue-sheet`~~ — not implemented
+- ~~`/remnants/:id/location`~~ — not implemented
+- ~~`/dashboard/remnant-summary`~~ — not implemented
+- ~~`/barcode/:id/qr`~~ — not implemented (barcodes, not barcode)
+- ~~`/barcode/batch-print`~~ — not implemented
+
+---
+
+## Scan checkpoints (3 fixed)
+
+| Checkpoint | Vietnamese label | When |
+|------------|-----------------|------|
+| `CNC_COMPLETE` | Hoàn thành CNC | After CNC machine finishes |
+| `FINISHING_COMPLETE` | Hoàn thành gia công | After sanding/finishing |
+| `WAREHOUSE_SHIP` | Xuất kho | When goods leave warehouse |
+
+Use `ScannerView` on the `/scan` kiosk page to capture these.
+
+---
+
+## QR code content format
+
+QR codes encode JSON:
+```json
+{
+  "type": "REMNANT" | "WIP",
+  "id": "uuid-here",
+  "sku": "SKU-001",
+  "dimensions": { "lengthMm": 800, "widthMm": 400, "thicknessMm": 18 },
+  "lot": "LOT-2026-03",
+  "location": "A1-R2-S3"
+}
+```
+
+Always `JSON.parse()` the scanned string — if it fails, treat as a plain barcode ID.
+
+---
+
+## Work order status machine
+
+```
+PLANNED ──approve──→ IN_CUTTING ──recordCut──→ IN_PROCESSING ──finish──→ COMPLETED
+```
+
+Only `IN_CUTTING` work orders appear in the kiosk "Lệnh cắt hôm nay" screen.
+Filter: `cuttingOrdersApi.list({ status: 'IN_CUTTING' })`.

--- a/.codex/skills/senior-workflow-frontend/SKILL.md
+++ b/.codex/skills/senior-workflow-frontend/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: senior-workflow-frontend
+description: >
+  Use when starting ANY non-trivial issue or feature on the Next.js frontend —
+  covers the full Senior Engineer workflow: requirements clarification →
+  technical design → task breakdown → implement → self-QA → PR.
+  ALWAYS trigger this skill when the user says "implement", "add feature",
+  "build page", "add component", "create hook", "fix", "fix bug", "find root cause",
+  "plan and implement", or pastes a GitHub issue/ticket number.
+  Do NOT skip phases — Phase 5 (Self-QA) is the gate before PR and the phase
+  most commonly skipped; skipping it is the #1 source of rework.
+---
+
+# Senior Engineer Workflow — Next.js Frontend
+
+Run these 6 phases **in order**. Mark each one done before moving to the next.
+Phase 5 is mandatory — do not open a PR without completing it.
+
+---
+
+## Phase 1 — Requirements Clarification
+
+Before writing a single line of code, understand the *why*.
+
+**Questions to answer (ask the user if unclear):**
+- Who uses this screen?
+  - Worker on phone → `(kiosk)` route group, Vietnamese labels, touch targets ≥ 48px
+  - Manager on desktop → `(dashboard)` route group, responsive grid
+- What is the exact Definition of Done?
+  - Screen renders? Or also: loading state, error state, empty state, responsive at 375/768/1280px?
+- Adversarial edge cases to surface:
+  - "What if the API returns an empty array?"
+  - "What if the user taps the button twice before the mutation resolves?"
+  - "What if `data` is `undefined` on first render?" (TanStack Query always starts undefined)
+  - "Is the response a `PagedResult<T>` (`{ items, total_items }`) or a plain `T[]`?"
+  - "Are any date/optional fields missing in some API responses?"
+- Is there a Sprint issue number? (for commit/PR tagging)
+
+**Output of this phase:** a short bullet list — *Who / DoD / Edge cases identified*
+
+---
+
+## Phase 2 — Technical Design (Next.js Frontend)
+
+Design before coding. Answer these questions before opening any file.
+
+### Route & component tree
+```
+Worker on phone?     → (kiosk)/page-name/page.tsx
+Manager on desktop?  → (dashboard)/page-name/page.tsx
+```
+Component tree sketch:
+```
+page.tsx  (can be server component — exports metadata)
+  └── PageContent  ('use client' — owns state + data fetching)
+        ├── loading.tsx   (Skeleton that mirrors real layout)
+        ├── error.tsx     ('use client' — required directive)
+        └── domain components (pure, props only, no fetching)
+```
+
+### API alignment check — do this before writing any TypeScript
+Read the backend `iface.go` for the relevant module. Confirm:
+- Does the endpoint return `PagedResult<T>` or `T[]`?
+  - `PagedResult<T>` → `{ items: T[], total_items: number, ... }` — always unwrap `.items`
+  - Skipping this causes `TypeError: cannot read property 'filter' of undefined`
+- What are the exact JSON field names? Go uses `snake_case` — must match exactly in `src/types/api.ts`
+- Which fields are pointers in Go (`*string`, `*time.Time`)? These can be `null` — type them as `field?: string` or `field: string | null`
+- Are date fields always present or sometimes omitted? → type as `created_at?: string` and guard before formatting
+
+### State & data flow
+- Server state → TanStack Query `useQuery` / `useMutation`
+- Local UI state → `useState` in the component
+- Cross-component shared state (rare) → Zustand in `src/lib/hooks/`
+- Query key strategy: `[domain]` → `[domain, filter]` → `[domain, id]`
+- Which queries need `invalidateQueries` after a mutation? List them now.
+
+### Impact analysis
+- Does this touch existing cache keys? A mutation may need to invalidate more than one key.
+- New route? → needs `loading.tsx` + `error.tsx` siblings
+- New navigation entry? → update `side-nav.tsx` or `bottom-nav.tsx` AND `authorization.ts`
+- New API domain file? → follow 4-file pattern
+
+**Output of this phase:** component tree sketch, confirmed API shape + optional fields, query keys, list of mutations that invalidate
+
+---
+
+## Phase 3 — Task Breakdown
+
+Split into discrete tasks. Use TaskCreate to track them.
+
+Typical order for a new feature:
+1. Add/update types in `src/types/api.ts` (match backend iface.go exactly)
+2. Create `src/lib/api/<domain>.ts` (thin wrappers over `apiClient`)
+3. Create `src/lib/hooks/use-<domain>.ts` (TanStack Query hooks)
+4. Create `page.tsx` + `loading.tsx` + `error.tsx`
+5. Build presentational components (no fetch logic inside them)
+6. Wire data into page via hooks
+7. Handle all three states: loading / error / empty
+8. TypeScript check → ESLint → build
+
+**Rule:** Types must be correct before writing hooks. Hooks must be correct before writing UI. Never combine steps that should be sequential.
+
+---
+
+## Phase 4 — Implement
+
+### 4-file pattern for every new API domain
+```
+src/types/api.ts                      ← Step 1: DTOs (never declare types locally in a page)
+src/lib/api/<domain>.ts               ← Step 2: thin API wrappers over apiClient
+src/lib/hooks/use-<domain>.ts         ← Step 3: TanStack Query hooks
+src/app/(group)/page-name/page.tsx    ← Step 4: page + inline components
+```
+
+### Type safety rules
+```typescript
+// ✅ PagedResult: always unwrap .items
+const items = data?.items ?? []
+
+// ✅ Optional/nullable Go fields — guard before use
+plan.deadline ? formatDate(plan.deadline) : '—'
+
+// ✅ Dates are strings from Go — parse client-side, never trust format
+const d = new Date(entity.created_at)  // could be null if field is optional in Go
+
+// ✅ Nullable Go pointer fields (*string in Go → string | null in TS)
+supplier_code: string | null
+```
+
+### Hook patterns
+```typescript
+// Read hook — guard undefined at consumption site, not inside hook
+const { data, isLoading, error } = useMyEntities(filter)
+const items = data?.items ?? []   // never: data.items.filter(...)
+
+// Mutation — always invalidate on success, toast on error
+useMutation({
+  mutationFn: myApi.create,
+  onSuccess: () => {
+    queryClient.invalidateQueries({ queryKey: [MY_KEY] })
+    toast.success('Đã lưu')
+  },
+  onError: (err: ApiClientError) => toast.error(err.message),
+})
+```
+
+### Side effect rules — the #1 source of infinite loops
+**Never call `setState` or `setX` directly in the render body.**
+Any logic of the form "when X changes, update Y state" belongs in `useEffect`:
+```typescript
+// ❌ Causes infinite loop — new object created every render, condition always true
+const prevRef = { current: '' }
+if (someValue && prevRef.current !== someValue) {
+  prevRef.current = someValue
+  setOtherState(...)   // setState in render body → re-render → repeat forever
+}
+
+// ✅ Correct — runs after render, only when dependency changes
+useEffect(() => {
+  if (!someValue) return
+  setOtherState(derivedFrom(someValue))
+}, [someValue])
+```
+
+Use `useRef` for values that must persist across renders **without triggering a re-render** (e.g., scanner ref, previous value tracker). Declare refs with `useRef(initialValue)` — never as a plain object `{ current: '' }`.
+
+### Required states — every data-driven page must have all three
+```tsx
+if (isLoading) return <Skeleton ... />       // mirrors real layout structure
+if (error)     return <ErrorMessage ... />   // error.tsx must have 'use client'
+if (!items.length) return <EmptyState />     // specific empty message, not generic
+```
+
+### Kiosk-specific rules (if in `(kiosk)` route group)
+- All interactive elements: `min-h-[48px]` — no exceptions
+- Primary actions: `BigButton` from `@/components/kiosk/big-button`
+- All user-visible labels: Vietnamese
+- Font size: ≥ 16px for anything the user reads or taps
+- Action feedback: `toast.success()` / `toast.error()` within 300ms of mutation settling
+
+---
+
+## Phase 5 — Self-QA ⛔ DO NOT SKIP
+
+This is the gate before PR. Work through every section below in order — not just the ones that seem relevant. Most rework in this project comes from skipping this phase.
+
+### Step 5.1 — Run automated checks first
+These must all pass before anything else. Fix every error; do not move to 5.2 with failures.
+
+```bash
+npx tsc --noEmit        # 0 TypeScript errors — fix all, no exceptions
+npm run build           # Next.js production build must succeed
+```
+
+`npm run build` is the true gate. Turbopack and the production compiler catch different errors — a passing `tsc --noEmit` does not mean the build will pass.
+
+If lint reports `suggestCanonicalClasses` warnings (Tailwind v4), replace arbitrary values with canonical equivalents:
+```
+max-w-[375px]  →  max-w-93.75
+h-[48px]       →  h-12
+```
+
+### Step 5.2 — Read every changed file top to bottom
+
+Do not skim. For each changed file, ask yourself the questions below.
+
+#### Render body side effects
+- [ ] Does any code inside the component function (outside `useEffect`) call `setState`, `setX`, or any other state setter **conditionally or based on another state value**?
+  - If yes → it causes an infinite re-render loop. Move it to `useEffect`.
+- [ ] Is there a `useRef` declared as a plain object literal `{ current: ... }` instead of `useRef(...)`?
+  - Plain objects are re-created every render — they cannot track previous values.
+
+#### Import hygiene
+- [ ] Are all `import` statements at the **top of the file**, before any other code?
+  - ESLint `import/first` will fail if imports appear after variable declarations or JSX.
+- [ ] Any unused imports? → remove them.
+- [ ] Are imports grouped correctly: React/Next → third-party → `@/` aliases?
+
+#### TypeScript strictness
+- [ ] Any `any` type? → replace with `unknown` + type narrowing or the correct type.
+- [ ] `data!.field` (non-null assertion)? → replace with `data?.field ?? fallback`.
+- [ ] Optional Go field rendered directly without guard?
+  - `formatDate(plan.deadline)` where `deadline?: string` → `plan.deadline ? formatDate(plan.deadline) : '—'`
+- [ ] `useRef<HTMLElement>(null)` → must be `useRef<HTMLElement | null>(null)` in React 19.
+- [ ] Type declared locally inside a component or page file? → move to `src/types/api.ts`.
+
+#### Date handling
+- [ ] Every date field from the API — is it typed as optional (`string?`) if the backend Go field is a pointer or omitempty?
+- [ ] Is `formatDate` / `new Date()` called without a null/undefined guard?
+  - `new Date(undefined)` → `Invalid Date` — always guard first.
+- [ ] Is the date string from Go in the expected ISO 8601 format? Check with `console.log` if unsure.
+
+#### TanStack Query correctness
+- [ ] Every `useQuery` result used as an array — is it guarded with `?? []`?
+- [ ] Mutation `onSuccess` — does it invalidate **all** cache keys that depend on the mutated entity?
+  - E.g., creating a plan should invalidate both `['plans']` and potentially `['plan', id]`.
+- [ ] Query with a dependency param — does it have `enabled: !!param`?
+- [ ] Any query key that is a bare string literal (`'plans'`) instead of an exported constant?
+
+#### Component structure
+- [ ] Component longer than ~120 lines? → extract a named sub-component (not an inline arrow function).
+- [ ] Inline `style={}` for something Tailwind can express? → replace with `className`.
+- [ ] `fetch()` called directly instead of `apiClient`? → replace.
+- [ ] `'use client'` missing from a component that uses `useState`, `useEffect`, or browser APIs?
+- [ ] `error.tsx` missing `'use client'`? (Next.js requires it — the build will fail without it.)
+- [ ] `loading.tsx` skeleton — does it structurally match the real page? (same number of cards/rows)
+
+#### Storybook (if stories were added or modified)
+- [ ] All `import` statements at the top of the stories file?
+- [ ] Helper components used only in stories — are they named without a leading underscore (since they are used)?
+- [ ] Story covers the happy path AND the meaningful error/empty states?
+
+#### Navigation & routing
+- [ ] New route added → is it listed in `authorization.ts` so the middleware allows it?
+- [ ] New nav item added → does it appear in both `side-nav.tsx` (dashboard) or `bottom-nav.tsx` (kiosk) as appropriate?
+- [ ] Nav item points to the correct `href`?
+
+### Step 5.3 — Spot-check in the browser
+
+Before marking the task done, open the page and verify:
+- [ ] Renders correctly at 375px (mobile) — no horizontal scroll, no clipped text
+- [ ] Loading state shows before data arrives (add a 3G throttle in DevTools if needed)
+- [ ] Empty state shows when no data exists (test with an empty filter)
+- [ ] Error state shows when the API fails (temporarily break the URL to test)
+- [ ] All mutations show a success or error toast — no silent failures
+- [ ] Console has 0 errors and 0 warnings
+
+---
+
+## Phase 6 — PR
+
+### Commit message format
+```
+[area] verb: brief description
+
+- bullet detail 1
+- bullet detail 2
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+`area` is one of: `kiosk`, `dashboard`, `api`, `hooks`, `types`, or the feature name.
+
+Example:
+```
+[kiosk] fix: classify camera errors with user-facing guidance
+
+- Detect NotAllowedError, NotFoundError, insecure context separately
+- Show Vietnamese error banner with actionable instructions per error type
+- Move lineItems → rows sync into useEffect to prevent infinite re-render
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+### Branch rules
+- Feature branch from `dev`: `git checkout -b feat/area-brief-description dev`
+- Never push directly to `main` or `dev`
+- PR: feature → `dev` (approval optional)
+- `dev` → `main` requires 1 approval
+
+### PR body template
+```markdown
+## Summary
+- What was changed and why
+- Route group affected: (kiosk) / (dashboard) / shared
+
+## Technical notes
+- New API types added: yes/no — list them
+- New query keys: list them
+- Breaking changes: yes/no
+
+## Test plan
+- [ ] `npx tsc --noEmit` — 0 errors
+- [ ] `npm run lint` — clean
+- [ ] `npm run build` — succeeds
+- [ ] Renders at 375px / 768px / 1280px without layout issues
+- [ ] Loading / error / empty states all render correctly
+- [ ] All mutations show success/error toast
+- [ ] Tested manually: describe scenario
+```

--- a/.codex/skills/senior-workflow/SKILL.md
+++ b/.codex/skills/senior-workflow/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: senior-workflow
+description: >
+  Use when starting ANY non-trivial issue or feature on the Next.js frontend —
+  covers the full Senior Engineer workflow: requirements clarification →
+  technical design → task breakdown → implement + test → self-QA → PR.
+  ALWAYS trigger this skill when the user says "implement", "add feature",
+  "build page", "add component", "create hook", "fix", "fix bug", "find root cause" or pastes a GitHub issue/ticket.
+  Do NOT skip phases — especially Phase 5 (Self-QA) which is the most commonly
+  forgotten step before submitting code.
+---
+
+# Senior Engineer Workflow — Next.js Frontend
+
+Run these 6 phases **in order**. Mark each one done before moving to the next.
+Never skip Phase 5 — it is the gate before PR.
+
+---
+
+## Phase 1 — Requirements Clarification
+
+Before writing a single line of code, understand the *why*.
+
+**Questions to answer (ask the user if unclear):**
+- Who uses this screen — worker on mobile kiosk or manager on desktop dashboard?
+  - Kiosk → `(kiosk)` route group, Vietnamese labels, touch targets ≥ 48px
+  - Dashboard → `(dashboard)` route group, desktop/responsive grid
+- What is the exact Definition of Done?
+  - Screen renders? Or also: loading state, error state, empty state, edge cases?
+- Adversarial edge cases to surface:
+  - "What if the API returns an empty array?"
+  - "What if the user taps the button twice before the mutation resolves?"
+  - "What if `data` is `undefined` on first render?" (TanStack Query)
+  - "Is the response a `PagedResult<T>` or a plain `T[]`?" ← common type mismatch bug
+- Is there a Sprint issue number? (for commit/PR tagging)
+
+**Output of this phase:** a short bullet list: *Who / DoD / Edge cases identified*
+
+---
+
+## Phase 2 — Technical Design (Next.js Frontend)
+
+Design before coding. Answer these questions before opening any file.
+
+### Route & component tree decision
+```
+Worker on phone?      → (kiosk)/page-name/page.tsx
+Manager on desktop?   → (dashboard)/page-name/page.tsx
+```
+Component tree sketch:
+```
+page.tsx (server component — exports metadata)
+  └── PageContent.tsx ('use client' — data fetching + state)
+        ├── LoadingSkeleton (loading.tsx)
+        ├── ErrorBoundary (error.tsx)
+        └── DomainCard / DomainTable / etc.
+```
+
+### API alignment check
+Before writing types, read the backend `iface.go` for the relevant module.
+Key questions:
+- Does the endpoint return `PagedResult<T>` or `T[]`?
+  - `PagedResult<T>` has `{ items: T[], total_items: N, ... }` — must unwrap `.items`
+  - Forgetting this causes `TypeError: x.filter is not a function` at runtime
+- What are the exact field names? (Go uses `snake_case`, must match exactly in `src/types/api.ts`)
+- Are there nullable fields (`*string` in Go → `string | null` or `string | undefined` in TS)?
+
+### State & data flow
+- Server state (from API) → TanStack Query `useQuery` / `useMutation`
+- UI-only state → `useState` in the component
+- Global shared state (rare) → Zustand store in `src/lib/hooks/`
+- Query key strategy: `[domain]` → `[domain, filter]` → `[domain, id]`
+- Which queries need `invalidateQueries` after a mutation?
+
+### Impact analysis
+- Does this touch existing TanStack Query cache keys? (mutation might need to invalidate more)
+- Does this add a new route? → needs `loading.tsx` + `error.tsx` siblings
+- Does this add a new `src/lib/api/*.ts` file? → follow 4-file pattern
+- Is there a real-time need? → `refetchInterval` or `refetchOnWindowFocus`
+
+**Output of this phase:** component tree, confirmed API shape, query keys, state decisions
+
+---
+
+## Phase 3 — Task Breakdown
+
+Split into sub-tasks of 2–4 hours each. Create a TodoList.
+
+Typical order for a new feature:
+1. Add/update types in `src/types/api.ts`
+2. Create `src/lib/api/<domain>.ts` (API functions)
+3. Create `src/lib/hooks/use-<domain>.ts` (TanStack Query hooks)
+4. Create page files: `page.tsx` + `loading.tsx` + `error.tsx`
+5. Build presentational components (no data fetching logic inside)
+6. Wire data into page via hooks
+7. Handle empty state, error state, loading state
+8. TypeScript check + lint
+
+**Rule:** Types must be correct before writing hooks. Hooks must be correct before writing UI.
+
+---
+
+## Phase 4 — Implement & Test (Next.js Frontend)
+
+### 4-file pattern for every new API domain
+
+```
+src/types/api.ts           ← Step 1: add DTOs (never re-declare locally)
+src/lib/api/<domain>.ts    ← Step 2: thin API wrappers over apiClient
+src/lib/hooks/use-<domain>.ts  ← Step 3: TanStack Query hooks
+src/app/(group)/page/page.tsx  ← Step 4: page + components
+```
+
+### Type safety rules
+```typescript
+// ✅ Always use PagedResult generic when endpoint is paginated
+apiClient.get<PagedResult<Remnant>>('/inventory/remnants', { params: { limit: 1000 } })
+  .then(res => res.items)  // ← always unwrap .items
+
+// ✅ Dates are strings from Go — parse client-side
+const date = new Date(remnant.created_at)
+
+// ✅ Nullable Go fields (*string) → string | null in TS
+supplier_code: string | null
+```
+
+### Hook patterns
+```typescript
+// Read hook — always guard undefined
+const { data, isLoading, error } = useMyEntities(filter)
+const items = data ?? []   // never data.filter() without ?? []
+
+// Mutation — always invalidate on success
+useMutation({
+  mutationFn: myApi.create,
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: [MY_ENTITY_KEY] }),
+  onError: (err: ApiClientError) => toast.error(err.message),
+})
+```
+
+### Required states — all three must exist for every data-driven page
+```tsx
+if (isLoading) return <Skeleton ... />          // loading state
+if (error) return <ErrorMessage ... />          // error state
+if (items.length === 0) return <EmptyState />   // empty state
+```
+
+### Kiosk-specific rules (if in `(kiosk)` route group)
+- All interactive elements: `min-h-[48px]`
+- Primary actions: `BigButton` from `@/components/kiosk/big-button` (not `Button`)
+- All labels: Vietnamese
+- Font size: ≥ 16px for all text the user reads/taps
+- Action feedback: `toast.success()` / `toast.error()` within 300ms
+
+---
+
+## Phase 5 — Self-QA & Refactor ⛔ DO NOT SKIP
+
+This phase is the gate before PR. Run through **all** of these.
+
+### Type mismatch checklist (most common bugs)
+- [ ] API returns `PagedResult<T>` but code treats it as `T[]`? → add `.then(res => res.items)`
+- [ ] Used `data!.items` without null guard? → change to `data?.items ?? []`
+- [ ] `useRef<HTMLDivElement>(null)` typed as `RefObject<HTMLDivElement>`? → must be `RefObject<HTMLDivElement | null>` in React 19
+- [ ] Hook file has `'use client'` at top unnecessarily? → remove if no browser APIs used
+
+### Code smell checklist
+- [ ] Component over 100 lines? → extract sub-component
+- [ ] Inline style for something Tailwind can do? → replace with className
+- [ ] `any` type anywhere? → replace with `unknown` + narrowing or proper type
+- [ ] `fetch()` called directly instead of `apiClient`? → replace
+- [ ] Same type declared in two places? → consolidate to `src/types/api.ts`
+- [ ] Query key as bare string `"remnants"`? → use exported constant `REMNANT_KEY`
+- [ ] Missing `enabled: !!id` on query that depends on a param?
+
+### Silly bug checklist
+- [ ] `data?.filter(...)` but `data` could be `undefined` → `(data ?? []).filter(...)`
+- [ ] Mutation called without `await` inside async function?
+- [ ] `toast.loading()` shown but never dismissed on error path?
+- [ ] `loading.tsx` structure doesn't match actual page (different number of cards)?
+- [ ] `error.tsx` missing `'use client'` directive?
+- [ ] Double padding: layout has `p-4` AND page wrapper has `p-4`?
+
+### Automated checks (must all pass before PR)
+```bash
+npx tsc --noEmit       # 0 TypeScript errors
+npm run lint           # 0 ESLint warnings/errors
+npm run build          # next build succeeds — ALWAYS run this last
+```
+
+**Rule: `npm run build` is MANDATORY after every implement/fix task.** TypeScript errors
+caught by `tsc --noEmit` may differ from the build-time checker Turbopack uses.
+Only a passing `npm run build` is the true gate.
+
+If `tsc --noEmit` finds errors → fix all of them, no exceptions.
+
+---
+
+## Phase 6 — PR
+
+### Commit message format
+```
+[area] verb: brief description
+
+- bullet point detail 1
+- bullet point detail 2
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+```
+
+Where `area` is: `kiosk`, `dashboard`, `api`, `hooks`, `types`, or the feature name.
+
+Example:
+```
+[kiosk] feat: add pull-to-refresh on cutting orders page
+
+- Attach touch listeners at document level (not child div)
+- Read window.scrollY for scroll position check
+- Default threshold: 72px with rubber-band damping
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+```
+
+### Branch rules
+- Feature branch from `dev`: `git checkout -b feat/area-brief-description dev`
+- Never push directly to `main` or `dev`
+- PR: feature → `dev` (approval optional)
+- `dev` → `main` requires 1 approval
+
+### PR body template
+```markdown
+## Summary
+- What was changed and why
+- Route group affected: (kiosk) / (dashboard) / shared
+
+## Technical notes
+- New API types added: yes/no
+- New query keys: list them
+- Breaking changes: yes/no
+
+## Test plan
+- [ ] `npx tsc --noEmit` — 0 errors
+- [ ] `npm run lint` — clean
+- [ ] `npm run build` — succeeds
+- [ ] Tested at 375px width (mobile kiosk) if applicable
+- [ ] Loading / error / empty states all render correctly
+- [ ] Tested manually: describe scenario
+```

--- a/.codex/skills/typescript-patterns/SKILL.md
+++ b/.codex/skills/typescript-patterns/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: typescript-patterns
+description: Use when writing TypeScript in this project — API DTOs, component prop types, hook generics, strict null handling, and avoiding common TS mistakes with the existing codebase patterns.
+---
+
+# TypeScript Patterns
+
+## Golden rule — import types, never re-declare
+
+All API DTOs are in **`src/types/api.ts`**. Import them everywhere:
+
+```typescript
+// ✅ Correct
+import type { Remnant, WorkOrder, PaginatedResponse } from '@/types/api'
+
+// ❌ Wrong — re-declaring inline creates divergence with the backend
+interface Remnant { id: string; ... }
+```
+
+If the type doesn't exist yet in `src/types/api.ts`, add it there — not locally.
+
+---
+
+## Component prop types — extend HTML elements
+
+Follow the `ComponentProps<>` pattern used in all shadcn components:
+
+```tsx
+import * as React from 'react'
+
+// ✅ Extend native HTML element props — gets all HTML attributes for free
+interface ButtonProps extends React.ComponentProps<'button'> {
+  variant?: 'primary' | 'danger'
+  isLoading?: boolean
+}
+
+// ✅ For custom wrapper components, extend the base component's props
+import type { buttonVariants } from '@/components/ui/button'
+import type { VariantProps } from 'class-variance-authority'
+
+interface MyButtonProps
+  extends React.ComponentProps<'button'>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+// ❌ Avoid manual prop declarations that duplicate HTML attrs
+interface BadButtonProps {
+  onClick: () => void    // too narrow — blocks onMouseDown, etc.
+  disabled: boolean
+  className: string
+}
+```
+
+---
+
+## TanStack Query generics
+
+Always specify the generic types for full type inference and better error handling:
+
+```typescript
+import { useQuery, useMutation } from '@tanstack/react-query'
+import type { Remnant, PaginatedResponse } from '@/types/api'
+import type { ApiClientError } from '@/lib/api/client'
+
+// useQuery<TData, TError>
+const { data } = useQuery<PaginatedResponse<Remnant>, ApiClientError>({
+  queryKey: ['remnants'],
+  queryFn: () => remnantsApi.list(),
+})
+// data is typed as PaginatedResponse<Remnant> | undefined
+
+// useMutation<TData, TError, TVariables>
+const mutation = useMutation<Remnant, ApiClientError, { id: string; locationId: string }>({
+  mutationFn: ({ id, locationId }) => remnantsApi.assignLocation(id, locationId),
+})
+```
+
+---
+
+## Strict null / undefined handling
+
+The project uses `"strict": true`. Always handle nullable values:
+
+```typescript
+// useQuery returns data as T | undefined until it resolves
+const { data } = useRemnants()
+
+// ✅ Optional chaining
+const count = data?.total ?? 0
+const items = data?.data ?? []
+
+// ✅ Early return in JSX
+if (!data) return <Skeleton />
+
+// ✅ Non-null assertion only when you KNOW a value is defined
+// (after a guard check above)
+const id = remnant!.id   // only after if (!remnant) return ...
+
+// ❌ Unsafe assertion without guard
+const id = data!.total   // will crash if data is undefined
+```
+
+---
+
+## `ApiClientError` — typed error handling
+
+```typescript
+import { ApiClientError } from '@/lib/api/client'
+
+// Pattern 1 — in mutation callbacks
+useMutation({
+  mutationFn: myApi.create,
+  onError: (err: ApiClientError) => {
+    if (err.status === 422) {
+      // err.details is Record<string, string> — field-level validation errors
+      const fieldErrors = err.details ?? {}
+      setErrors(fieldErrors)
+    } else {
+      toast.error(err.message)
+    }
+  },
+})
+
+// Pattern 2 — in try/catch
+try {
+  await myApi.create(input)
+} catch (err) {
+  if (err instanceof ApiClientError) {
+    // typed — err.status, err.code, err.message, err.details
+    if (err.status === 404) return toast.error('Không tìm thấy')
+    if (err.status === 409) return toast.error('Đã tồn tại')
+  }
+  // unknown errors — rethrow or show generic message
+  toast.error('Lỗi không xác định')
+}
+```
+
+---
+
+## Avoiding `any`
+
+```typescript
+// ❌ Never use any
+const data: any = await fetch(...)
+
+// ✅ Use unknown + type narrowing
+const raw: unknown = JSON.parse(qrCode)
+if (raw && typeof raw === 'object' && 'id' in raw) {
+  const id = (raw as { id: string }).id
+}
+
+// ✅ Or use a type assertion with a guard function
+function isQrPayload(v: unknown): v is QrPayload {
+  return typeof v === 'object' && v !== null && 'type' in v && 'id' in v
+}
+
+const parsed: unknown = JSON.parse(code)
+if (isQrPayload(parsed)) {
+  handleScan(parsed) // typed as QrPayload
+}
+```
+
+---
+
+## Zustand store typing
+
+Follow the pattern in `src/lib/hooks/use-scan.ts`:
+
+```typescript
+import { create } from 'zustand'
+
+interface MyStore {
+  // state
+  count: number
+  items: string[]
+  // actions
+  increment: () => void
+  addItem: (item: string) => void
+  reset: () => void
+}
+
+export const useMyStore = create<MyStore>((set) => ({
+  count: 0,
+  items: [],
+  increment: () => set((s) => ({ count: s.count + 1 })),
+  addItem: (item) => set((s) => ({ items: [...s.items, item] })),
+  reset: () => set({ count: 0, items: [] }),
+}))
+```
+
+---
+
+## `cn()` utility for conditional classes
+
+```typescript
+import { cn } from '@/lib/utils'   // combines clsx + tailwind-merge
+
+// Basic usage
+className={cn('base-class', conditionalClass && 'applied-if-truthy')}
+
+// With variants
+className={cn(
+  'flex items-center',
+  isActive && 'bg-primary text-primary-foreground',
+  isDisabled && 'opacity-50 pointer-events-none',
+  className,   // always allow override via props
+)}
+
+// tailwind-merge resolves conflicts automatically:
+cn('px-4 px-6')  // → 'px-6' (last wins)
+cn('text-sm', 'text-lg')  // → 'text-lg'
+```
+
+---
+
+## Common import paths
+
+```typescript
+// Types
+import type { Remnant, WorkOrder, BarcodeRecord } from '@/types/api'
+
+// API client
+import { apiClient, ApiClientError } from '@/lib/api/client'
+
+// Domain API functions
+import { remnantsApi } from '@/lib/api/remnants'
+import { cuttingOrdersApi } from '@/lib/api/cutting-orders'
+
+// Hooks
+import { useRemnants, useAllocateRemnant } from '@/lib/hooks/use-remnants'
+import { useRecordCut } from '@/lib/hooks/use-cutting-orders'
+
+// UI components
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+// Kiosk components
+import { BigButton } from '@/components/kiosk/big-button'
+import { ScannerView } from '@/components/kiosk/scanner-view'
+import { LabelPreview } from '@/components/kiosk/label-preview'
+
+// Dashboard components
+import { StatCard } from '@/components/dashboard/stat-card'
+import { AlertBanner } from '@/components/dashboard/alert-banner'
+
+// Utilities
+import { cn } from '@/lib/utils'
+import { toast } from 'sonner'
+```


### PR DESCRIPTION
## Summary
- Add `.codex` scaffold aligned with reference structure (`AGENTS.md`, `agents/`, `config.toml`).
- Mirror all project skills from `.claude/skills` into `.codex/agents` and `.codex/skills`.
- Extend trigger wording in `.codex/AGENTS.md` so Vietnamese prompts like `làm task tiếp theo` and `task tiếp theo` map to the workflow trigger.

## Technical notes
- Added local Codex config at `.codex/config.toml`.
- Copied skill docs as-is to support Codex-side discoverability.

## How to trigger
- Natural prompt: `làm task tiếp theo`
- Equivalent prompts: `task tiếp theo`, `implement issue`, `fix bug`, `add feature`

## Test plan
- [x] Verify `.codex` structure exists
- [x] Verify skills copied from `.claude/skills`
- [x] Verify trigger keywords present in `.codex/AGENTS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)