### PR TITLE
[infra] Component tests + E2E expansion + Storybook play() #59

### DIFF
--- a/e2e/dashboard-work-orders.spec.ts
+++ b/e2e/dashboard-work-orders.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test'
+import { loginAs } from './helpers/api-mocks'
+
+async function mockDashboardWorkOrders(page: import('@playwright/test').Page) {
+  await page.route('**/api/proxy/work-orders*', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        items: [
+          {
+            id: 'wo-001',
+            plan_id: 'plan-001',
+            sku_id: 'sku-001',
+            sku_code: 'PLY-1200×600',
+            sku_name: 'Mặt bàn gỗ ép 1200×600',
+            sku_dimensions: { length_mm: 1200, width_mm: 600 },
+            material_type: 'PLYWOOD',
+            material_id: 'mat-001',
+            quantity: 5,
+            status: 'IN_CUTTING',
+            assigned_to_id: null,
+            assigned_to_name: null,
+            created_at: '2025-01-01T00:00:00Z',
+          },
+          {
+            id: 'wo-002',
+            plan_id: 'plan-001',
+            sku_id: 'sku-002',
+            sku_code: 'PLY-800×400',
+            sku_name: 'Mặt ghế 800×400',
+            sku_dimensions: { length_mm: 800, width_mm: 400 },
+            material_type: 'PLYWOOD',
+            material_id: 'mat-001',
+            quantity: 10,
+            status: 'PLANNED',
+            assigned_to_id: null,
+            assigned_to_name: null,
+            created_at: '2025-01-01T00:00:00Z',
+          },
+        ],
+        total_items: 2,
+        total_pages: 1,
+        current_page: 1,
+        limit: 20,
+      }),
+    })
+  })
+}
+
+test.describe('Dashboard work orders list', () => {
+  test.use({ viewport: { width: 1280, height: 800 } })
+
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'foreman')
+    await mockDashboardWorkOrders(page)
+  })
+
+  test('work orders page renders WO rows from API', async ({ page }) => {
+    await page.goto('/work-orders')
+    await expect(page.getByText('PLY-1200×600')).toBeVisible()
+    await expect(page.getByText('PLY-800×400')).toBeVisible()
+  })
+
+  test('page heading is visible', async ({ page }) => {
+    await page.goto('/work-orders')
+    await expect(page.getByRole('heading', { name: /lệnh sản xuất/i })).toBeVisible()
+  })
+
+  test('side nav shows Lệnh sản xuất link for foreman', async ({ page }) => {
+    await page.goto('/work-orders')
+    await expect(page.getByRole('link', { name: 'Lệnh sản xuất' })).toBeVisible()
+  })
+
+  test('empty state shown when no work orders exist', async ({ page }) => {
+    await page.route('**/api/proxy/work-orders*', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          items: [],
+          total_items: 0,
+          total_pages: 0,
+          current_page: 1,
+          limit: 20,
+        }),
+      })
+    })
+    await page.goto('/work-orders')
+    await expect(page.getByText(/không có lệnh/i).or(page.getByText(/chưa có/i))).toBeVisible({ timeout: 5000 })
+  })
+})

