### PR TITLE
[chore] security: remove hardcoded VPN IP before public repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 #       process.env.BACKEND_URL at runtime. NEXT_PUBLIC_API_URL can then be
 #       set to the relative path '/api/proxy' — environment-agnostic, no
 #       build ARG needed, one image works across all environments.
-ARG BACKEND_URL=http://10.8.0.1:8080
+ARG BACKEND_URL=http://localhost:8080
 ENV BACKEND_URL=$BACKEND_URL
 ARG NEXT_PUBLIC_API_URL=/api/proxy
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL

--- a/deploy/staging/.env.fe.staging.example
+++ b/deploy/staging/.env.fe.staging.example
@@ -1,1 +1,5 @@
-BACKEND_URL=http://10.8.0.1:8080
+# URL của BE reachable từ container Next.js (thường là VPN IP hoặc service name nội bộ)
+BACKEND_URL=http://<IP_VPN_CUA_SERVER>:8080
+
+# IP của interface VPN trên server — dùng để bind port Double Binding
+STAGING_VPN_IP=<IP_VPN_CUA_SERVER>

--- a/deploy/staging/docker-compose.fe.staging.yml
+++ b/deploy/staging/docker-compose.fe.staging.yml
@@ -1,5 +1,7 @@
 # docker-compose.fe.staging.yml
-# Double Binding: localhost & VPN (same pattern as BE)
+# Double Binding: localhost + VPN interface.
+# Set STAGING_VPN_IP and BACKEND_URL in .env.fe.staging to expose over VPN.
+# Defaults to 127.0.0.1 (localhost-only) when STAGING_VPN_IP is not set.
 
 services:
   frontend:
@@ -7,15 +9,15 @@ services:
     restart: unless-stopped
     ports:
       - "127.0.0.1:3000:3000"
-      - "10.8.0.1:3000:3000"
+      - "${STAGING_VPN_IP:-127.0.0.1}:3000:3000"
     logging:
       driver: "journald"
       options:
         tag: "vwms-staging-frontend"
     environment:
       # Next.js server-side proxy: forwards /api/proxy/* → BE
-      # Next.js container reaches BE via VPN IP (same server)
-      BACKEND_URL: ${BACKEND_URL:-http://10.8.0.1:8080}
+      # Set BACKEND_URL to the BE address reachable from this container (e.g. VPN IP or service name)
+      BACKEND_URL: ${BACKEND_URL:-http://localhost:8080}
       NODE_ENV: production
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:3000/ || exit 1"]


### PR DESCRIPTION
## Summary

- **Vấn đề**: Địa chỉ IP VPN nội bộ (`10.8.0.1`) bị hardcode trong `Dockerfile` (build ARG default) và các file staging config, lộ thông tin topology mạng khi repo được public.
- **Giải pháp**: Đổi default ARG về `localhost:8080` và dùng `${STAGING_VPN_IP}` / `${BACKEND_URL}` trong compose file. DevOps tự cấu hình giá trị thực trong `.env.fe.staging` trên server.

## Files thay đổi

| File | Thay đổi |
|---|---|
| `Dockerfile` | `ARG BACKEND_URL` default đổi từ `10.8.0.1:8080` → `localhost:8080` |
| `deploy/staging/docker-compose.fe.staging.yml` | Port binding và `BACKEND_URL` default dùng `${STAGING_VPN_IP:-127.0.0.1}` |
| `deploy/staging/.env.fe.staging.example` | Thêm `STAGING_VPN_IP` placeholder, cập nhật `BACKEND_URL` dùng placeholder |

## Hành động DevOps cần làm sau khi merge

> **Bắt buộc** — CI sẽ build image với `BACKEND_URL=localhost:8080` nếu không pass build ARG. Image đó sẽ bị lỗi proxy trên staging.

### 1. Cập nhật CI/CD pipeline (GitHub Actions)

Trong workflow build FE image, thêm `--build-arg` khi gọi `docker build`:

```yaml
- name: Build and push image
  uses: docker/build-push-action@v6
  with:
    build-args: |
      BACKEND_URL=http://${{ secrets.STAGING_VPN_IP }}:8080
```

Hoặc thêm GitHub Actions secret `STAGING_VPN_IP` với giá trị IP VPN thực.

### 2. Cập nhật `.env.fe.staging` trên server

SSH vào staging server và thêm vào `/opt/vwms-staging/.env.fe.staging`:

```bash
# URL của BE reachable từ container Next.js
BACKEND_URL=http://<IP_VPN_THỰC>:8080

# IP VPN để bind port (Double Binding)
STAGING_VPN_IP=<IP_VPN_THỰC>
```

Restart frontend container:

```bash
cd /opt/vwms-staging
docker compose -f docker-compose.fe.staging.yml --env-file .env.fe.staging up -d
```

### Kiểm tra

```bash
# Kiểm tra port binding
docker compose -f docker-compose.fe.staging.yml --env-file .env.fe.staging ps

# Kiểm tra frontend qua VPN
curl -I http://$STAGING_VPN_IP:3000/
```

## Business rules impacted

Không ảnh hưởng business logic — đây là thay đổi cấu hình infrastructure thuần túy.

## Test plan

- [x] `Dockerfile` build với ARG default (`localhost:8080`) không lộ IP nội bộ
- [x] `docker-compose.fe.staging.yml` fallback về `127.0.0.1` khi `STAGING_VPN_IP` unset
- [x] Không còn hardcode IP nào trong code tracked bởi git

🤖 Generated with [Claude Code](https://claude.com/claude-code)