### PR TITLE
[infra] Setup Playwright E2E + smoke tests for kiosk cutting flow #58

### DIFF
--- a/e2e/auth-redirect.spec.ts
+++ b/e2e/auth-redirect.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Auth redirect', () => {
+  test('unauthenticated user accessing kiosk is redirected to /login', async ({ page }) => {
+    // No cookies set — middleware should redirect
+    await page.goto('/cutting-orders')
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test('unauthenticated user accessing dashboard is redirected to /login', async ({ page }) => {
+    await page.goto('/overview')
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test('login page is accessible without auth', async ({ page }) => {
+    await page.goto('/login')
+    await expect(page).toHaveURL('/login')
+    // Should show a login form element
+    await expect(page.getByRole('button', { name: /đăng nhập/i })).toBeVisible()
+  })
+})

--- a/e2e/helpers/api-mocks.ts
+++ b/e2e/helpers/api-mocks.ts
@@ -1,0 +1,101 @@
+import type { Page } from '@playwright/test'
+
+/**
+ * Sets auth_token + auth_role cookies so the middleware lets the page through.
+ * The token is a dummy JWT-shaped string — no signature validation in middleware,
+ * it only checks existence.
+ */
+export async function loginAs(page: Page, role = 'cnc') {
+  await page.context().addCookies([
+    {
+      name: 'auth_token',
+      value: 'e2e.test.token',
+      url: 'http://localhost:3000',
+      httpOnly: false,
+    },
+    {
+      name: 'auth_role',
+      value: role,
+      url: 'http://localhost:3000',
+      httpOnly: false,
+    },
+  ])
+}
+
+/**
+ * Intercepts the work-orders list API with a minimal mock response.
+ */
+export async function mockWorkOrders(page: Page) {
+  await page.route('**/api/proxy/work-orders*', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        items: [
+          {
+            id: 'wo-001',
+            plan_id: 'plan-001',
+            sku_id: 'sku-001',
+            sku_code: 'PLY-1200×600',
+            sku_name: 'Mặt bàn gỗ ép 1200×600',
+            sku_dimensions: { length_mm: 1200, width_mm: 600 },
+            material_type: 'PLYWOOD',
+            material_id: 'mat-001',
+            quantity: 5,
+            status: 'IN_CUTTING',
+            assigned_to_id: null,
+            assigned_to_name: null,
+            created_at: new Date().toISOString(),
+          },
+        ],
+        total_items: 1,
+        total_pages: 1,
+        current_page: 1,
+        limit: 20,
+      }),
+    })
+  })
+}
+
+/**
+ * Intercepts remnant suggestions API.
+ */
+export async function mockRemnantSuggestions(page: Page) {
+  await page.route('**/api/proxy/inventory/remnants/suggestions*', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          remnant: {
+            id: 'rem-001',
+            parent_board_id: 'board-001',
+            parent_remnant_id: null,
+            dimensions: { length_mm: 1300, width_mm: 700 },
+            status: 'AVAILABLE',
+            allocated_to_wo: null,
+            lot_batch: 'SUP-ABC-001',
+            created_at: new Date().toISOString(),
+          },
+          location: { id: 'loc-001', zone: 'A', rack: '1', shelf: '2', label: 'A-1-2', barcode: 'LOC-A12', isActive: true },
+          rank: 1,
+        },
+      ]),
+    })
+  })
+}
+
+/**
+ * Intercepts the materials list API.
+ */
+export async function mockMaterials(page: Page) {
+  await page.route('**/api/proxy/materials*', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { id: 'mat-001', type: 'PLYWOOD', name: 'Gỗ ép 18mm', unit: 'tấm', created_at: new Date().toISOString() },
+      ]),
+    })
+  })
+}

--- a/e2e/kiosk-cutting-flow.spec.ts
+++ b/e2e/kiosk-cutting-flow.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test'
+import { loginAs, mockWorkOrders, mockRemnantSuggestions } from './helpers/api-mocks'
+
+test.describe('Kiosk cutting flow (smoke)', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'cnc')
+    await mockWorkOrders(page)
+    await mockRemnantSuggestions(page)
+  })
+
+  test('cutting orders list renders work order card', async ({ page }) => {
+    await page.goto('/cutting-orders')
+
+    // SKU code appears on the card
+    await expect(page.getByText('PLY-1200×600')).toBeVisible()
+    // SKU name visible
+    await expect(page.getByText('Mặt bàn gỗ ép 1200×600')).toBeVisible()
+    // Primary action button present
+    await expect(page.getByRole('button', { name: /bắt đầu cắt/i })).toBeVisible()
+  })
+
+  test('tapping "Bắt đầu cắt" opens remnant suggestion modal', async ({ page }) => {
+    await page.goto('/cutting-orders')
+
+    await page.getByRole('button', { name: /bắt đầu cắt/i }).click()
+
+    // Suggestion modal should appear with the mocked remnant
+    await expect(page.getByText('Gợi ý tấm').or(page.getByText('Tấm lẻ gợi ý')).or(page.getByText('A-1-2'))).toBeVisible({ timeout: 5000 })
+  })
+
+  test('viewport is 375px — kiosk baseline', async ({ page }) => {
+    await page.goto('/cutting-orders')
+    const width = page.viewportSize()?.width
+    expect(width).toBe(375)
+  })
+
+  test('loading skeleton shown before data arrives', async ({ page }) => {
+    // Delay the mock response to catch the skeleton
+    await page.route('**/api/proxy/work-orders*', async (route) => {
+      await new Promise((r) => setTimeout(r, 600))
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          items: [],
+          total_items: 0,
+          total_pages: 1,
+          current_page: 1,
+          limit: 20,
+        }),
+      })
+    })
+
+    await page.goto('/cutting-orders')
+
+    // Skeleton present during loading
+    const skeleton = page.locator('.animate-pulse').first()
+    await expect(skeleton).toBeVisible()
+  })
+
+  test('empty state shown when no work orders', async ({ page }) => {
+    // Override with empty response
+    await page.route('**/api/proxy/work-orders*', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          items: [],
+          total_items: 0,
+          total_pages: 0,
+          current_page: 1,
+          limit: 20,
+        }),
+      })
+    })
+
+    await page.goto('/cutting-orders')
+    await expect(page.getByText(/không có lệnh cắt/i)).toBeVisible()
+  })
+})

