### PR TITLE
[shared] feat: RBAC action-level + admin read-only

### DIFF
--- a/src/app/(dashboard)/costing/page.tsx
+++ b/src/app/(dashboard)/costing/page.tsx
@@ -35,6 +35,7 @@ import {
 import { useComputeCosting, useCosting, useFinalizeCosting } from '@/lib/hooks/use-costing'
 import { useDebounce } from '@/lib/hooks/use-debounce'
 import { usePageParams } from '@/lib/hooks/use-page-params'
+import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
 import type { CostingRecord } from '@/types/api'
 
 const fmt = (n: number) =>
@@ -57,11 +58,6 @@ const FINALIZED_LABELS: Record<FinalizedFilter, string> = {
   DRAFT: 'Nháp',
 }
 
-function getCurrentRole(): string | null {
-  if (typeof document === 'undefined') return null
-  const match = document.cookie.match(/(?:^|;\s*)auth_role=([^;]+)/)
-  return match ? decodeURIComponent(match[1]) : null
-}
 
 function TableSkeleton({ rows = 8 }: { rows?: number }) {
   return (
@@ -154,8 +150,11 @@ function AdjustmentDialog({
 }
 
 function CostingContent() {
-  const role = useMemo(() => getCurrentRole(), [])
-  const isAccountant = role === 'accountant'
+  const role = useMemo(() => getCurrentRoleFromCookie(), [])
+  const canComputeCosting = can(role, 'compute', 'costing')
+  const canFinalizeCosting = can(role, 'finalize', 'costing')
+  const canAdjustCosting = can(role, 'adjust', 'costing')
+  const canWriteCosting = canComputeCosting || canFinalizeCosting || canAdjustCosting
 
   const { page, search, limit, setPage, setSearch } = usePageParams(10)
 
@@ -335,15 +334,20 @@ function CostingContent() {
                           {formatDate(r.created_at)}
                         </TableCell>
                         <TableCell className="text-right">
-                          {!isAccountant ? (
-                            <span className="text-xs text-muted-foreground">Chỉ kế toán thao tác</span>
+                          {!canWriteCosting ? (
+                            <span className="text-xs text-muted-foreground">Bạn chỉ có quyền xem bảng giá thành.</span>
                           ) : (
                             <div className="flex justify-end gap-2">
                               <Button
                                 type="button"
                                 size="sm"
                                 variant="outline"
-                                disabled={lockByFinalized || rowComputing || rowFinalizing}
+                                disabled={
+                                  !canComputeCosting
+                                  || lockByFinalized
+                                  || rowComputing
+                                  || rowFinalizing
+                                }
                                 onClick={() => handleCompute(r.work_order_id)}
                               >
                                 {rowComputing ? 'Đang tính...' : 'Compute'}
@@ -351,7 +355,12 @@ function CostingContent() {
                               <Button
                                 type="button"
                                 size="sm"
-                                disabled={lockByFinalized || rowComputing || rowFinalizing}
+                                disabled={
+                                  !canFinalizeCosting
+                                  || lockByFinalized
+                                  || rowComputing
+                                  || rowFinalizing
+                                }
                                 onClick={() => handleFinalize(r.work_order_id)}
                               >
                                 {rowFinalizing ? 'Đang chốt...' : 'Finalize'}
@@ -360,7 +369,7 @@ function CostingContent() {
                                 type="button"
                                 size="sm"
                                 variant="secondary"
-                                disabled={!r.finalized}
+                                disabled={!canAdjustCosting || !r.finalized}
                                 onClick={() => openAdjustment(r)}
                               >
                                 Điều chỉnh

--- a/src/app/(dashboard)/cutting-dispatch/page.tsx
+++ b/src/app/(dashboard)/cutting-dispatch/page.tsx
@@ -38,6 +38,7 @@ import {
   useSuggestAssignment,
 } from '@/lib/hooks/use-work-orders'
 import { ApiClientError, mapApiErrorVi } from '@/lib/api/client'
+import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
 import type { WorkOrder, WorkOrderStatus } from '@/types/api'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -233,6 +234,9 @@ function AssignDialog({ wo, suggestedWorkerName, suggestedWorkerUsername, onSugg
 // ── Main content ──────────────────────────────────────────────────────────────
 
 function CuttingDispatchContent() {
+  const role = useMemo(() => getCurrentRoleFromCookie(), [])
+  const canAssignWorkOrder = can(role, 'assign', 'cutting_dispatch')
+
   const [statusFilter, setStatusFilter] = useState<WorkOrderStatus | 'ALL'>('ALL')
   const [assignTarget, setAssignTarget] = useState<WorkOrder | null>(null)
   const [lastSuggestedUserMeta, setLastSuggestedUserMeta] = useState<{
@@ -348,7 +352,7 @@ function CuttingDispatchContent() {
                       {formatDate(wo.created_at)}
                     </TableCell>
                     <TableCell className="text-right">
-                      {(wo.status === 'PLANNED' || wo.status === 'IN_CUTTING') && (
+                      {(wo.status === 'PLANNED' || wo.status === 'IN_CUTTING') && canAssignWorkOrder && (
                         <Button
                           size="sm"
                           variant={wo.assigned_to_name ? 'outline' : 'default'}
@@ -376,16 +380,18 @@ function CuttingDispatchContent() {
         />
       )}
 
-      <AssignDialog
-        wo={assignTarget}
-        suggestedWorkerName={suggestedWorkerName}
-        suggestedWorkerUsername={suggestedWorkerUsername}
-        onSuggestedUserMetaChange={setLastSuggestedUserMeta}
-        onClose={() => {
-          setAssignTarget(null)
-          setLastSuggestedUserMeta(null)
-        }}
-      />
+      {canAssignWorkOrder && (
+        <AssignDialog
+          wo={assignTarget}
+          suggestedWorkerName={suggestedWorkerName}
+          suggestedWorkerUsername={suggestedWorkerUsername}
+          onSuggestedUserMetaChange={setLastSuggestedUserMeta}
+          onClose={() => {
+            setAssignTarget(null)
+            setLastSuggestedUserMeta(null)
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/src/app/(dashboard)/plans/[id]/page.tsx
+++ b/src/app/(dashboard)/plans/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { use, useState } from 'react'
+import { use, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { toast } from 'sonner'
 import { ArrowLeft, ClipboardList } from 'lucide-react'
@@ -29,6 +29,7 @@ import {
 } from '@/components/ui/alert-dialog'
 import { usePlan, useApprovePlan, useCancelPlan } from '@/lib/hooks/use-plans'
 import { useSKUs } from '@/lib/hooks/use-skus'
+import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
 import type { PlanStatus } from '@/types/api'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -68,6 +69,10 @@ export default function PlanDetailPage({
   params: Promise<{ id: string }>
 }) {
   const { id } = use(params)
+  const role = useMemo(() => getCurrentRoleFromCookie(), [])
+  const canApprovePlan = can(role, 'approve', 'plans')
+  const canCancelPlan = can(role, 'cancel', 'plans')
+
   const { data: plan, isLoading, isError } = usePlan(id)
 
   // Load SKUs to resolve code + name for plan items.
@@ -160,12 +165,14 @@ export default function PlanDetailPage({
       </Card>
 
       {/* Action buttons — only for DRAFT */}
-      {plan?.status === 'DRAFT' && (
+      {plan?.status === 'DRAFT' && (canApprovePlan || canCancelPlan) && (
         <div className="flex gap-3">
-          <Button onClick={() => setApproveOpen(true)}>Duyệt kế hoạch</Button>
-          <Button variant="destructive" onClick={() => setCancelOpen(true)}>
-            Hủy kế hoạch
-          </Button>
+          {canApprovePlan && <Button onClick={() => setApproveOpen(true)}>Duyệt kế hoạch</Button>}
+          {canCancelPlan && (
+            <Button variant="destructive" onClick={() => setCancelOpen(true)}>
+              Hủy kế hoạch
+            </Button>
+          )}
         </div>
       )}
 
@@ -222,7 +229,7 @@ export default function PlanDetailPage({
       </Card>
 
       {/* Approve confirm */}
-      <AlertDialog open={approveOpen}>
+      <AlertDialog open={canApprovePlan && approveOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Duyệt kế hoạch sản xuất?</AlertDialogTitle>
@@ -240,7 +247,7 @@ export default function PlanDetailPage({
       </AlertDialog>
 
       {/* Cancel confirm */}
-      <AlertDialog open={cancelOpen}>
+      <AlertDialog open={canCancelPlan && cancelOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Hủy kế hoạch sản xuất?</AlertDialogTitle>

--- a/src/app/(dashboard)/plans/page.tsx
+++ b/src/app/(dashboard)/plans/page.tsx
@@ -50,6 +50,7 @@ import {
 } from '@/lib/hooks/use-plans'
 import { usePOs, usePOLineItems } from '@/lib/hooks/use-pos'
 import { useSKUs } from '@/lib/hooks/use-skus'
+import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
 import type { PlanStatus, ProductionPlan, CreatePlanInput, LineItem } from '@/types/api'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -112,7 +113,7 @@ function CreatePlanDialog({ open, onOpenChange }: CreatePlanDialogProps) {
   const [errors, setErrors] = useState<Record<string, string>>({})
 
   const { data: posData } = usePOs({ limit: 200 })
-  const pos = posData?.items ?? []
+  const pos = useMemo(() => posData?.items ?? [], [posData?.items])
 
   const { data: skusData } = useSKUs({ limit: 500 })
   const skuMap = useMemo(
@@ -376,6 +377,11 @@ function TableSkeleton() {
 // ── Main list content ─────────────────────────────────────────────────────────
 
 function PlansContent() {
+  const role = useMemo(() => getCurrentRoleFromCookie(), [])
+  const canCreatePlan = can(role, 'create', 'plans')
+  const canApprovePlan = can(role, 'approve', 'plans')
+  const canCancelPlan = can(role, 'cancel', 'plans')
+
   const [statusFilter, setStatusFilter] = useState<PlanStatus | 'ALL'>('ALL')
   const [createOpen, setCreateOpen] = useState(false)
   const [approveTarget, setApproveTarget] = useState<ProductionPlan | null>(null)
@@ -440,10 +446,14 @@ function PlansContent() {
           </SelectContent>
         </Select>
 
-        <Button onClick={() => setCreateOpen(true)}>
-          <Plus className="size-4" />
-          Tạo kế hoạch
-        </Button>
+        {canCreatePlan ? (
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="size-4" />
+            Tạo kế hoạch
+          </Button>
+        ) : (
+          <p className="text-xs text-muted-foreground">Bạn chỉ có quyền xem danh sách kế hoạch.</p>
+        )}
       </div>
 
       {/* Table */}
@@ -497,19 +507,23 @@ function PlansContent() {
                         </Button>
                         {plan.status === 'DRAFT' && (
                           <>
-                            <Button
-                              size="sm"
-                              onClick={() => setApproveTarget(plan)}
-                            >
-                              Duyệt
-                            </Button>
-                            <Button
-                              size="sm"
-                              variant="destructive"
-                              onClick={() => setCancelTarget(plan)}
-                            >
-                              Hủy
-                            </Button>
+                            {canApprovePlan && (
+                              <Button
+                                size="sm"
+                                onClick={() => setApproveTarget(plan)}
+                              >
+                                Duyệt
+                              </Button>
+                            )}
+                            {canCancelPlan && (
+                              <Button
+                                size="sm"
+                                variant="destructive"
+                                onClick={() => setCancelTarget(plan)}
+                              >
+                                Hủy
+                              </Button>
+                            )}
                           </>
                         )}
                       </div>
@@ -522,10 +536,10 @@ function PlansContent() {
         )}
       </div>
 
-      <CreatePlanDialog open={createOpen} onOpenChange={setCreateOpen} />
+      {canCreatePlan && <CreatePlanDialog open={createOpen} onOpenChange={setCreateOpen} />}
 
       <ConfirmActionDialog
-        open={approveTarget !== null}
+        open={canApprovePlan && approveTarget !== null}
         title="Duyệt kế hoạch sản xuất?"
         description={`Kế hoạch cho đơn hàng "${approveTarget ? (poMap.get(approveTarget.po_id) ?? approveTarget.po_id.slice(0, 8)) : ''}" sẽ chuyển sang trạng thái Đã duyệt. Hành động này không thể hoàn tác.`}
         actionLabel="Duyệt"
@@ -535,7 +549,7 @@ function PlansContent() {
       />
 
       <ConfirmActionDialog
-        open={cancelTarget !== null}
+        open={canCancelPlan && cancelTarget !== null}
         title="Hủy kế hoạch sản xuất?"
         description={`Kế hoạch cho đơn hàng "${cancelTarget ? (poMap.get(cancelTarget.po_id) ?? cancelTarget.po_id.slice(0, 8)) : ''}" sẽ bị hủy và không thể khôi phục.`}
         actionLabel="Hủy kế hoạch"

--- a/src/app/(dashboard)/pos/page.tsx
+++ b/src/app/(dashboard)/pos/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Suspense, useState } from 'react'
+import { Suspense, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
 import { Plus, Trash2, ShoppingCart } from 'lucide-react'
@@ -30,6 +30,7 @@ import { mapApiErrorVi } from '@/lib/api/client'
 import { usePOs, useCreatePO } from '@/lib/hooks/use-pos'
 import { useSKUs } from '@/lib/hooks/use-skus'
 import { usePageParams } from '@/lib/hooks/use-page-params'
+import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
 import type { CreatePOInput, CreateLineItemInput, SKU } from '@/types/api'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -352,6 +353,9 @@ function CreatePODialog({ open, onOpenChange }: CreatePODialogProps) {
 // ── PO list content ───────────────────────────────────────────────────────────
 
 function POsContent() {
+  const role = useMemo(() => getCurrentRoleFromCookie(), [])
+  const canCreatePO = can(role, 'create', 'pos')
+
   const { page, limit, setPage } = usePageParams(10)
   const [createOpen, setCreateOpen] = useState(false)
   const router = useRouter()
@@ -365,10 +369,14 @@ function POsContent() {
   return (
     <>
       <div className="flex items-center">
-        <Button className="ml-auto" onClick={() => setCreateOpen(true)}>
-          <Plus className="size-4" />
-          Tạo đơn hàng
-        </Button>
+        {canCreatePO ? (
+          <Button className="ml-auto" onClick={() => setCreateOpen(true)}>
+            <Plus className="size-4" />
+            Tạo đơn hàng
+          </Button>
+        ) : (
+          <p className="ml-auto text-xs text-muted-foreground">Bạn chỉ có quyền xem danh sách đơn hàng.</p>
+        )}
       </div>
 
       {isError ? (
@@ -397,7 +405,7 @@ function POsContent() {
                 ) : pos.length === 0 ? (
                   <TableRow>
                     <TableCell colSpan={5} className="h-40 text-center text-muted-foreground">
-                      Chưa có đơn hàng nào. Nhấn "Tạo đơn hàng" để bắt đầu.
+                      Chưa có đơn hàng nào. Nhấn &quot;Tạo đơn hàng&quot; để bắt đầu.
                     </TableCell>
                   </TableRow>
                 ) : (
@@ -439,7 +447,7 @@ function POsContent() {
         />
       )}
 
-      <CreatePODialog open={createOpen} onOpenChange={setCreateOpen} />
+      {canCreatePO && <CreatePODialog open={createOpen} onOpenChange={setCreateOpen} />}
     </>
   )
 }

--- a/src/app/(dashboard)/work-orders/[id]/page.tsx
+++ b/src/app/(dashboard)/work-orders/[id]/page.tsx
@@ -39,6 +39,7 @@ import {
 import { usePlan } from '@/lib/hooks/use-plans'
 import { useMaterials } from '@/lib/hooks/use-materials'
 import { useGenerateBarcode, useBarcodesForWorkOrder, useBarcodeScanEvents } from '@/lib/hooks/use-barcode'
+import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
 import type {
   WorkOrderStatus,
   BarcodeRecord,
@@ -323,6 +324,10 @@ function GenerateBarcodeDialog({ wo, open, onClose }: {
 // ── Detail content ────────────────────────────────────────────────────────────
 
 function WorkOrderDetail({ id }: { id: string }) {
+  const role = useMemo(() => getCurrentRoleFromCookie(), [])
+  const canGenerateBarcode = can(role, 'generate', 'work_orders')
+  const canConsume = can(role, 'consume', 'work_orders')
+
   const [showBarcodeDialog, setShowBarcodeDialog] = useState(false)
   const [materialId, setMaterialId] = useState('')
   const [quantity, setQuantity] = useState('')
@@ -343,7 +348,7 @@ function WorkOrderDetail({ id }: { id: string }) {
     () => materials.find((material) => material.id === materialId),
     [materials, materialId],
   )
-  const canAddConsumption = wo?.status === 'IN_PROCESSING' || wo?.status === 'COMPLETED'
+  const canAddConsumption = canConsume && (wo?.status === 'IN_PROCESSING' || wo?.status === 'COMPLETED')
   const effectiveUnit = unitTouched ? unit : selectedMaterial?.unit ?? unit
 
   function handleAddConsumption(e: React.FormEvent) {
@@ -403,11 +408,13 @@ function WorkOrderDetail({ id }: { id: string }) {
 
   return (
     <div className="space-y-8">
-      <GenerateBarcodeDialog
-        wo={wo}
-        open={showBarcodeDialog}
-        onClose={() => setShowBarcodeDialog(false)}
-      />
+      {canGenerateBarcode && (
+        <GenerateBarcodeDialog
+          wo={wo}
+          open={showBarcodeDialog}
+          onClose={() => setShowBarcodeDialog(false)}
+        />
+      )}
 
       {/* Header card */}
       <div className="rounded-lg border p-6">
@@ -419,14 +426,16 @@ function WorkOrderDetail({ id }: { id: string }) {
             <p className="font-mono text-lg font-bold">{shortId(wo.id)}</p>
           </div>
           <div className="flex items-center gap-2">
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => setShowBarcodeDialog(true)}
-            >
-              <QrCode className="size-4" />
-              Tạo barcode
-            </Button>
+            {canGenerateBarcode && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setShowBarcodeDialog(true)}
+              >
+                <QrCode className="size-4" />
+                Tạo barcode
+              </Button>
+            )}
             <Badge variant="outline" className={STATUS_CLASS[wo.status]}>
               {STATUS_LABEL[wo.status]}
             </Badge>
@@ -469,7 +478,9 @@ function WorkOrderDetail({ id }: { id: string }) {
         <h2 className="mb-3 text-base font-semibold">Vật tư tiêu thụ</h2>
 
         <div className="mb-3 rounded-lg border p-4">
-          {!canAddConsumption ? (
+          {!canConsume ? (
+            <p className="text-sm text-muted-foreground">Bạn chỉ có quyền xem vật tư tiêu thụ.</p>
+          ) : !canAddConsumption ? (
             <p className="text-sm text-muted-foreground">
               Chỉ ghi nhận vật tư khi lệnh ở trạng thái Đang xử lý hoặc Hoàn thành.
             </p>

--- a/src/app/(dashboard)/work-orders/page.tsx
+++ b/src/app/(dashboard)/work-orders/page.tsx
@@ -52,6 +52,7 @@ import { usePlans } from '@/lib/hooks/use-plans'
 import { usePOs } from '@/lib/hooks/use-pos'
 import { usePageParams } from '@/lib/hooks/use-page-params'
 import { DataPagination } from '@/components/ui/data-pagination'
+import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
 import type {
   WorkOrderStatus,
   WorkOrder,
@@ -429,6 +430,10 @@ function AdvanceDialog({ wo, onConfirm, onCancel, isPending }: AdvanceDialogProp
 // ── Main list ─────────────────────────────────────────────────────────────────
 
 function WorkOrdersContent() {
+  const role = useMemo(() => getCurrentRoleFromCookie(), [])
+  const canCreateWorkOrder = can(role, 'create', 'work_orders')
+  const canAdvanceWorkOrder = can(role, 'advance', 'work_orders')
+
   const [statusFilter, setStatusFilter] = useState<WorkOrderStatus | 'ALL'>('ALL')
   const [planFilter, setPlanFilter] = useState<string>('ALL')
   const [createOpen, setCreateOpen] = useState(false)
@@ -514,10 +519,14 @@ function WorkOrdersContent() {
           </Select>
         </div>
 
-        <Button onClick={() => setCreateOpen(true)}>
-          <Plus className="size-4" />
-          Tạo lệnh
-        </Button>
+        {canCreateWorkOrder ? (
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="size-4" />
+            Tạo lệnh
+          </Button>
+        ) : (
+          <p className="text-xs text-muted-foreground">Bạn chỉ có quyền xem danh sách lệnh sản xuất.</p>
+        )}
       </div>
 
       {/* Table */}
@@ -583,7 +592,7 @@ function WorkOrdersContent() {
                           <Button variant="outline" size="sm" asChild>
                             <Link href={`/work-orders/${wo.id}`}>Chi tiết</Link>
                           </Button>
-                          {canAdvance && (
+                          {canAdvance && canAdvanceWorkOrder && (
                             <Button
                               size="sm"
                               variant={wo.status === 'PLANNED' ? 'default' : 'outline'}
@@ -613,9 +622,9 @@ function WorkOrdersContent() {
         />
       )}
 
-      <CreateWODialog open={createOpen} onOpenChange={setCreateOpen} />
+      {canCreateWorkOrder && <CreateWODialog open={createOpen} onOpenChange={setCreateOpen} />}
 
-      {advanceTarget && (
+      {canAdvanceWorkOrder && advanceTarget && (
         <AdvanceDialog
           key={advanceTarget.id}
           wo={advanceTarget}

--- a/src/components/dashboard/side-nav.tsx
+++ b/src/components/dashboard/side-nav.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
+import { useMemo } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 import { LayoutDashboard, Package, DollarSign, Layers, Boxes, ShoppingCart, ClipboardList, ClipboardCheck, Scissors, LogOut, UserCircle } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -9,35 +9,24 @@ import { Separator } from '@/components/ui/separator'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { logout } from '@/lib/hooks/use-auth'
+import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
 
 // Full management nav — visible to admin, accountant, planner, warehouse, cnc_manager
 const MANAGEMENT_NAV = [
-  { href: '/overview',          label: 'Tổng quan',       icon: LayoutDashboard },
-  { href: '/pos',               label: 'Đơn hàng',        icon: ShoppingCart },
-  { href: '/plans',             label: 'Kế hoạch SX',     icon: ClipboardList },
-  { href: '/work-orders',       label: 'Lệnh sản xuất',   icon: ClipboardCheck },
-  { href: '/cutting-dispatch',  label: 'Điều phối cắt',   icon: Scissors },
-  { href: '/remnants',          label: 'Kho tấm lẻ',      icon: Package },
-  { href: '/costing',           label: 'Giá thành',       icon: DollarSign },
-  { href: '/materials',         label: 'Nguyên liệu',     icon: Layers },
-  { href: '/skus',              label: 'Sản phẩm',        icon: Boxes },
-] as const
-
-// CNC Manager nav — cutting dispatch + work orders
-const CNC_MANAGER_NAV = [
-  { href: '/cutting-dispatch', label: 'Điều phối cắt', icon: Scissors },
-  { href: '/work-orders',      label: 'Lệnh sản xuất', icon: ClipboardCheck },
-] as const
-
-// Foreman nav — shop-floor supervisor: only work orders are relevant
-const FOREMAN_NAV = [
-  { href: '/work-orders',  label: 'Lệnh sản xuất', icon: ClipboardCheck },
+  { href: '/overview', label: 'Tổng quan', icon: LayoutDashboard, resource: 'overview' },
+  { href: '/pos', label: 'Đơn hàng', icon: ShoppingCart, resource: 'pos' },
+  { href: '/plans', label: 'Kế hoạch SX', icon: ClipboardList, resource: 'plans' },
+  { href: '/work-orders', label: 'Lệnh sản xuất', icon: ClipboardCheck, resource: 'work_orders' },
+  { href: '/cutting-dispatch', label: 'Điều phối cắt', icon: Scissors, resource: 'cutting_dispatch' },
+  { href: '/remnants', label: 'Kho tấm lẻ', icon: Package, resource: 'remnants' },
+  { href: '/costing', label: 'Giá thành', icon: DollarSign, resource: 'costing' },
+  { href: '/materials', label: 'Nguyên liệu', icon: Layers, resource: 'materials' },
+  { href: '/skus', label: 'Sản phẩm', icon: Boxes, resource: 'skus' },
 ] as const
 
 function navItemsForRole(role: string | null) {
-  if (role === 'foreman') return FOREMAN_NAV
-  if (role === 'cnc_manager') return CNC_MANAGER_NAV
-  return MANAGEMENT_NAV
+  if (!role) return []
+  return MANAGEMENT_NAV.filter((item) => can(role, 'read', item.resource))
 }
 
 const ROLE_LABELS: Record<string, string> = {
@@ -51,12 +40,7 @@ const ROLE_LABELS: Record<string, string> = {
 }
 
 function useCurrentRole(): string | null {
-  const [role, setRole] = useState<string | null>(null)
-  useEffect(() => {
-    const match = document.cookie.match(/(?:^|;\s*)auth_role=([^;]+)/)
-    setRole(match ? decodeURIComponent(match[1]) : null)
-  }, [])
-  return role
+  return useMemo(() => getCurrentRoleFromCookie(), [])
 }
 
 export function SideNav() {

--- a/src/components/kiosk/bottom-nav.tsx
+++ b/src/components/kiosk/bottom-nav.tsx
@@ -4,22 +4,25 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { Scissors, ClipboardList, Package, User, QrCode } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
 
 // cnc is the only kiosk role — all items are visible to every kiosk user.
 const NAV_ITEMS = [
-  { href: '/cutting-orders', label: 'Lệnh cắt',    icon: Scissors },
-  { href: '/report-cut',     label: 'Báo cáo',      icon: ClipboardList },
-  { href: '/scan',           label: 'Quét mã',      icon: QrCode },
-  { href: '/remnant-store',  label: 'Tấm lẻ',      icon: Package },
-  { href: '/account',        label: 'Tài khoản',    icon: User },
+  { href: '/cutting-orders', label: 'Lệnh cắt', icon: Scissors, resource: 'cutting_orders' },
+  { href: '/report-cut', label: 'Báo cáo', icon: ClipboardList, resource: 'report_cut' },
+  { href: '/scan', label: 'Quét mã', icon: QrCode, resource: 'scan' },
+  { href: '/remnant-store', label: 'Tấm lẻ', icon: Package, resource: 'remnant_store' },
+  { href: '/account', label: 'Tài khoản', icon: User, resource: 'account' },
 ] as const
 
 export function BottomNav() {
   const pathname = usePathname()
+  const role = getCurrentRoleFromCookie()
+  const navItems = NAV_ITEMS.filter((item) => can(role, 'read', item.resource))
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 z-20 flex h-20 items-stretch justify-around border-t border-gray-200 bg-white pb-[env(safe-area-inset-bottom)]">
-      {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
+      {navItems.map(({ href, label, icon: Icon }) => {
         const active =
           pathname === href ||
           pathname.startsWith(href + '/') ||

--- a/src/components/kiosk/logout-button.tsx
+++ b/src/components/kiosk/logout-button.tsx
@@ -6,6 +6,7 @@ import { LogOut, UserCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { logout } from '@/lib/hooks/use-auth'
+import { getCurrentRoleFromCookie } from '@/lib/auth/authorization'
 
 const ROLE_LABELS: Record<string, string> = {
   admin: 'Admin',
@@ -18,11 +19,7 @@ const ROLE_LABELS: Record<string, string> = {
 }
 
 function useCurrentRole(): string | null {
-  return useMemo(() => {
-    if (typeof document === 'undefined') return null
-    const match = document.cookie.match(/(?:^|;\s*)auth_role=([^;]+)/)
-    return match ? decodeURIComponent(match[1]) : null
-  }, [])
+  return useMemo(() => getCurrentRoleFromCookie(), [])
 }
 
 export function KioskLogoutButton() {

--- a/src/lib/auth/authorization.ts
+++ b/src/lib/auth/authorization.ts
@@ -1,37 +1,185 @@
-// ── Role groups ──────────────────────────────────────────────────────────────
-//
-// cnc_manager scope is deferred to v2; for now it lands in the dashboard as a
-// management role with no dedicated UI beyond what admin already provides.
-
 export const DASHBOARD_ROLES = ['admin', 'accountant', 'planner', 'warehouse', 'foreman', 'cnc_manager'] as const
 export const KIOSK_ROLES = ['cnc'] as const
 
-// ── Path tables ───────────────────────────────────────────────────────────────
-//
-// IMPORTANT: every route physically inside (dashboard)/ or (kiosk)/ MUST be
-// listed here so the middleware can enforce role-based access correctly.
-// A path missing from both lists is treated as public (no role check).
+export type DashboardRole = (typeof DASHBOARD_ROLES)[number]
+export type KioskRole = (typeof KIOSK_ROLES)[number]
+export type AppRole = DashboardRole | KioskRole
 
-const DASHBOARD_PATHS = ['/overview', '/remnants', '/costing', '/materials', '/skus', '/pos', '/plans', '/work-orders', '/barcodes', '/cutting-dispatch']
-const KIOSK_PATHS = ['/scan', '/cutting-orders', '/report-cut', '/remnant-list', '/remnant-store']
+export type AppResource =
+  | 'overview'
+  | 'remnants'
+  | 'costing'
+  | 'materials'
+  | 'skus'
+  | 'pos'
+  | 'plans'
+  | 'work_orders'
+  | 'barcodes'
+  | 'cutting_dispatch'
+  | 'scan'
+  | 'cutting_orders'
+  | 'report_cut'
+  | 'remnant_list'
+  | 'remnant_store'
+  | 'account'
 
-// ── Default landing page per role ────────────────────────────────────────────
+export type AppAction =
+  | 'read'
+  | 'create'
+  | 'approve'
+  | 'cancel'
+  | 'advance'
+  | 'compute'
+  | 'finalize'
+  | 'adjust'
+  | 'consume'
+  | 'generate'
+  | 'assign'
+
+const DASHBOARD_PATHS = [
+  '/overview',
+  '/remnants',
+  '/costing',
+  '/materials',
+  '/skus',
+  '/pos',
+  '/plans',
+  '/work-orders',
+  '/barcodes',
+  '/cutting-dispatch',
+]
+
+const KIOSK_PATHS = ['/scan', '/cutting-orders', '/report-cut', '/remnant-list', '/remnant-store', '/account']
+
+const RESOURCE_BY_PATH: Array<{ path: string; resource: AppResource }> = [
+  { path: '/overview', resource: 'overview' },
+  { path: '/remnants', resource: 'remnants' },
+  { path: '/costing', resource: 'costing' },
+  { path: '/materials', resource: 'materials' },
+  { path: '/skus', resource: 'skus' },
+  { path: '/pos', resource: 'pos' },
+  { path: '/plans', resource: 'plans' },
+  { path: '/work-orders', resource: 'work_orders' },
+  { path: '/barcodes', resource: 'barcodes' },
+  { path: '/cutting-dispatch', resource: 'cutting_dispatch' },
+  { path: '/scan', resource: 'scan' },
+  { path: '/cutting-orders', resource: 'cutting_orders' },
+  { path: '/report-cut', resource: 'report_cut' },
+  { path: '/remnant-list', resource: 'remnant_list' },
+  { path: '/remnant-store', resource: 'remnant_store' },
+  { path: '/account', resource: 'account' },
+]
+
+const DASHBOARD_RESOURCES: AppResource[] = [
+  'overview',
+  'remnants',
+  'costing',
+  'materials',
+  'skus',
+  'pos',
+  'plans',
+  'work_orders',
+  'barcodes',
+  'cutting_dispatch',
+]
+
+function matchPath(pathname: string, path: string): boolean {
+  return pathname === path || pathname.startsWith(`${path}/`)
+}
+
+function readOnly(resources: readonly AppResource[]): Partial<Record<AppResource, readonly AppAction[]>> {
+  return Object.fromEntries(resources.map((resource) => [resource, ['read'] as const]))
+}
+
+const POLICY: Record<AppRole, Partial<Record<AppResource, readonly AppAction[]>>> = {
+  admin: {
+    ...readOnly(DASHBOARD_RESOURCES),
+  },
+  accountant: {
+    ...readOnly(DASHBOARD_RESOURCES),
+    pos: ['read', 'create'],
+    costing: ['read', 'compute', 'finalize', 'adjust'],
+  },
+  planner: {
+    ...readOnly(DASHBOARD_RESOURCES),
+    plans: ['read', 'create', 'approve', 'cancel'],
+    work_orders: ['read', 'create'],
+  },
+  warehouse: {
+    ...readOnly(DASHBOARD_RESOURCES),
+  },
+  foreman: {
+    work_orders: ['read', 'advance', 'consume', 'generate'],
+    barcodes: ['read'],
+  },
+  cnc_manager: {
+    work_orders: ['read'],
+    cutting_dispatch: ['read', 'assign'],
+  },
+  cnc: {
+    scan: ['read'],
+    cutting_orders: ['read'],
+    report_cut: ['read'],
+    remnant_list: ['read'],
+    remnant_store: ['read'],
+    account: ['read'],
+  },
+}
+
+export function isDashboardRole(role: string): role is DashboardRole {
+  return DASHBOARD_ROLES.includes(role as DashboardRole)
+}
+
+export function isKioskRole(role: string): role is KioskRole {
+  return KIOSK_ROLES.includes(role as KioskRole)
+}
+
+export function isAppRole(role: string): role is AppRole {
+  return isDashboardRole(role) || isKioskRole(role)
+}
+
+export function can(
+  role: string | null | undefined,
+  action: AppAction,
+  resource: AppResource,
+): boolean {
+  if (!role || !isAppRole(role)) return false
+  const allowedActions = POLICY[role][resource]
+  return !!allowedActions?.includes(action)
+}
+
+export function getResourceForPath(pathname: string): AppResource | null {
+  const hit = RESOURCE_BY_PATH.find((entry) => matchPath(pathname, entry.path))
+  return hit?.resource ?? null
+}
 
 export function getDefaultRouteForRole(role: string): string {
   switch (role) {
-    case 'warehouse':   return '/materials'
-    case 'foreman':     return '/work-orders'
-    case 'cnc':         return '/scan'
-    default:            return '/overview'   // admin, accountant, planner, cnc_manager
+    case 'warehouse':
+      return '/materials'
+    case 'foreman':
+      return '/work-orders'
+    case 'cnc_manager':
+      return '/cutting-dispatch'
+    case 'cnc':
+      return '/scan'
+    default:
+      return '/overview'
   }
 }
 
-// ── Path predicates ───────────────────────────────────────────────────────────
+export function getCurrentRoleFromCookie(): AppRole | null {
+  if (typeof document === 'undefined') return null
+  const match = document.cookie.match(/(?:^|;\s*)auth_role=([^;]+)/)
+  if (!match) return null
+  const decoded = decodeURIComponent(match[1])
+  return isAppRole(decoded) ? decoded : null
+}
 
 export function isDashboardPath(pathname: string): boolean {
-  return DASHBOARD_PATHS.some((path) => pathname === path || pathname.startsWith(`${path}/`))
+  return DASHBOARD_PATHS.some((path) => matchPath(pathname, path))
 }
 
 export function isKioskPath(pathname: string): boolean {
-  return KIOSK_PATHS.some((path) => pathname === path || pathname.startsWith(`${path}/`))
+  return KIOSK_PATHS.some((path) => matchPath(pathname, path))
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import {
-  DASHBOARD_ROLES,
-  KIOSK_ROLES,
   getDefaultRouteForRole,
+  getResourceForPath,
+  can,
   isDashboardPath,
   isKioskPath,
 } from '@/lib/auth/authorization'
@@ -39,10 +39,10 @@ export function proxy(request: NextRequest) {
       return response
     }
 
+    const resource = getResourceForPath(pathname)
     if (
-      (isDashboardPath(pathname) &&
-        !DASHBOARD_ROLES.includes(role as (typeof DASHBOARD_ROLES)[number])) ||
-      (isKioskPath(pathname) && !KIOSK_ROLES.includes(role as (typeof KIOSK_ROLES)[number]))
+      (isDashboardPath(pathname) || isKioskPath(pathname))
+      && (!resource || !can(role, 'read', resource))
     ) {
       return NextResponse.redirect(new URL(getDefaultRouteForRole(role), request.url))
     }


### PR DESCRIPTION
## Summary
- Centralized RBAC policy in `authorization.ts` with action-level checks (`can(role, action, resource)`) and per-path resource mapping.
- Updated route guard in `proxy.ts` and dashboard/kiosk navigation visibility to use read permission consistently.
- Enforced write-action guards on PO/Plan/WO/Costing/Cutting Dispatch screens so admin is read-only in management modules.

## Technical notes
- New API types added: no
- New query keys: none
- Breaking changes: no

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint -- src/lib/auth/authorization.ts src/proxy.ts src/components/dashboard/side-nav.tsx src/components/kiosk/bottom-nav.tsx src/components/kiosk/logout-button.tsx "src/app/(dashboard)/pos/page.tsx" "src/app/(dashboard)/plans/page.tsx" "src/app/(dashboard)/plans/[id]/page.tsx" "src/app/(dashboard)/work-orders/page.tsx" "src/app/(dashboard)/work-orders/[id]/page.tsx" "src/app/(dashboard)/costing/page.tsx" "src/app/(dashboard)/cutting-dispatch/page.tsx"` — clean
- [x] `npm run build` — succeeds
- [ ] Renders at 375px / 768px / 1280px without layout issues
- [ ] Loading / error / empty states all render correctly
- [ ] All mutations show success/error toast
- [ ] Tested manually: verify each role only sees allowed actions, and admin is read-only

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)