--- a/e2e/kiosk-scan-checkpoint.spec.ts
+++ b/e2e/kiosk-scan-checkpoint.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test'
+import { loginAs } from './helpers/api-mocks'
+
+const BARCODE_ID = 'bc-001'
+
+async function mockBarcodeApi(page: import('@playwright/test').Page) {
+  await page.route(`**/api/proxy/barcodes/${BARCODE_ID}`, (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: BARCODE_ID,
+        work_order_id: 'wo-001',
+        sku_id: 'sku-001',
+        po_id: 'po-001',
+        production_plan_id: 'plan-001',
+        sku_code: 'PLY-1200×600',
+        sku_name: 'Mặt bàn gỗ ép 1200×600',
+        dimensions: '1200×600mm',
+        produced_date: '2025-01-01',
+        created_at: new Date().toISOString(),
+      }),
+    })
+  })
+  await page.route(`**/api/proxy/barcodes/${BARCODE_ID}/scans`, (route) => {
+    route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 'scan-001',
+        barcode_id: BARCODE_ID,
+        checkpoint: 'CNC_COMPLETE',
+        scanned_by: 'device-test',
+        scanned_at: new Date().toISOString(),
+      }),
+    })
+  })
+}
+
+test.describe('Kiosk scan checkpoint', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'cnc')
+  })
+
+  test('scan page lists all 3 checkpoint cards', async ({ page }) => {
+    await page.goto('/scan')
+    await expect(page.getByText('Quét điểm kiểm tra')).toBeVisible()
+    await expect(page.getByText('CNC')).toBeVisible()
+    await expect(page.getByText('Hoàn thiện')).toBeVisible()
+    await expect(page.getByText('Xuất kho')).toBeVisible()
+  })
+
+  test('entering CNC checkpoint page shows scanner UI', async ({ page }) => {
+    await page.goto('/scan/cnc')
+    await expect(page.getByText(/quét: cnc/i)).toBeVisible()
+    // Step 2 card always renders
+    await expect(page.getByText(/bước 2.*xác nhận/i)).toBeVisible()
+    // Confirm button present but disabled (no barcode yet)
+    const btn = page.getByRole('button', { name: /xác nhận hoàn thành/i })
+    await expect(btn).toBeDisabled()
+  })
+
+  test('manual barcode input shows product info card', async ({ page }) => {
+    await mockBarcodeApi(page)
+    await page.goto('/scan/cnc')
+
+    // Camera will fail in headless CI — find manual input
+    const input = page.getByPlaceholder(/nhập mã rồi nhấn enter/i)
+    await input.fill(BARCODE_ID)
+    await input.press('Enter')
+
+    // Product info should appear in the confirmation card
+    await expect(page.getByText('PLY-1200×600')).toBeVisible({ timeout: 5000 })
+    const btn = page.getByRole('button', { name: /xác nhận hoàn thành/i })
+    await expect(btn).toBeEnabled()
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,19 +39,25 @@
         "@storybook/addon-vitest": "^10.3.3",
         "@storybook/nextjs-vite": "^10.3.3",
         "@tailwindcss/postcss": "^4",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@vitejs/plugin-react": "^6.0.1",
         "@vitest/browser-playwright": "^4.1.1",
         "@vitest/coverage-v8": "^4.1.1",
         "eslint": "^9",
         "eslint-config-next": "16.2.1",
         "eslint-plugin-storybook": "^10.3.3",
+        "jsdom": "^29.0.2",
         "playwright": "^1.58.2",
         "storybook": "^10.3.3",
         "tailwindcss": "^4",
         "typescript": "^5",
         "vite": "^8.0.2",
+        "vite-tsconfig-paths": "^6.1.1",
         "vitest": "^4.1.1"
       }
     },
@@ -74,6 +80,57 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -341,6 +398,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@chromatic-com/storybook": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@chromatic-com/storybook/-/storybook-5.1.0.tgz",
@@ -360,6 +430,146 @@
       },
       "peerDependencies": {
         "storybook": "^0.0.0-0 || ^10.1.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -979,6 +1189,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -4578,6 +4806,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@testing-library/user-event": {
       "version": "14.6.1",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
@@ -5373,6 +5629,39 @@
         "win32"
       ]
     },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
+      "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-rc.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitejs/plugin-react/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
+      "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitest/browser": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.1.tgz",
@@ -6004,6 +6293,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -6302,6 +6601,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -6443,6 +6756,20 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -6514,6 +6841,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -6726,6 +7060,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -8011,6 +8358,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -8413,6 +8773,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8672,6 +9039,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -9194,6 +9612,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -9664,6 +10089,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -10401,6 +10839,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -10577,6 +11025,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -11176,6 +11637,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
@@ -11298,6 +11766,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -11319,6 +11807,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -11552,6 +12066,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -11855,7 +12379,7 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/vite-tsconfig-paths": {
+    "node_modules/vite-plugin-storybook-nextjs/node_modules/vite-tsconfig-paths": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
       "integrity": "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==",
