### PR TITLE
[dashboard] Add WO consumption input + METAL completion gate

### DIFF
--- a/src/app/(dashboard)/work-orders/[id]/page.tsx
+++ b/src/app/(dashboard)/work-orders/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { use, useState } from 'react'
+import { use, useMemo, useState } from 'react'
 import QRCode from 'react-qr-code'
 import Link from 'next/link'
 import { ArrowLeft, ClipboardCheck, QrCode, Copy, Check, CheckCircle2, Circle, ExternalLink } from 'lucide-react'
@@ -24,10 +24,29 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { useWorkOrder, useWorkOrderConsumptions } from '@/lib/hooks/use-work-orders'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  useAddWorkOrderConsumption,
+  useWorkOrder,
+  useWorkOrderConsumptions,
+} from '@/lib/hooks/use-work-orders'
 import { usePlan } from '@/lib/hooks/use-plans'
+import { useMaterials } from '@/lib/hooks/use-materials'
 import { useGenerateBarcode, useBarcodesForWorkOrder, useBarcodeScanEvents } from '@/lib/hooks/use-barcode'
-import type { WorkOrderStatus, BarcodeRecord, ScanEvent, WorkOrder, ScanCheckpoint } from '@/types/api'
+import type {
+  WorkOrderStatus,
+  BarcodeRecord,
+  ScanEvent,
+  WorkOrder,
+  ScanCheckpoint,
+  MaterialType,
+} from '@/types/api'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -305,12 +324,58 @@ function GenerateBarcodeDialog({ wo, open, onClose }: {
 
 function WorkOrderDetail({ id }: { id: string }) {
   const [showBarcodeDialog, setShowBarcodeDialog] = useState(false)
+  const [materialId, setMaterialId] = useState('')
+  const [quantity, setQuantity] = useState('')
+  const [unit, setUnit] = useState('')
+  const [unitTouched, setUnitTouched] = useState(false)
+
   const { data: wo, isLoading: woLoading, isError: woError } = useWorkOrder(id)
   const {
     data: consumptions,
     isLoading: consumptionsLoading,
     isError: consumptionsError,
   } = useWorkOrderConsumptions(id)
+  const { data: materialsData, isLoading: materialsLoading } = useMaterials({ limit: 200 })
+  const { mutate: addConsumption, isPending: addingConsumption } = useAddWorkOrderConsumption()
+
+  const materials = useMemo(() => materialsData?.items ?? [], [materialsData?.items])
+  const selectedMaterial = useMemo(
+    () => materials.find((material) => material.id === materialId),
+    [materials, materialId],
+  )
+  const canAddConsumption = wo?.status === 'IN_PROCESSING' || wo?.status === 'COMPLETED'
+  const effectiveUnit = unitTouched ? unit : selectedMaterial?.unit ?? unit
+
+  function handleAddConsumption(e: React.FormEvent) {
+    e.preventDefault()
+    if (!wo || !selectedMaterial || !canAddConsumption || addingConsumption) return
+
+    const parsedQuantity = Number(quantity)
+    if (!Number.isFinite(parsedQuantity) || parsedQuantity <= 0) return
+
+    const trimmedUnit = effectiveUnit.trim()
+    if (!trimmedUnit) return
+
+    addConsumption(
+      {
+        workOrderId: wo.id,
+        input: {
+          material_id: selectedMaterial.id,
+          material_type: selectedMaterial.type as MaterialType,
+          quantity: parsedQuantity,
+          unit: trimmedUnit,
+        },
+      },
+      {
+        onSuccess: () => {
+          setMaterialId('')
+          setQuantity('')
+          setUnit('')
+          setUnitTouched(false)
+        },
+      },
+    )
+  }
 
   if (woLoading) {
     return (
@@ -402,6 +467,86 @@ function WorkOrderDetail({ id }: { id: string }) {
       {/* Consumptions */}
       <div>
         <h2 className="mb-3 text-base font-semibold">Vật tư tiêu thụ</h2>
+
+        <div className="mb-3 rounded-lg border p-4">
+          {!canAddConsumption ? (
+            <p className="text-sm text-muted-foreground">
+              Chỉ ghi nhận vật tư khi lệnh ở trạng thái Đang xử lý hoặc Hoàn thành.
+            </p>
+          ) : (
+            <form onSubmit={handleAddConsumption} className="space-y-3">
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+                <div className="space-y-1.5">
+                  <Label htmlFor="material">Vật tư *</Label>
+                  <Select value={materialId} onValueChange={setMaterialId} disabled={materialsLoading || addingConsumption}>
+                    <SelectTrigger id="material" className="h-12">
+                      <SelectValue placeholder={materialsLoading ? 'Đang tải vật tư…' : 'Chọn vật tư'} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {materials.length === 0 && (
+                        <SelectItem value="__none__" disabled>
+                          Chưa có vật tư trong danh mục
+                        </SelectItem>
+                      )}
+                      {materials.map((material) => (
+                        <SelectItem key={material.id} value={material.id}>
+                          {material.name} ({material.type})
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="quantity">Số lượng *</Label>
+                  <Input
+                    id="quantity"
+                    type="number"
+                    min={0.000001}
+                    step="any"
+                    inputMode="decimal"
+                    className="h-12"
+                    value={quantity}
+                    onChange={(e) => setQuantity(e.target.value)}
+                    disabled={addingConsumption}
+                    required
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="unit">Đơn vị *</Label>
+                  <Input
+                    id="unit"
+                    className="h-12"
+                    value={effectiveUnit}
+                    onChange={(e) => {
+                      setUnitTouched(true)
+                      setUnit(e.target.value)
+                    }}
+                    disabled={addingConsumption}
+                    required
+                  />
+                </div>
+              </div>
+
+              <Button
+                type="submit"
+                className="h-12"
+                disabled={
+                  addingConsumption ||
+                  materialsLoading ||
+                  !materialId ||
+                  !effectiveUnit.trim() ||
+                  !quantity.trim() ||
+                  Number(quantity) <= 0
+                }
+              >
+                {addingConsumption ? 'Đang lưu…' : 'Ghi nhận vật tư'}
+              </Button>
+            </form>
+          )}
+        </div>
+
         <div className="rounded-lg border">
           {consumptionsLoading ? (
             <div className="divide-y">
@@ -416,40 +561,42 @@ function WorkOrderDetail({ id }: { id: string }) {
           ) : consumptionsError ? (
             <p className="p-4 text-sm text-destructive">Không thể tải vật tư tiêu thụ.</p>
           ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Loại vật tư</TableHead>
-                  <TableHead>Mã vật tư</TableHead>
-                  <TableHead className="text-right">Số lượng</TableHead>
-                  <TableHead>Đơn vị</TableHead>
-                  <TableHead>Thời gian</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {!consumptions || consumptions.length === 0 ? (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
                   <TableRow>
-                    <TableCell colSpan={5} className="py-8 text-center text-muted-foreground">
-                      Chưa có vật tư nào được ghi nhận.
-                    </TableCell>
+                    <TableHead>Loại vật tư</TableHead>
+                    <TableHead>Mã vật tư</TableHead>
+                    <TableHead className="text-right">Số lượng</TableHead>
+                    <TableHead>Đơn vị</TableHead>
+                    <TableHead>Thời gian</TableHead>
                   </TableRow>
-                ) : (
-                  consumptions.map((c) => (
-                    <TableRow key={c.id}>
-                      <TableCell className="font-medium">{c.material_type}</TableCell>
-                      <TableCell className="font-mono text-xs text-muted-foreground">
-                        {c.material_id.slice(0, 8).toUpperCase()}
-                      </TableCell>
-                      <TableCell className="text-right">{c.quantity}</TableCell>
-                      <TableCell>{c.unit}</TableCell>
-                      <TableCell className="text-sm text-muted-foreground">
-                        {formatDate(c.created_at)}
+                </TableHeader>
+                <TableBody>
+                  {!consumptions || consumptions.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={5} className="py-8 text-center text-muted-foreground">
+                        Chưa có vật tư nào được ghi nhận.
                       </TableCell>
                     </TableRow>
-                  ))
-                )}
-              </TableBody>
-            </Table>
+                  ) : (
+                    consumptions.map((c) => (
+                      <TableRow key={c.id}>
+                        <TableCell className="font-medium">{c.material_type}</TableCell>
+                        <TableCell className="font-mono text-xs text-muted-foreground">
+                          {c.material_id.slice(0, 8).toUpperCase()}
+                        </TableCell>
+                        <TableCell className="text-right">{c.quantity}</TableCell>
+                        <TableCell>{c.unit}</TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {formatDate(c.created_at)}
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </div>
           )}
         </div>
       </div>

--- a/src/app/(dashboard)/work-orders/page.tsx
+++ b/src/app/(dashboard)/work-orders/page.tsx
@@ -25,6 +25,7 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useMaterials } from '@/lib/hooks/use-materials'
+import { useSKU } from '@/lib/hooks/use-skus'
 import {
   Select,
   SelectContent,
@@ -45,6 +46,7 @@ import {
   useWorkOrders,
   useCreateWorkOrder,
   useAdvanceStatus,
+  useWorkOrderConsumptions,
 } from '@/lib/hooks/use-work-orders'
 import { usePlans } from '@/lib/hooks/use-plans'
 import { usePOs } from '@/lib/hooks/use-pos'
@@ -328,9 +330,20 @@ function AdvanceDialog({ wo, onConfirm, onCancel, isPending }: AdvanceDialogProp
   const [selectedMaterialId, setSelectedMaterialId] = useState(wo.material_id ?? NONE)
 
   const isPlannedToInCutting = wo.status === 'PLANNED'
+  const isProcessingToCompleted = wo.status === 'IN_PROCESSING'
 
   const { data: materialsData, isLoading: isLoadingMaterials } = useMaterials({ limit: 200 })
   const materials = materialsData?.items ?? []
+  const { data: sku, isLoading: loadingSku } = useSKU(wo.sku_id)
+  const {
+    data: consumptions,
+    isLoading: loadingConsumptions,
+  } = useWorkOrderConsumptions(isProcessingToCompleted ? wo.id : '')
+
+  const hasMetalConsumption = (consumptions ?? []).some((c) => c.material_type === 'METAL')
+  const requiresMetal = sku?.requires_metal ?? false
+  const blockedByMissingMetal =
+    isProcessingToCompleted && requiresMetal && !hasMetalConsumption
 
   const next = NEXT_STATUS[wo.status]
   if (!next) return null
@@ -387,11 +400,23 @@ function AdvanceDialog({ wo, onConfirm, onCancel, isPending }: AdvanceDialogProp
           </div>
         )}
 
+        {blockedByMissingMetal && !loadingConsumptions && !loadingSku && (
+          <p className="text-sm text-destructive">
+            SKU này yêu cầu vật tư METAL. Cần ghi nhận ít nhất 1 vật tư METAL trước khi hoàn thành.
+          </p>
+        )}
+
         <AlertDialogFooter>
           <AlertDialogCancel onClick={handleCancel}>Hủy</AlertDialogCancel>
           <AlertDialogAction
             onClick={handleConfirm}
-            disabled={isPending || (isPlannedToInCutting && selectedMaterialId === NONE)}
+            disabled={
+              isPending ||
+              loadingSku ||
+              loadingConsumptions ||
+              blockedByMissingMetal ||
+              (isPlannedToInCutting && selectedMaterialId === NONE)
+            }
           >
             {isPending ? 'Đang xử lý…' : 'Xác nhận'}
           </AlertDialogAction>

--- a/src/lib/api/skus.ts
+++ b/src/lib/api/skus.ts
@@ -16,6 +16,9 @@ export const skusApi = {
   create: (input: CreateSKUInput) =>
     apiClient.post<SKU>('/skus', input),
 
+  getById: (skuId: string) =>
+    apiClient.get<SKU>(`/skus/${skuId}`),
+
   getBOM: (skuId: string) =>
     apiClient.get<BOMResponse>(`/skus/${skuId}/bom`),
 

--- a/src/lib/api/work-orders.ts
+++ b/src/lib/api/work-orders.ts
@@ -5,6 +5,7 @@ import type {
   AssignWorkOrderInput,
   SuggestAssignmentResult,
   ConsumptionRecord,
+  AddConsumptionInput,
   PagedResult,
 } from '@/types/api'
 import { apiClient } from './client'
@@ -37,6 +38,10 @@ export const workOrdersApi = {
   /** GET /api/v1/work-orders/:id/consumptions */
   listConsumptions: (id: string) =>
     apiClient.get<ConsumptionRecord[]>(`/work-orders/${id}/consumptions`),
+
+  /** POST /api/v1/work-orders/:id/consumptions */
+  addConsumption: (id: string, input: AddConsumptionInput) =>
+    apiClient.post<ConsumptionRecord>(`/work-orders/${id}/consumptions`, input),
 
   /** POST /api/v1/work-orders/:id/assign */
   assign: (id: string, input: AssignWorkOrderInput) =>

--- a/src/lib/hooks/use-skus.ts
+++ b/src/lib/hooks/use-skus.ts
@@ -24,6 +24,15 @@ export function useCreateSKU() {
   })
 }
 
+export function useSKU(skuId: string | null) {
+  return useQuery({
+    queryKey: [SKUS_KEY, skuId],
+    queryFn: () => skusApi.getById(skuId!),
+    enabled: skuId !== null,
+    staleTime: 30_000,
+  })
+}
+
 export function useSKUBOM(skuId: string | null) {
   return useQuery({
     queryKey: [SKUS_KEY, skuId, BOM_KEY],

--- a/src/lib/hooks/use-work-orders.ts
+++ b/src/lib/hooks/use-work-orders.ts
@@ -1,7 +1,12 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { workOrdersApi, type WorkOrdersFilter } from '@/lib/api/work-orders'
-import type { CreateWOInput, AdvanceStatusInput, AssignWorkOrderInput } from '@/types/api'
+import type {
+  CreateWOInput,
+  AdvanceStatusInput,
+  AssignWorkOrderInput,
+  AddConsumptionInput,
+} from '@/types/api'
 import { mapApiErrorVi } from '@/lib/api/client'
 
 export const WORK_ORDERS_KEY = 'work-orders'
@@ -57,6 +62,28 @@ export function useWorkOrderConsumptions(workOrderId: string) {
     queryKey: [CONSUMPTIONS_KEY, workOrderId],
     queryFn: () => workOrdersApi.listConsumptions(workOrderId),
     enabled: !!workOrderId,
+  })
+}
+
+export function useAddWorkOrderConsumption() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      workOrderId,
+      input,
+    }: {
+      workOrderId: string
+      input: AddConsumptionInput
+    }) => workOrdersApi.addConsumption(workOrderId, input),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: [CONSUMPTIONS_KEY, variables.workOrderId] })
+      queryClient.invalidateQueries({ queryKey: [WORK_ORDERS_KEY, variables.workOrderId] })
+      queryClient.invalidateQueries({ queryKey: [WORK_ORDERS_KEY] })
+      toast.success('Đã ghi nhận vật tư tiêu thụ')
+    },
+    onError: (err) => {
+      toast.error(mapApiErrorVi(err, 'Ghi nhận vật tư tiêu thụ thất bại'))
+    },
   })
 }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -231,6 +231,14 @@ export interface SuggestAssignmentResult {
   in_cutting_count: number
 }
 
+/** POST /api/v1/work-orders/:id/consumptions */
+export interface AddConsumptionInput {
+  material_id: string
+  material_type: MaterialType
+  quantity: number
+  unit: string
+}
+
 /** GET /api/v1/work-orders/:id/consumptions */
 export interface ConsumptionRecord {
   id: string


### PR DESCRIPTION
## Summary
- Add Work Order consumption input flow on dashboard detail page (`POST /work-orders/:id/consumptions`) with DTO/API/hook alignment.
- Add requires_metal guard in advance dialog: block `IN_PROCESSING -> COMPLETED` until at least one `METAL` consumption exists.
- Keep work-order and consumption data fresh via targeted TanStack Query invalidation.

## Technical notes
- New API types added: `AddConsumptionInput` in `src/types/api.ts`.
- New API/hook wiring:
  - `workOrdersApi.addConsumption` in `src/lib/api/work-orders.ts`
  - `useAddWorkOrderConsumption` in `src/lib/hooks/use-work-orders.ts`
- Added SKU detail fetch for gate check:
  - `skusApi.getById` + `useSKU`
- Breaking changes: no.

## Test plan
- [x] `npx tsc --noEmit` — pass
- [ ] `npm run lint` — full repo currently has unrelated pre-existing lint errors
- [x] `npm run build` — pass
- [ ] Manual responsive checks at 375/768/1280
- [ ] Manual flow test: requires_metal gate + consumption add success/error

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)