### PR TITLE
[infra] Change SSH port to 2288

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -167,7 +167,7 @@ jobs:
           host:     ${{ secrets.STAGING_HOST }}
           username: root
           password: ${{ secrets.STAGING_SSH_PASSWORD }}
-          port:     22
+          port:     ${{ secrets.STAGING_SSH_PORT }}
           timeout:  180s
           envs:     FULL_IMAGE,GHCR_USER,GHCR_TOKEN
           script: |


### PR DESCRIPTION
Updates the staging workflow to use the STAGING_SSH_PORT secret. Linked to #100.