--- a/e2e/kiosk-navigation.spec.ts
+++ b/e2e/kiosk-navigation.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test'
+import { loginAs, mockWorkOrders } from './helpers/api-mocks'
+
+test.describe('Kiosk navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'cnc')
+    await mockWorkOrders(page)
+  })
+
+  test('bottom nav renders all tabs for cnc role', async ({ page }) => {
+    await page.goto('/cutting-orders')
+    // CNC role tabs: Lệnh cắt, Báo cáo, Quét mã, Tấm lẻ, Tài khoản
+    await expect(page.getByRole('link', { name: 'Lệnh cắt' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Báo cáo' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Quét mã' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Tấm lẻ' })).toBeVisible()
+  })
+
+  test('navigating to Quét mã tab loads scan page', async ({ page }) => {
+    await page.goto('/cutting-orders')
+    await page.getByRole('link', { name: 'Quét mã' }).click()
+    await expect(page).toHaveURL('/scan')
+    await expect(page.getByText('Quét điểm kiểm tra')).toBeVisible()
+  })
+
+  test('navigating to Báo cáo tab loads report-cut page', async ({ page }) => {
+    await page.goto('/cutting-orders')
+    await page.getByRole('link', { name: 'Báo cáo' }).click()
+    await expect(page).toHaveURL('/report-cut')
+  })
+})

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts", "../playwright.config.ts"]
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,7 @@ const eslintConfig = [
   ...nextCoreWebVitals,
   ...storybook.configs['flat/recommended'],
   {
-    ignores: ['storybook-static/**'],
+    ignores: ['storybook-static/**', 'e2e/**', 'playwright.config.ts'],
   },
 ]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^5.1.0",
+        "@playwright/test": "^1.59.1",
         "@storybook/addon-a11y": "^10.3.3",
         "@storybook/addon-docs": "^10.3.3",
         "@storybook/addon-onboarding": "^10.3.3",
@@ -1824,6 +1825,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -7606,7 +7623,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9741,13 +9757,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
-      "dev": true,
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -9760,10 +9776,10 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
-      "dev": true,
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "start": "next start",
     "lint": "eslint . --max-warnings=0",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:debug": "playwright test --debug"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.4",
@@ -35,6 +38,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.1.0",
+    "@playwright/test": "^1.59.1",
     "@storybook/addon-a11y": "^10.3.3",
     "@storybook/addon-docs": "^10.3.3",
     "@storybook/addon-onboarding": "^10.3.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? 'github' : 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    // Kiosk baseline — 375px mobile viewport
+    viewport: { width: 375, height: 812 },
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Pixel 5'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    // Reuse running dev server locally; CI always starts fresh
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,8 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "e2e",
+    "playwright.config.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- Setup Playwright E2E testing infrastructure từ 0 — 11 tests, 3 spec files
- Tất cả tests chạy mà không cần backend (API mocked với `page.route()`)
- Route group affected: infra (ảnh hưởng `(kiosk)` routes)

## Technical notes
- New API types: không
- New query keys: không
- Breaking changes: không
- `@playwright/test` được install thêm vào devDependencies — `playwright` (CLI) đã có nhưng thiếu test library
- e2e/ và playwright.config.ts được exclude khỏi Next.js tsconfig và ESLint để tránh rule conflicts
- Auth được mock qua cookies `auth_token` + `auth_role` (middleware chỉ check sự tồn tại của token)
- API mock pattern: `page.route('**/api/proxy/**', ...)` — match đúng với NEXT_PUBLIC_API_URL=/api/proxy

## Tests (11 total)

| Spec | Tests |
|---|---|
| `auth-redirect.spec.ts` | Unauthenticated kiosk → /login; dashboard → /login; login accessible |
| `kiosk-navigation.spec.ts` | Bottom nav tabs render; navigate Quét mã; navigate Báo cáo |
| `kiosk-cutting-flow.spec.ts` | WO card renders; Bắt đầu cắt opens modal; viewport 375px; skeleton loading; empty state |

## CI note
`playwright.config.ts` dùng `reuseExistingServer: !process.env.CI` — CI luôn khởi động dev server mới. Cần thêm Playwright vào CI workflow (chạy sau khi build pass) — pending PR thêm CI job.

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — succeeds
- [x] `npx playwright test --list` — 11 tests listed
- [ ] `npm run test:e2e` — chạy local sau khi `npm run dev` đang chạy

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)