### PR TITLE
[dashboard] fix: grant admin create/manage permissions for PO, Plans, WO #117

### DIFF
--- a/src/lib/auth/authorization.ts
+++ b/src/lib/auth/authorization.ts
@@ -99,6 +99,11 @@ const POLICY: Record<AppRole, Partial<Record<AppResource, readonly AppAction[]>>
   admin: {
     ...readOnly(DASHBOARD_RESOURCES),
     users: ['read', 'create', 'toggle_active'],
+    pos: ['read', 'create'],
+    plans: ['read', 'create', 'approve', 'cancel'],
+    work_orders: ['read', 'create', 'advance', 'assign', 'consume', 'generate'],
+    cutting_dispatch: ['read', 'assign'],
+    costing: ['read', 'compute', 'finalize', 'adjust'],
   },
   accountant: {
     ...readOnly(DASHBOARD_RESOURCES),


### PR DESCRIPTION
## Summary
- **Root cause**: `POLICY.admin` in `authorization.ts` only had `read` on all resources — missing `create`/`approve`/`cancel`/`advance` actions that the backend already grants to admin
- All pages already use `can(role, action, resource)` correctly; only the policy table needed updating
- Route group affected: (dashboard)

## Changes
Single file change — `src/lib/auth/authorization.ts` POLICY.admin:

| Resource | Actions added |
|---|---|
| `pos` | `create` |
| `plans` | `create`, `approve`, `cancel` |
| `work_orders` | `create`, `advance`, `assign`, `consume`, `generate` |
| `cutting_dispatch` | `assign` |
| `costing` | `compute`, `finalize`, `adjust` |

## Technical notes
- New API types added: no
- New query keys: no
- Breaking changes: no — only additive, no existing permissions removed

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — succeeds
- [ ] Login as `admin` → `/pos` → "Tạo đơn hàng" button visible and form works end-to-end
- [ ] Login as `admin` → `/plans` → "Tạo kế hoạch" + "Duyệt" / "Hủy" buttons visible
- [ ] Login as `admin` → `/work-orders` → "Tạo lệnh sản xuất" button visible
- [ ] Login as `warehouse` → confirm no new create buttons appear (read-only preserved)
- [ ] Login as `cnc` → kiosk access unchanged

Closes #117