### PR TITLE
[shared] Standardize Vietnamese domain terminology #90

### DIFF
--- a/src/app/(dashboard)/cutting-dispatch/page.tsx
+++ b/src/app/(dashboard)/cutting-dispatch/page.tsx
@@ -298,11 +298,11 @@ function CuttingDispatchContent() {
       {/* Table */}
       <div className={`rounded-lg border transition-opacity ${isFetching && !isLoading ? 'opacity-60' : ''}`}>
         <div className="border-b px-4 py-3 text-sm font-medium text-muted-foreground">
-          {isLoading ? 'Đang tải…' : `Tất cả lệnh sản xuất (${totalItems})`}
+          {isLoading ? 'Đang tải…' : `Tất cả lệnh cắt (${totalItems})`}
         </div>
 
         {isError ? (
-          <p className="p-4 text-sm text-destructive">Không thể tải danh sách lệnh sản xuất.</p>
+          <p className="p-4 text-sm text-destructive">Không thể tải danh sách lệnh cắt.</p>
         ) : (
           <Table>
             <TableHeader>
@@ -321,7 +321,7 @@ function CuttingDispatchContent() {
               ) : workOrders.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={6} className="py-10 text-center text-muted-foreground">
-                    Không có lệnh sản xuất nào.
+                    Không có lệnh cắt nào.
                   </TableCell>
                 </TableRow>
               ) : (

--- a/src/app/(dashboard)/materials/page.tsx
+++ b/src/app/(dashboard)/materials/page.tsx
@@ -114,7 +114,7 @@ function CreateMaterialDialog({ open, onOpenChange }: CreateDialogProps) {
           setErrors({})
         },
         onError: (err) => {
-          toast.error(mapApiErrorVi(err, 'Tạo vật liệu thất bại, thử lại'))
+          toast.error(mapApiErrorVi(err, 'Tạo nguyên liệu thất bại, thử lại'))
         },
       },
     )

--- a/src/app/(dashboard)/remnants/page.tsx
+++ b/src/app/(dashboard)/remnants/page.tsx
@@ -129,7 +129,7 @@ function RemnantsContent() {
                 <TableHead>ID</TableHead>
                 <TableHead>Kích thước (mm)</TableHead>
                 <TableHead>Nguồn gốc</TableHead>
-                <TableHead>Phân bổ cho WO</TableHead>
+                <TableHead>Phân bổ cho lệnh cắt</TableHead>
                 <TableHead>Ngày tạo</TableHead>
                 <TableHead>Trạng thái</TableHead>
               </TableRow>
@@ -157,9 +157,9 @@ function RemnantsContent() {
                     </TableCell>
                     <TableCell className="font-mono text-xs text-muted-foreground">
                       {r.parent_board_id
-                        ? `Board: ${r.parent_board_id.slice(0, 6)}…`
+                        ? `Tấm nguyên: ${r.parent_board_id.slice(0, 6)}…`
                         : r.parent_remnant_id
-                          ? `Remnant: ${r.parent_remnant_id.slice(0, 6)}…`
+                          ? `Tấm lẻ: ${r.parent_remnant_id.slice(0, 6)}…`
                           : '—'}
                     </TableCell>
                     <TableCell className="font-mono text-xs text-muted-foreground">

--- a/src/app/(dashboard)/work-orders/page.tsx
+++ b/src/app/(dashboard)/work-orders/page.tsx
@@ -383,7 +383,7 @@ function CreateWODialog({ open, onOpenChange }: CreateWODialogProps) {
     <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent className="max-w-lg">
         <DialogHeader>
-          <DialogTitle>Tạo lệnh sản xuất mới</DialogTitle>
+          <DialogTitle>Tạo lệnh cắt mới</DialogTitle>
         </DialogHeader>
 
         <div className="space-y-4">
@@ -516,7 +516,7 @@ function AdvanceDialog({ wo, onConfirm, onCancel, isPending }: AdvanceDialogProp
     <AlertDialog open>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Chuyển trạng thái lệnh sản xuất?</AlertDialogTitle>
+          <AlertDialogTitle>Chuyển trạng thái lệnh cắt?</AlertDialogTitle>
           <AlertDialogDescription>
             Lệnh <span className="font-medium">{shortId(wo.id)}</span> sẽ chuyển từ{' '}
             <span className="font-medium">{STATUS_LABEL[wo.status]}</span> sang{' '}
@@ -527,7 +527,7 @@ function AdvanceDialog({ wo, onConfirm, onCancel, isPending }: AdvanceDialogProp
         {/* Material picker — only shown for PLANNED → IN_CUTTING */}
         {isPlannedToInCutting && (
           <div className="space-y-1.5 py-1">
-            <Label>Loại vật liệu *</Label>
+            <Label>Loại nguyên liệu *</Label>
             <Select
               value={selectedMaterialId}
               onValueChange={setSelectedMaterialId}
@@ -536,12 +536,12 @@ function AdvanceDialog({ wo, onConfirm, onCancel, isPending }: AdvanceDialogProp
               <SelectTrigger>
                 <SelectValue
                   placeholder={
-                    isLoadingMaterials ? 'Đang tải vật liệu…' : 'Chọn loại vật liệu'
+                    isLoadingMaterials ? 'Đang tải nguyên liệu…' : 'Chọn loại nguyên liệu'
                   }
                 />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value={NONE}>— Chọn loại vật liệu —</SelectItem>
+                <SelectItem value={NONE}>— Chọn loại nguyên liệu —</SelectItem>
                 {materials.map((material) => (
                   <SelectItem key={material.id} value={material.id}>
                     {material.name} ({material.type})
@@ -550,7 +550,7 @@ function AdvanceDialog({ wo, onConfirm, onCancel, isPending }: AdvanceDialogProp
               </SelectContent>
             </Select>
             <p className="text-xs text-muted-foreground">
-              Công nhân CNC sẽ chọn lô và tấm cụ thể tại kiosk theo loại vật liệu này.
+              Công nhân CNC sẽ chọn lô và tấm cụ thể tại kiosk theo loại nguyên liệu này.
             </p>
           </div>
         )}
@@ -679,23 +679,23 @@ function WorkOrdersContent() {
             Tạo lệnh
           </Button>
         ) : (
-          <p className="text-xs text-muted-foreground">Bạn chỉ có quyền xem danh sách lệnh sản xuất.</p>
+          <p className="text-xs text-muted-foreground">Bạn chỉ có quyền xem danh sách lệnh cắt.</p>
         )}
       </div>
 
       {/* Table */}
       <div className={`rounded-lg border transition-opacity ${isFetching && !isLoading ? 'opacity-60' : ''}`}>
         <div className="border-b px-4 py-3 text-sm font-medium text-muted-foreground">
-          {isLoading ? 'Đang tải…' : `Tất cả lệnh sản xuất (${totalItems})`}
+          {isLoading ? 'Đang tải…' : `Tất cả lệnh cắt (${totalItems})`}
         </div>
 
         {isError ? (
-          <p className="p-4 text-sm text-destructive">Không thể tải danh sách lệnh sản xuất.</p>
+          <p className="p-4 text-sm text-destructive">Không thể tải danh sách lệnh cắt.</p>
         ) : (
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Mã Lệnh SX</TableHead>
+                <TableHead>Mã Lệnh Cắt</TableHead>
                 <TableHead>Sản phẩm</TableHead>
                 <TableHead>Kế hoạch</TableHead>
                 <TableHead>Trạng thái</TableHead>
@@ -710,7 +710,7 @@ function WorkOrdersContent() {
               ) : workOrders.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={7} className="py-10 text-center text-muted-foreground">
-                    Chưa có lệnh sản xuất nào.
+                    Chưa có lệnh cắt nào.
                   </TableCell>
                 </TableRow>
               ) : (

--- a/src/app/(kiosk)/remnant-list/client.tsx
+++ b/src/app/(kiosk)/remnant-list/client.tsx
@@ -71,7 +71,7 @@ function RemnantCard({ remnant: r, location }: RemnantCardProps) {
           {location ? (
             <span className="font-medium">{location.label}</span>
           ) : (
-            <span className="text-muted-foreground italic">Chưa xếp kệ</span>
+            <span className="text-muted-foreground italic">Chưa có vị trí kho</span>
           )}
         </div>
         <span className={`text-xs ${isOld ? 'font-medium text-amber-600' : 'text-muted-foreground'}`}>

--- a/src/components/kiosk/report-cut-form.tsx
+++ b/src/components/kiosk/report-cut-form.tsx
@@ -39,7 +39,7 @@ const API_ERROR_VI: Record<string, string> = {
     'Dữ liệu nhập không hợp lệ. Kiểm tra lại các trường.',
   // domain.ErrNotFound
   ERR_NOT_FOUND:
-    'Không tìm thấy lệnh cắt hoặc tấm nguyên liệu.',
+    'Không tìm thấy lệnh cắt hoặc tấm nguyên.',
 }
 
 function mapApiError(err: unknown): string {
@@ -641,11 +641,11 @@ export function ReportCutForm() {
                 <Controller
                   name="boardSheetId"
                   control={control}
-                  rules={{ required: 'Chọn tấm ván trước khi báo cáo' }}
+                  rules={{ required: 'Chọn tấm nguyên trước khi báo cáo' }}
                   render={({ field }) => (
                     <div className="space-y-1">
                       <Label htmlFor={fid('board-sheet-id')} className="text-base">
-                        Tấm ván trong lô
+                        Tấm nguyên trong lô
                       </Label>
                       <Select
                         value={field.value ?? ''}
@@ -665,15 +665,15 @@ export function ReportCutForm() {
                               !selectedLotId
                                 ? 'Chọn lô trước'
                                 : isLoadingFilteredSheets
-                                  ? 'Đang tải danh sách tấm ván…'
-                                  : 'Chọn tấm ván…'
+                                  ? 'Đang tải danh sách tấm nguyên…'
+                                  : 'Chọn tấm nguyên…'
                             }
                           />
                         </SelectTrigger>
                         <SelectContent>
                           {filteredSheets.length === 0 && !isLoadingFilteredSheets ? (
                             <div className="px-3 py-4 text-center text-base text-muted-foreground">
-                              Không có tấm ván trong lô đã chọn
+                              Không có tấm nguyên trong lô đã chọn
                             </div>
                           ) : (
                             filteredSheets.map((sheet) => (


### PR DESCRIPTION
## Summary
- Đồng bộ thuật ngữ tiếng Việt theo glossary nghiệp vụ trên toàn UI kiosk + dashboard
- Route group affected: (kiosk), (dashboard), shared components

## Thay đổi thuật ngữ

| Trước | Sau | Áp dụng ở |
|---|---|---|
| "lệnh sản xuất" | "lệnh cắt" | cutting-dispatch, work-orders page |
| "Mã Lệnh SX" | "Mã Lệnh Cắt" | work-orders table header |
| "tấm ván" / "tấm nguyên liệu" | "tấm nguyên" | report-cut-form labels, placeholders, validation |
| "vật liệu" | "nguyên liệu" | advance-dialog picker, materials toast |
| `Board: <id>` / `Remnant: <id>` | `Tấm nguyên: <id>` / `Tấm lẻ: <id>` | remnants lineage column |
| "Phân bổ cho WO" | "Phân bổ cho lệnh cắt" | remnants table column header |
| "Chưa xếp kệ" | "Chưa có vị trí kho" | remnant-list kiosk |

## Technical notes
- New API types added: không
- Breaking changes: không — chỉ thay đổi UI text literals
- Không đổi code logic, variable names, hay query keys

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [ ] Dashboard Work Orders: table header "Mã Lệnh Cắt", dialog "Tạo lệnh cắt mới"
- [ ] Dashboard Cutting Dispatch: "Tất cả lệnh cắt (N)"
- [ ] Dashboard Remnants: lineage "Tấm nguyên:…" / "Tấm lẻ:…", header "Phân bổ cho lệnh cắt"
- [ ] Kiosk Report Cut: label "Tấm nguyên trong lô", placeholder "Chọn tấm nguyên…"
- [ ] Kiosk Remnant List: "Chưa có vị trí kho" khi chưa nhập kho

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)