### PR TITLE
[infra] migrate staging logging to journald

### DIFF
--- a/deploy/staging/docker-compose.fe.staging.yml
+++ b/deploy/staging/docker-compose.fe.staging.yml
@@ -9,10 +9,9 @@ services:
       - "127.0.0.1:3000:3000"
       - "10.8.0.1:3000:3000"
     logging:
-      driver: "json-file"
+      driver: "journald"
       options:
-        max-size: "100m"
-        max-file: "3"
+        tag: "vwms-staging-frontend"
     environment:
       # Next.js server-side proxy: forwards /api/proxy/* → BE
       # Next.js container reaches BE via VPN IP (same server)


### PR DESCRIPTION
## Summary
Switch Docker logging driver from json-file to journald for persistent logs across deployments.

## Business rules impacted
None (Infrastructure change).

## Test plan
[x] Verified on staging server with journalctl.
[x] Verified docker-compose config syntax.