@@ -11873,6 +12397,21 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
+      "integrity": "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
       }
     },
     "node_modules/vite/node_modules/fsevents": {
@@ -12026,12 +12565,60 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -12202,6 +12789,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "build-storybook": "storybook build",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:debug": "playwright test --debug"
+    "test:e2e:debug": "playwright test --debug",
+    "test:unit": "vitest run --project unit",
+    "test:unit:watch": "vitest --project unit"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.4",
@@ -45,19 +47,25 @@
     "@storybook/addon-vitest": "^10.3.3",
     "@storybook/nextjs-vite": "^10.3.3",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitejs/plugin-react": "^6.0.1",
     "@vitest/browser-playwright": "^4.1.1",
     "@vitest/coverage-v8": "^4.1.1",
     "eslint": "^9",
     "eslint-config-next": "16.2.1",
     "eslint-plugin-storybook": "^10.3.3",
+    "jsdom": "^29.0.2",
     "playwright": "^1.58.2",
     "storybook": "^10.3.3",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vite": "^8.0.2",
+    "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.1"
   },
   "eslintConfig": {

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/src/components/kiosk/cutting-order-card.test.tsx
+++ b/src/components/kiosk/cutting-order-card.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CuttingOrderCard } from '@/components/kiosk/cutting-order-card'
+import type { WorkOrder } from '@/types/api'
+
+const baseOrder: WorkOrder = {
+  id: 'wo-001',
+  plan_id: 'plan-001',
+  sku_id: 'sku-001',
+  sku_code: 'PLY-1200×600',
+  sku_name: 'Mặt bàn gỗ ép 1200×600',
+  sku_dimensions: { length_mm: 1200, width_mm: 600 },
+  material_type: 'PLYWOOD',
+  material_id: 'mat-001',
+  quantity: 5,
+  status: 'IN_CUTTING',
+  assigned_to_id: null,
+  assigned_to_name: null,
+  created_at: '2025-01-01T00:00:00Z',
+}
+
+describe('CuttingOrderCard', () => {
+  it('renders SKU code and name', () => {
+    render(<CuttingOrderCard order={baseOrder} onStartCutting={vi.fn()} />)
+    expect(screen.getByText('PLY-1200×600')).toBeInTheDocument()
+    expect(screen.getByText('Mặt bàn gỗ ép 1200×600')).toBeInTheDocument()
+  })
+
+  it('renders dimensions and quantity badge', () => {
+    render(<CuttingOrderCard order={baseOrder} onStartCutting={vi.fn()} />)
+    expect(screen.getByText('1200 × 600 mm')).toBeInTheDocument()
+    expect(screen.getByText('SL: 5')).toBeInTheDocument()
+  })
+
+  it('renders material badge for PLYWOOD', () => {
+    render(<CuttingOrderCard order={baseOrder} onStartCutting={vi.fn()} />)
+    expect(screen.getByText('Ván gỗ')).toBeInTheDocument()
+  })
+
+  it('falls back to truncated sku_id when sku_code is absent', () => {
+    const order = { ...baseOrder, sku_code: undefined }
+    render(<CuttingOrderCard order={order} onStartCutting={vi.fn()} />)
+    expect(screen.getByText(/sku-001/)).toBeInTheDocument()
+  })
+
+  it('shows default SKU name when sku_name is absent', () => {
+    const order = { ...baseOrder, sku_name: undefined }
+    render(<CuttingOrderCard order={order} onStartCutting={vi.fn()} />)
+    expect(screen.getByText('Chưa có tên SKU')).toBeInTheDocument()
+  })
+
+  it('does not render material badge when material_type is absent', () => {
+    const order = { ...baseOrder, material_type: undefined }
+    render(<CuttingOrderCard order={order} onStartCutting={vi.fn()} />)
+    expect(screen.queryByText('Ván gỗ')).not.toBeInTheDocument()
+  })
+
+  it('fires onStartCutting with the order when button is clicked', async () => {
+    const user = userEvent.setup()
+    const onStartCutting = vi.fn()
+    render(<CuttingOrderCard order={baseOrder} onStartCutting={onStartCutting} />)
+    await user.click(screen.getByRole('button', { name: /bắt đầu cắt/i }))
+    expect(onStartCutting).toHaveBeenCalledTimes(1)
+    expect(onStartCutting).toHaveBeenCalledWith(baseOrder)
+  })
+})

