### PR TITLE
[kiosk] checkpoint scan flow with confirm step (#16)

### DIFF
--- a/src/app/(kiosk)/scan/[checkpoint]/error.tsx
+++ b/src/app/(kiosk)/scan/[checkpoint]/error.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import Link from 'next/link'
+import { BigButton } from '@/components/kiosk/big-button'
+
+export default function CheckpointScanError() {
+  return (
+    <div className="space-y-4 p-4">
+      <p className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-base text-destructive">
+        Không thể tải màn hình quét checkpoint.
+      </p>
+      <Link href="/scan" className="block">
+        <BigButton variant="secondary">Quay lại chọn công đoạn</BigButton>
+      </Link>
+    </div>
+  )
+}

--- a/src/app/(kiosk)/scan/[checkpoint]/loading.tsx
+++ b/src/app/(kiosk)/scan/[checkpoint]/loading.tsx
@@ -1,0 +1,28 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+
+export default function CheckpointScanLoading() {
+  return (
+    <div className="space-y-4 p-4">
+      <Skeleton className="h-8 w-72" />
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-56" />
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Skeleton className="h-64 w-full" />
+          <Skeleton className="h-5 w-48" />
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-52" />
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-12 w-full" />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/(kiosk)/scan/[checkpoint]/page.tsx
+++ b/src/app/(kiosk)/scan/[checkpoint]/page.tsx
@@ -1,0 +1,165 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import { useParams, useRouter } from 'next/navigation'
+import { ArrowLeft } from 'lucide-react'
+import { toast } from 'sonner'
+import { ScannerView } from '@/components/kiosk/scanner-view'
+import { BigButton } from '@/components/kiosk/big-button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { useBarcode } from '@/lib/hooks/use-barcode'
+import { useRecordScan, useScanStore } from '@/lib/hooks/use-scan'
+import { CHECKPOINT_LABEL, getCheckpointBySlug } from '@/lib/checkpoints'
+
+function formatTime(iso: string) {
+  const d = new Date(iso)
+  return d.toLocaleTimeString('vi-VN', { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+}
+
+function normalizeBarcodeId(raw: string): string {
+  const text = raw.trim()
+  if (!text) return ''
+  if (text.startsWith('{') && text.endsWith('}')) {
+    try {
+      const parsed = JSON.parse(text) as Record<string, unknown>
+      const candidate = parsed.id ?? parsed.barcode_id ?? parsed.barcodeId
+      return typeof candidate === 'string' ? candidate.trim() : text
+    } catch {
+      return text
+    }
+  }
+  return text
+}
+
+export default function CheckpointScanPage() {
+  const params = useParams<{ checkpoint: string }>()
+  const router = useRouter()
+  const checkpointInfo = getCheckpointBySlug(params.checkpoint)
+
+  const [scannedBarcodeId, setScannedBarcodeId] = useState<string>('')
+  const history = useScanStore((s) => s.history)
+  const { mutate: recordScan, isPending } = useRecordScan()
+
+  const { data: barcode, isLoading: isLoadingBarcode, isError: barcodeError } = useBarcode(scannedBarcodeId)
+
+  const canConfirm = !!checkpointInfo && !!barcode && !isLoadingBarcode && !isPending
+
+  const historyForCheckpoint = useMemo(() => {
+    if (!checkpointInfo) return []
+    return history.filter((entry) => entry.scanEvent.checkpoint === checkpointInfo.checkpoint)
+  }, [history, checkpointInfo])
+
+  if (!checkpointInfo) {
+    return (
+      <div className="space-y-4 p-4">
+        <p className="text-base text-destructive">Không tìm thấy công đoạn quét.</p>
+        <Button asChild variant="outline" className="min-h-[48px] text-base">
+          <Link href="/scan">Quay lại chọn công đoạn</Link>
+        </Button>
+      </div>
+    )
+  }
+
+  function handleScan(rawCode: string) {
+    const barcodeId = normalizeBarcodeId(rawCode)
+    if (!barcodeId) {
+      toast.error('Mã quét không hợp lệ. Vui lòng thử lại.')
+      return
+    }
+    setScannedBarcodeId(barcodeId)
+  }
+
+  function handleConfirmCheckpoint() {
+    if (!barcode || !checkpointInfo) return
+    recordScan(
+      {
+        barcodeId: barcode.id,
+        checkpoint: checkpointInfo.checkpoint,
+        scannedBy: 'worker',
+      },
+      {
+        onSuccess: () => {
+          setScannedBarcodeId('')
+        },
+      },
+    )
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => router.push('/scan')}
+          className="flex min-h-[48px] min-w-[48px] items-center justify-center rounded-xl border bg-white text-muted-foreground"
+          aria-label="Quay lại"
+        >
+          <ArrowLeft className="size-5" />
+        </button>
+        <div>
+          <h1 className="text-xl font-bold">Quét checkpoint: {checkpointInfo.label}</h1>
+          <p className="text-base text-muted-foreground">Quét QR, kiểm tra thông tin, rồi xác nhận hoàn thành.</p>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Bước 1: Quét QR sản phẩm</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <ScannerView onScan={handleScan} disabled={isPending || isLoadingBarcode} />
+          {isLoadingBarcode && <p className="text-base text-muted-foreground">Đang tải thông tin sản phẩm...</p>}
+          {barcodeError && (
+            <p className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+              Không tìm thấy barcode hoặc barcode không hợp lệ.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Bước 2: Xác nhận checkpoint</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {!barcode ? (
+            <p className="text-base text-muted-foreground">Chưa có barcode được quét.</p>
+          ) : (
+            <div className="space-y-2 rounded-lg border bg-muted/30 p-3">
+              <div className="flex items-center justify-between">
+                <p className="text-base font-semibold">{barcode.sku_code}</p>
+                <Badge variant="secondary" className="text-sm">{CHECKPOINT_LABEL[checkpointInfo.checkpoint]}</Badge>
+              </div>
+              <p className="text-sm text-muted-foreground">{barcode.sku_name}</p>
+              <p className="text-sm text-muted-foreground">Kích thước: {barcode.dimensions}</p>
+              <p className="font-mono text-xs text-muted-foreground">{barcode.id}</p>
+            </div>
+          )}
+
+          <BigButton disabled={!canConfirm} onClick={handleConfirmCheckpoint}>
+            {isPending ? 'Đang xác nhận...' : 'Xác nhận hoàn thành checkpoint'}
+          </BigButton>
+        </CardContent>
+      </Card>
+
+      {historyForCheckpoint.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Lịch sử quét gần đây ({checkpointInfo.label})</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {historyForCheckpoint.map((entry, i) => (
+              <div key={`${entry.scanEvent.id}-${i}`} className="flex items-center justify-between rounded-lg border px-3 py-2">
+                <span className="font-mono text-sm">{entry.barcodeShort}</span>
+                <span className="text-sm text-muted-foreground">{formatTime(entry.scanEvent.scanned_at)}</span>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/src/app/(kiosk)/scan/[checkpoint]/page.tsx
+++ b/src/app/(kiosk)/scan/[checkpoint]/page.tsx
@@ -100,14 +100,14 @@ export default function CheckpointScanPage() {
           <ArrowLeft className="size-5" />
         </button>
         <div>
-          <h1 className="text-xl font-bold">Quét checkpoint: {checkpointInfo.label}</h1>
-          <p className="text-base text-muted-foreground">Quét QR, kiểm tra thông tin, rồi xác nhận hoàn thành.</p>
+          <h1 className="text-xl font-bold">Quét điểm kiểm tra: {checkpointInfo.label}</h1>
+          <p className="text-base text-muted-foreground">Quét mã barcode, kiểm tra thông tin, rồi xác nhận hoàn thành.</p>
         </div>
       </div>
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Bước 1: Quét QR sản phẩm</CardTitle>
+          <CardTitle className="text-base">Bước 1: Quét mã barcode sản phẩm</CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">
           <ScannerView onScan={handleScan} disabled={isPending || isLoadingBarcode} />
@@ -140,7 +140,7 @@ export default function CheckpointScanPage() {
           )}
 
           <BigButton disabled={!canConfirm} onClick={handleConfirmCheckpoint}>
-            {isPending ? 'Đang xác nhận...' : 'Xác nhận hoàn thành checkpoint'}
+            {isPending ? 'Đang xác nhận...' : 'Xác nhận hoàn thành điểm kiểm tra'}
           </BigButton>
         </CardContent>
       </Card>

--- a/src/app/(kiosk)/scan/page.tsx
+++ b/src/app/(kiosk)/scan/page.tsx
@@ -1,124 +1,38 @@
-'use client'
-
-import { useState } from 'react'
-import { toast } from 'sonner'
-import { ScannerView } from '@/components/kiosk/scanner-view'
+import Link from 'next/link'
+import { ArrowRight, QrCode } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
-import { useRecordScan, useScanStore } from '@/lib/hooks/use-scan'
-import type { ScanCheckpoint } from '@/types/api'
-import { cn } from '@/lib/utils'
-
-const CHECKPOINTS: { key: ScanCheckpoint; label: string }[] = [
-  { key: 'CNC_COMPLETE', label: 'Hoàn thành CNC' },
-  { key: 'FINISHED_GOODS', label: 'Hoàn thành gia công' },
-  { key: 'SHIPPED', label: 'Xuất kho' },
-]
-
-function formatTime(iso: string) {
-  const d = new Date(iso)
-  return d.toLocaleTimeString('vi-VN', { hour: '2-digit', minute: '2-digit', second: '2-digit' })
-}
+import { CHECKPOINT_ROUTES } from '@/lib/checkpoints'
 
 export default function ScanPage() {
-  const [selectedCheckpoint, setSelectedCheckpoint] = useState<ScanCheckpoint | null>(null)
-  const { mutate: recordScan, isPending } = useRecordScan()
-  const history = useScanStore((s) => s.history)
-
-  function handleScan(code: string) {
-    if (!selectedCheckpoint) {
-      toast.error('Vui lòng chọn điểm kiểm tra')
-      return
-    }
-    recordScan({
-      barcodeId: code,
-      checkpoint: selectedCheckpoint,
-      scannedBy: 'worker',
-    })
-  }
+  const checkpoints = Object.values(CHECKPOINT_ROUTES)
 
   return (
     <div className="space-y-4 p-4">
       <h1 className="text-xl font-bold">Quét điểm kiểm tra</h1>
+      <p className="text-base text-muted-foreground">
+        Chọn công đoạn để bắt đầu quét và xác nhận hoàn thành.
+      </p>
 
-      {/* Checkpoint selector */}
-      <div>
-        <p className="mb-2 text-base text-muted-foreground">Chọn điểm kiểm tra:</p>
-        <div className="flex flex-wrap gap-2">
-          {CHECKPOINTS.map((cp) => (
-            <button
-              key={cp.key}
-              type="button"
-              onClick={() => setSelectedCheckpoint(cp.key)}
-              className={cn(
-                'min-h-12 rounded-full border px-4 py-2 text-base font-medium transition-colors',
-                selectedCheckpoint === cp.key
-                  ? 'border-primary bg-primary text-primary-foreground'
-                  : 'border-border bg-background hover:bg-muted',
-              )}
-            >
-              {cp.label}
-            </button>
-          ))}
-        </div>
+      <div className="space-y-3">
+        {checkpoints.map((item) => (
+          <Link key={item.checkpoint} href={item.href} className="block">
+            <Card className="transition-colors hover:bg-muted/30">
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center justify-between text-lg">
+                  <span className="flex items-center gap-2">
+                    <QrCode className="size-5" />
+                    {item.label}
+                  </span>
+                  <ArrowRight className="size-5 text-muted-foreground" />
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="pt-0">
+                <p className="text-base text-muted-foreground">{item.description}</p>
+              </CardContent>
+            </Card>
+          </Link>
+        ))}
       </div>
-
-      {/* Scanner */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base">
-            Quét mã QR sản phẩm
-            {selectedCheckpoint && (
-              <Badge variant="secondary" className="text-sm">
-                {CHECKPOINTS.find((c) => c.key === selectedCheckpoint)?.label}
-              </Badge>
-            )}
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <ScannerView
-            onScan={handleScan}
-            disabled={isPending}
-          />
-          {isPending && (
-            <p className="mt-2 text-center text-base text-muted-foreground">Đang xử lý...</p>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* Scan history */}
-      {history.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Lịch sử quét (phiên này)</CardTitle>
-          </CardHeader>
-          <CardContent className="p-0">
-            <table className="w-full text-base">
-              <thead>
-                <tr className="border-b bg-muted/50 text-left text-sm text-muted-foreground">
-                  <th className="px-4 py-2">Mã barcode</th>
-                  <th className="px-4 py-2">Điểm kiểm tra</th>
-                  <th className="px-4 py-2">Thời gian</th>
-                </tr>
-              </thead>
-              <tbody>
-                {history.map((entry, i) => (
-                  <tr key={entry.scanEvent.id ?? i} className="border-b last:border-0">
-                    <td className="px-4 py-3 font-mono text-sm">{entry.barcodeShort}</td>
-                    <td className="px-4 py-3">
-                      {CHECKPOINTS.find((c) => c.key === entry.scanEvent.checkpoint)?.label ??
-                        entry.scanEvent.checkpoint}
-                    </td>
-                    <td className="px-4 py-3 tabular-nums text-muted-foreground">
-                      {formatTime(entry.scanEvent.scanned_at)}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </CardContent>
-        </Card>
-      )}
     </div>
   )
 }

--- a/src/lib/checkpoints.ts
+++ b/src/lib/checkpoints.ts
@@ -1,0 +1,42 @@
+import type { ScanCheckpoint } from '@/types/api'
+
+export type CheckpointSlug = 'cnc' | 'processing' | 'shipping'
+
+export const CHECKPOINT_ROUTES: Record<CheckpointSlug, {
+  checkpoint: ScanCheckpoint
+  label: string
+  description: string
+  href: string
+}> = {
+  cnc: {
+    checkpoint: 'CNC_COMPLETE',
+    label: 'CNC',
+    description: 'Xác nhận hoàn thành công đoạn cắt CNC',
+    href: '/scan/cnc',
+  },
+  processing: {
+    checkpoint: 'FINISHED_GOODS',
+    label: 'Hoàn thiện',
+    description: 'Xác nhận hoàn thành gia công thành phẩm',
+    href: '/scan/processing',
+  },
+  shipping: {
+    checkpoint: 'SHIPPED',
+    label: 'Xuất kho',
+    description: 'Xác nhận bàn giao và xuất kho thành phẩm',
+    href: '/scan/shipping',
+  },
+}
+
+export const CHECKPOINT_LABEL: Record<ScanCheckpoint, string> = {
+  CNC_COMPLETE: 'Hoàn thành CNC',
+  FINISHED_GOODS: 'Hoàn thành gia công',
+  SHIPPED: 'Xuất kho',
+}
+
+export function getCheckpointBySlug(slug: string): (typeof CHECKPOINT_ROUTES)[CheckpointSlug] | null {
+  if (slug in CHECKPOINT_ROUTES) {
+    return CHECKPOINT_ROUTES[slug as CheckpointSlug]
+  }
+  return null
+}

--- a/src/lib/hooks/use-scan.ts
+++ b/src/lib/hooks/use-scan.ts
@@ -1,8 +1,10 @@
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { create } from 'zustand'
 import { toast } from 'sonner'
 import { barcodeApi } from '@/lib/api/barcode'
 import { mapApiErrorVi } from '@/lib/api/client'
+import { BARCODES_KEY, SCAN_EVENTS_KEY } from '@/lib/hooks/use-barcode'
+import { WORK_ORDERS_KEY } from '@/lib/hooks/use-work-orders'
 import type { ScanEvent, ScanCheckpoint } from '@/types/api'
 
 // ── Zustand scan-session store ────────────────────────────────────────────────
@@ -36,6 +38,7 @@ const CHECKPOINT_LABEL: Record<ScanCheckpoint, string> = {
 
 export function useRecordScan() {
   const addEntry = useScanStore((s) => s.addEntry)
+  const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (input: {
@@ -51,6 +54,10 @@ export function useRecordScan() {
         scanEvent,
         barcodeShort: variables.barcodeId.slice(-8),
       })
+      queryClient.invalidateQueries({ queryKey: [SCAN_EVENTS_KEY, variables.barcodeId] })
+      queryClient.invalidateQueries({ queryKey: [BARCODES_KEY, variables.barcodeId] })
+      queryClient.invalidateQueries({ queryKey: [BARCODES_KEY] })
+      queryClient.invalidateQueries({ queryKey: [WORK_ORDERS_KEY] })
     },
 
     onError: (err: unknown) => {


### PR DESCRIPTION
## Summary
- Redesign kiosk scan flow into 3 checkpoint-specific routes: CNC / Hoàn thiện / Xuất kho.
- Add explicit sequence: quét mã barcode -> hiển thị SKU info -> xác nhận hoàn thành điểm kiểm tra.
- Keep session scan history per checkpoint and improve immediate UI freshness by invalidating related barcode/work-order queries after scan.

## Technical notes
- Route group affected: (kiosk), shared hooks
- New files:
  - `src/app/(kiosk)/scan/[checkpoint]/page.tsx`
  - `src/app/(kiosk)/scan/[checkpoint]/loading.tsx`
  - `src/app/(kiosk)/scan/[checkpoint]/error.tsx`
  - `src/lib/checkpoints.ts`
- Updated files:
  - `src/app/(kiosk)/scan/page.tsx`
  - `src/lib/hooks/use-scan.ts`
- Breaking changes: no

## Test plan
- [x] `npx tsc --noEmit` — pass
- [x] `npm run build` — pass
- [x] Scoped ESLint on changed files — pass
- [x] Manual walkthrough on kiosk flow:
  - [x] `/scan` hiển thị 3 công đoạn
  - [x] `/scan/cnc` quét mã -> hiện SKU -> xác nhận checkpoint
  - [x] `/scan/processing` quét mã -> hiện SKU -> xác nhận checkpoint
  - [x] `/scan/shipping` quét mã -> hiện SKU -> xác nhận checkpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #16