### PR TITLE
[kiosk+dashboard] Scan metadata: actor from JWT, device info #89

### DIFF
--- a/src/app/(dashboard)/barcodes/[id]/scans/page.tsx
+++ b/src/app/(dashboard)/barcodes/[id]/scans/page.tsx
@@ -145,6 +145,12 @@ function CheckpointTimeline({ events }: { events: ScanEvent[] }) {
                   <div className="mt-1 space-y-0.5 text-xs text-muted-foreground">
                     <p>{formatDateTime(event.scanned_at)}</p>
                     <p>Quét bởi: <span className="font-medium text-foreground">{event.scanned_by}</span></p>
+                    {event.device_name && (
+                      <p>Thiết bị: <span className="font-medium text-foreground">{event.device_name}</span></p>
+                    )}
+                    {event.shift && (
+                      <p>Ca: <span className="font-medium text-foreground">{event.shift}</span></p>
+                    )}
                   </div>
                 ) : (
                   <p className="mt-1 text-xs text-muted-foreground">Chưa quét</p>

--- a/src/app/(kiosk)/scan/[checkpoint]/page.tsx
+++ b/src/app/(kiosk)/scan/[checkpoint]/page.tsx
@@ -11,7 +11,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { useBarcode } from '@/lib/hooks/use-barcode'
-import { useRecordScan, useScanStore } from '@/lib/hooks/use-scan'
+import { useRecordScan, useScanStore, getDeviceId, getDeviceName } from '@/lib/hooks/use-scan'
 import { CHECKPOINT_LABEL, getCheckpointBySlug } from '@/lib/checkpoints'
 
 function formatTime(iso: string) {
@@ -49,7 +49,7 @@ export default function CheckpointScanPage() {
 
   const historyForCheckpoint = useMemo(() => {
     if (!checkpointInfo) return []
-    return history.filter((entry) => entry.scanEvent.checkpoint === checkpointInfo.checkpoint)
+    return history.filter((entry) => entry.scanResult.checkpoint === checkpointInfo.checkpoint)
   }, [history, checkpointInfo])
 
   if (!checkpointInfo) {
@@ -78,7 +78,8 @@ export default function CheckpointScanPage() {
       {
         barcodeId: barcode.id,
         checkpoint: checkpointInfo.checkpoint,
-        scannedBy: 'worker',
+        deviceId: getDeviceId(),
+        deviceName: getDeviceName(),
       },
       {
         onSuccess: () => {
@@ -152,9 +153,9 @@ export default function CheckpointScanPage() {
           </CardHeader>
           <CardContent className="space-y-2">
             {historyForCheckpoint.map((entry, i) => (
-              <div key={`${entry.scanEvent.id}-${i}`} className="flex items-center justify-between rounded-lg border px-3 py-2">
+              <div key={`${entry.scanResult.id}-${i}`} className="flex items-center justify-between rounded-lg border px-3 py-2">
                 <span className="font-mono text-sm">{entry.barcodeShort}</span>
-                <span className="text-sm text-muted-foreground">{formatTime(entry.scanEvent.scanned_at)}</span>
+                <span className="text-sm text-muted-foreground">{formatTime(entry.scanResult.scanned_at)}</span>
               </div>
             ))}
           </CardContent>

--- a/src/lib/api/barcode.ts
+++ b/src/lib/api/barcode.ts
@@ -1,5 +1,5 @@
 import { normalizeAuthToken } from '@/lib/auth/token'
-import type { BarcodeRecord, ScanEvent, ScanCheckpoint, GenerateBarcodeInput } from '@/types/api'
+import type { BarcodeRecord, ScanEvent, ScanResult, ScanCheckpoint, GenerateBarcodeInput } from '@/types/api'
 import { ApiClientError, apiClient } from './client'
 
 function buildApiUrl(path: string) {
@@ -23,15 +23,22 @@ export const barcodeApi = {
   listScans: (barcodeId: string) =>
     apiClient.get<ScanEvent[]>(`/barcodes/${barcodeId}/scans`),
 
-  /** POST /api/proxy/barcodes/:id/scans */
+  /** POST /api/proxy/barcodes/:id/scans
+   * scanned_by UUID is extracted server-side from the JWT — do not send it.
+   * Optional device_id, device_name, shift are forwarded for audit metadata.
+   */
   recordScan: (input: {
     barcodeId: string
     checkpoint: ScanCheckpoint
-    scannedBy: string
+    deviceId?: string
+    deviceName?: string
+    shift?: string
   }) =>
-    apiClient.post<ScanEvent>(`/barcodes/${input.barcodeId}/scans`, {
+    apiClient.post<ScanResult>(`/barcodes/${input.barcodeId}/scans`, {
       checkpoint: input.checkpoint,
-      scanned_by: input.scannedBy,
+      ...(input.deviceId ? { device_id: input.deviceId } : {}),
+      ...(input.deviceName ? { device_name: input.deviceName } : {}),
+      ...(input.shift ? { shift: input.shift } : {}),
     }),
 
   getLabelPdfBlob: async (barcodeId: string) => {
@@ -58,3 +65,4 @@ export const barcodeApi = {
     return response.blob()
   },
 }
+

--- a/src/lib/hooks/use-scan.ts
+++ b/src/lib/hooks/use-scan.ts
@@ -5,12 +5,47 @@ import { barcodeApi } from '@/lib/api/barcode'
 import { mapApiErrorVi } from '@/lib/api/client'
 import { BARCODES_KEY, SCAN_EVENTS_KEY } from '@/lib/hooks/use-barcode'
 import { WORK_ORDERS_KEY } from '@/lib/hooks/use-work-orders'
-import type { ScanEvent, ScanCheckpoint } from '@/types/api'
+import type { ScanResult, ScanCheckpoint } from '@/types/api'
+
+// ── Device info helper ────────────────────────────────────────────────────────
+// Reads / generates a stable device ID from localStorage and derives a
+// human-readable device name from the browser UA string.
+
+const DEVICE_ID_KEY = 'scan_device_id'
+
+function generateDeviceId(): string {
+  const id = crypto.randomUUID()
+  try { localStorage.setItem(DEVICE_ID_KEY, id) } catch { /* storage blocked */ }
+  return id
+}
+
+export function getDeviceId(): string {
+  if (typeof window === 'undefined') return ''
+  try {
+    return localStorage.getItem(DEVICE_ID_KEY) ?? generateDeviceId()
+  } catch {
+    return generateDeviceId()
+  }
+}
+
+export function getDeviceName(): string {
+  if (typeof window === 'undefined' || !navigator.userAgent) return 'Unknown'
+  const ua = navigator.userAgent
+  const mobile = /Android|iPhone|iPad|iPod/i.test(ua)
+  const tablet = /iPad/i.test(ua)
+  let browser = 'Browser'
+  if (/Chrome\/\d/i.test(ua) && !/Edg\//i.test(ua)) browser = 'Chrome'
+  else if (/Firefox\/\d/i.test(ua)) browser = 'Firefox'
+  else if (/Safari\/\d/i.test(ua) && !/Chrome/i.test(ua)) browser = 'Safari'
+  else if (/Edg\//i.test(ua)) browser = 'Edge'
+  const form = tablet ? 'Tablet' : mobile ? 'Mobile' : 'Desktop'
+  return `${browser} on ${form}`
+}
 
 // ── Zustand scan-session store ────────────────────────────────────────────────
 
 interface ScanSessionEntry {
-  scanEvent: ScanEvent
+  scanResult: ScanResult
   /** Short display label — last 8 chars of barcode_id */
   barcodeShort: string
 }
@@ -44,14 +79,16 @@ export function useRecordScan() {
     mutationFn: (input: {
       barcodeId: string
       checkpoint: ScanCheckpoint
-      scannedBy: string
+      deviceId?: string
+      deviceName?: string
+      shift?: string
     }) => barcodeApi.recordScan(input),
 
-    onSuccess: (scanEvent, variables) => {
+    onSuccess: (scanResult, variables) => {
       const label = CHECKPOINT_LABEL[variables.checkpoint]
       toast.success(`Đã quét: ${variables.barcodeId.slice(-8)} tại ${label}`)
       addEntry({
-        scanEvent,
+        scanResult,
         barcodeShort: variables.barcodeId.slice(-8),
       })
       queryClient.invalidateQueries({ queryKey: [SCAN_EVENTS_KEY, variables.barcodeId] })

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -355,6 +355,15 @@ export interface ScanEvent {
   checkpoint: ScanCheckpoint
   scanned_by: string
   scanned_at: string
+  /** Optional metadata — omitempty in Go, may be absent in older records */
+  device_id?: string
+  device_name?: string
+  shift?: string
+}
+
+/** Enriched response from POST /api/proxy/barcodes/:id/scans — mirrors backend barcode.ScanResult */
+export interface ScanResult extends ScanEvent {
+  scanned_by_name: string
 }
 
 // ── Dashboard (computed client-side from real API data) ──────────────────────


### PR DESCRIPTION
## Summary
- Bỏ hardcode `scannedBy: 'worker'` — backend đã đọc actor UUID từ JWT token
- Gửi `device_id` (UUID bền vững trong localStorage) và `device_name` (Chrome on Mobile, v.v.)
- Dashboard timeline hiển thị Thiết bị và Ca khi có (backward-compatible với records cũ)
- Route group affected: (kiosk), (dashboard)

## Technical notes
- New API types added: `ScanResult` (extends `ScanEvent` với `scanned_by_name`); optional fields `device_id`, `device_name`, `shift` trong `ScanEvent`
- `barcodeApi.recordScan` nay trả `ScanResult` thay vì `ScanEvent`
- `getDeviceId()` / `getDeviceName()` helpers trong `use-scan.ts`
- New query keys: không
- Breaking changes: không (optional fields, backward-compatible)

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [ ] Kiosk scan page: sau khi quét, không còn `scanned_by: worker` trong payload
- [ ] Dashboard `/barcodes/:id/scans`: rows mới có Thiết bị hiển thị
- [ ] Scan records cũ (không có device_name) vẫn render bình thường

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)