--- a/src/components/kiosk/remnant-suggestion-modal.tsx
+++ b/src/components/kiosk/remnant-suggestion-modal.tsx
@@ -28,7 +28,7 @@ function fitScoreBg(score: number): string {
 
 // ── SuggestionCard ────────────────────────────────────────────────────────────
 
-interface SuggestionCardProps {
+export interface SuggestionCardProps {
   suggestion: RemnantSuggestion
   requiredDimensions: { length_mm: number; width_mm: number }
   /** True when THIS card's remnant is being allocated. */
@@ -38,7 +38,7 @@ interface SuggestionCardProps {
   onSelect: () => void
 }
 
-function SuggestionCard({ suggestion, requiredDimensions, isAllocating, isAnyAllocating, onSelect }: SuggestionCardProps) {
+export function SuggestionCard({ suggestion, requiredDimensions, isAllocating, isAnyAllocating, onSelect }: SuggestionCardProps) {
   const { remnant, location } = suggestion
   const { length_mm, width_mm } = remnant.dimensions
 

--- a/src/components/kiosk/report-cut-form.test.tsx
+++ b/src/components/kiosk/report-cut-form.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// ── Mock Next.js navigation ───────────────────────────────────────────────────
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn() }),
+  useSearchParams: () => new URLSearchParams('wo_id=wo-001'),
+}))
+
+// ── Mock all heavy domain hooks ───────────────────────────────────────────────
+vi.mock('@/lib/hooks/use-cutting-orders', () => ({
+  useCuttingOrder: () => ({
+    data: {
+      id: 'wo-001',
+      plan_id: 'plan-001',
+      sku_id: 'sku-001',
+      sku_code: 'PLY-1200×600',
+      sku_name: 'Mặt bàn gỗ ép 1200×600',
+      sku_dimensions: { length_mm: 1200, width_mm: 600 },
+      material_type: 'PLYWOOD',
+      material_id: 'mat-001',
+      quantity: 5,
+      status: 'IN_CUTTING',
+      assigned_to_id: null,
+      assigned_to_name: null,
+      created_at: '2025-01-01T00:00:00Z',
+    },
+    isLoading: false,
+    isError: false,
+  }),
+  useRecordCut: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+}))
+
+vi.mock('@/lib/hooks/use-barcode', () => ({
+  useGenerateBarcode: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+  useOpenBarcodeLabelPdf: () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false }),
+  useLabelDownload: () => ({ download: vi.fn(), isPending: false }),
+}))
+
+vi.mock('@/lib/hooks/use-plans', () => ({
+  usePlan: () => ({ data: null, isLoading: false }),
+}))
+
+vi.mock('@/lib/hooks/use-remnants', () => ({
+  useAvailableSheets: () => ({
+    data: { items: [], total_items: 0, total_pages: 0, current_page: 1, limit: 200 },
+    isLoading: false,
+  }),
+  useRemnant: () => ({ data: null, isLoading: false }),
+}))
+
+// ── Import component after mocks ──────────────────────────────────────────────
+import { ReportCutForm } from '@/components/kiosk/report-cut-form'
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+}
+
+describe('ReportCutForm (smoke)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders without crashing and shows SKU code in header', () => {
+    render(<ReportCutForm />, { wrapper })
+    // SKU code appears in the subtitle "PLY-1200×600 · 1200×600 mm"
+    expect(screen.getByText(/PLY-1200×600/)).toBeInTheDocument()
+  })
+
+  it('shows cut dimension input fields', () => {
+    render(<ReportCutForm />, { wrapper })
+    // Form has used + remnant dimension fields, both labelled "Chiều dài/rộng (mm)"
+    expect(screen.getAllByLabelText('Chiều dài (mm)').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByLabelText('Chiều rộng (mm)').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('has a "Báo cáo kết quả" submit button', () => {
+    render(<ReportCutForm />, { wrapper })
+    const submitBtn = screen.getByRole('button', { name: /báo cáo kết quả/i })
+    expect(submitBtn).toBeInTheDocument()
+  })
+})

--- a/src/components/kiosk/suggestion-card.test.tsx
+++ b/src/components/kiosk/suggestion-card.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SuggestionCard } from '@/components/kiosk/remnant-suggestion-modal'
+import type { RemnantSuggestion } from '@/types/api'
+
+function makeSuggestion(overrides: Partial<RemnantSuggestion> = {}): RemnantSuggestion {
+  return {
+    remnant: {
+      id: 'rem-001',
+      parent_board_id: 'board-001',
+      parent_remnant_id: null,
+      dimensions: { length_mm: 1400, width_mm: 800 },
+      status: 'AVAILABLE',
+      allocated_to_wo: null,
+      created_at: '2025-01-01T00:00:00Z',
+    },
+    location: {
+      id: 'loc-001',
+      zone: 'A',
+      rack: '1',
+      shelf: '2',
+      label: 'A-1-2',
+      barcode: 'LOC-A12',
+      isActive: true,
+    },
+    rank: 1,
+    ...overrides,
+  }
+}
+
+const requiredDimensions = { length_mm: 1200, width_mm: 600 }
+
+describe('SuggestionCard', () => {
+  it('renders remnant dimensions', () => {
+    render(
+      <SuggestionCard
+        suggestion={makeSuggestion()}
+        requiredDimensions={requiredDimensions}
+        isAllocating={false}
+        isAnyAllocating={false}
+        onSelect={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('1400 × 800 mm')).toBeInTheDocument()
+  })
+
+  it('renders shelf barcode', () => {
+    render(
+      <SuggestionCard
+        suggestion={makeSuggestion()}
+        requiredDimensions={requiredDimensions}
+        isAllocating={false}
+        isAnyAllocating={false}
+        onSelect={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('LOC-A12')).toBeInTheDocument()
+  })
+
+  it('shows "—" when location is null', () => {
+    render(
+      <SuggestionCard
+        suggestion={makeSuggestion({ location: null })}
+        requiredDimensions={requiredDimensions}
+        isAllocating={false}
+        isAnyAllocating={false}
+        onSelect={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  it('shows fit score badge with correct percent', () => {
+    // required area = 1200*600 = 720000; remnant area = 1400*800 = 1120000
+    // fitScore = 720000/1120000 ≈ 0.643 → 64%
+    render(
+      <SuggestionCard
+        suggestion={makeSuggestion()}
+        requiredDimensions={requiredDimensions}
+        isAllocating={false}
+        isAnyAllocating={false}
+        onSelect={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('64%')).toBeInTheDocument()
+  })
+
+  it('disables button and shows spinner when isAllocating=true', () => {
+    render(
+      <SuggestionCard
+        suggestion={makeSuggestion()}
+        requiredDimensions={requiredDimensions}
+        isAllocating={true}
+        isAnyAllocating={true}
+        onSelect={vi.fn()}
+      />,
+    )
+    const btn = screen.getByRole('button')
+    expect(btn).toBeDisabled()
+  })
+
+  it('disables button when isAnyAllocating=true (sibling card allocating)', () => {
+    render(
+      <SuggestionCard
+        suggestion={makeSuggestion()}
+        requiredDimensions={requiredDimensions}
+        isAllocating={false}
+        isAnyAllocating={true}
+        onSelect={vi.fn()}
+      />,
+    )
+    expect(screen.getByRole('button')).toBeDisabled()
+  })
+
+  it('fires onSelect when clicked', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+    render(
+      <SuggestionCard
+        suggestion={makeSuggestion()}
+        requiredDimensions={requiredDimensions}
+        isAllocating={false}
+        isAnyAllocating={false}
+        onSelect={onSelect}
+      />,
+    )
+    await user.click(screen.getByRole('button'))
+    expect(onSelect).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/stories/Button.stories.ts
+++ b/src/stories/Button.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
-import { fn } from 'storybook/test';
+import { fn, expect, userEvent, within } from 'storybook/test';
 
 import { Button } from './Button';
 
@@ -31,11 +31,21 @@ export const Primary: Story = {
     primary: true,
     label: 'Button',
   },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button');
+    await userEvent.click(button);
+    await expect(args.onClick).toHaveBeenCalled();
+  },
 };
 
 export const Secondary: Story = {
   args: {
     label: 'Button',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button')).toBeInTheDocument();
   },
 };
 

--- a/src/stories/Header.stories.ts
+++ b/src/stories/Header.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
-import { fn } from 'storybook/test';
+import { fn, expect, userEvent, within } from 'storybook/test';
 
 import { Header } from './Header';
 
@@ -29,6 +29,19 @@ export const LoggedIn: Story = {
       name: 'Jane Doe',
     },
   },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const logoutBtn = canvas.getByRole('button', { name: /log out/i });
+    await userEvent.click(logoutBtn);
+    await expect(args.onLogout).toHaveBeenCalled();
+  },
 };
 
-export const LoggedOut: Story = {};
+export const LoggedOut: Story = {
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const loginBtn = canvas.getByRole('button', { name: /log in/i });
+    await userEvent.click(loginBtn);
+    await expect(args.onLogin).toHaveBeenCalled();
+  },
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
 
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 
@@ -10,15 +11,13 @@ import { playwright } from '@vitest/browser-playwright';
 const dirname =
   typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
-// More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
   test: {
     projects: [
+      // ── Storybook interaction tests ────────────────────────────────────────
       {
         extends: true,
         plugins: [
-          // The plugin will run tests for the stories defined in your Storybook config
-          // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
           storybookTest({ configDir: path.join(dirname, '.storybook') }),
         ],
         test: {
@@ -29,6 +28,21 @@ export default defineConfig({
             provider: playwright({}),
             instances: [{ browser: 'chromium' }],
           },
+        },
+      },
+
+      // ── Component unit tests ──────────────────────────────────────────────
+      {
+        plugins: [react()],
+        resolve: {
+          alias: { '@': path.join(dirname, 'src') },
+        },
+        test: {
+          name: 'unit',
+          environment: 'jsdom',
+          globals: true,
+          include: ['src/**/*.test.{ts,tsx}'],
+          setupFiles: ['./src/__tests__/setup.ts'],
         },
       },
     ],


### PR DESCRIPTION
## Summary
- Cài và config `@testing-library/react` với Vitest jsdom project
- 17 component unit tests cho 3 component kiosk critical
- 7 E2E tests mới (scan checkpoint + dashboard WO) → tổng 18 E2E tests
- Storybook `play()` functions cho Button + Header stories
- Route group affected: infra (kiosk + dashboard)

## Technical notes
- New API types: không
- New query keys: không
- Breaking changes: `SuggestionCard` + `SuggestionCardProps` export từ `remnant-suggestion-modal.tsx` (additive)
- `@vitejs/plugin-react` + jsdom install mới; `vite-tsconfig-paths` install nhưng bị thay thế bởi native `resolve.alias` (plugin gây warning với Vite 6)
- Component hooks mocked bằng `vi.mock('@/lib/hooks/...')` — không cần backend hay QueryClient-level interceptor

## Component tests (17 tests)

| File | Tests | Nội dung |
|---|---|---|
| `cutting-order-card.test.tsx` | 7 | Render SKU, material badge, fallbacks, click callback |
| `suggestion-card.test.tsx` | 7 | Fit score 64%, shelf barcode, disabled states, onSelect |
| `report-cut-form.test.tsx` | 3 | Smoke: render với work order, label inputs, submit button |

## E2E expansion (+7 tests, tổng 18)

| Spec | Tests |
|---|---|
| `kiosk-scan-checkpoint.spec.ts` | Checkpoint list, CNC page, manual barcode input → info card + enable confirm |
| `dashboard-work-orders.spec.ts` | WO rows render, heading, side-nav, empty state |

## Storybook
- `Button.stories.ts`: Primary → click spy; Secondary → render check
- `Header.stories.ts`: LoggedIn → logout spy; LoggedOut → login spy

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — succeeds
- [x] `npm run test:unit` — 17/17 passed (3 files)
- [x] `npx playwright test --list` — 18 tests in 5 files
- [x] `npm run test:e2e` — chạy khi dev server đang chạy

Closes #59
<img width="3024" height="1758" alt="image" src="https://github.com/user-attachments/assets/56f21de0-729a-4ed2-b1bb-2b60d6122574" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)