### PR TITLE
[kiosk] ux: add [->] confirm button to manual scan input

### DIFF
--- a/src/components/kiosk/scanner-view.tsx
+++ b/src/components/kiosk/scanner-view.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useId, useRef, useState } from 'react'
 import type { Html5Qrcode } from 'html5-qrcode'
-import { Camera, CameraOff, Keyboard, Lock, ShieldAlert } from 'lucide-react'
+import { ArrowRight, Camera, CameraOff, Keyboard, Lock, ShieldAlert } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -338,11 +338,26 @@ export function ScannerView({ onScan, className, disabled = false, showControls 
                   setManualInput('')
                 }
               }}
-              placeholder="Nhập mã rồi nhấn Enter..."
+              placeholder="Nhập mã..."
               className="h-12 text-base"
               disabled={disabled}
               autoFocus
             />
+            <Button
+              type="button"
+              size="default"
+              className="h-12 shrink-0 px-4"
+              disabled={disabled || !manualInput.trim()}
+              onClick={() => {
+                const normalized = normalizeDecodedText(manualInput)
+                if (!normalized) return
+                onScan(normalized)
+                setManualInput('')
+              }}
+              aria-label="Xác nhận mã"
+            >
+              <ArrowRight className="size-5" />
+            </Button>
           </div>
           <Button
             size="default"


### PR DESCRIPTION
## Summary
- Thêm nút `[->]` (ArrowRight) kế bên ô nhập thủ công trong `ScannerView`
- Thợ CNC không cần bấm Enter trên bàn phím mobile để xác nhận mã quét thủ công
- Nút bị disabled khi input rỗng hoặc scanner đang disabled — không thể submit nhầm
- Giữ lại phím Enter cho người dùng quen dùng keyboard

## Technical notes
- File thay đổi duy nhất: `src/components/kiosk/scanner-view.tsx`
- Tất cả kiosk manual input đều đi qua component này — một chỗ sửa áp dụng toàn bộ flow (remnant-store, scan checkpoint, report-cut)
- Button có `aria-label="Xác nhận mã"` đảm bảo accessibility
- Touch target `h-12` (48px) đúng quy tắc kiosk

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — succeeds
- [x] Mở kiosk trên mobile (375px), vào màn "Nhập kho tấm lẻ" → nhấn "Nhập thủ công"
- [x] Nhập mã → nút `[->]` hiện ra active, bấm → xử lý đúng như Enter
- [ ] Để trống input → nút `[->]` disabled, không thể bấm
- [ ] Phím Enter vẫn hoạt động bình thường