### PR TITLE
[kiosk] fix: resolve KioskLogoutButton hydration mismatch

### DIFF
--- a/src/components/dashboard/side-nav.tsx
+++ b/src/components/dashboard/side-nav.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useMemo } from 'react'
+import { useSyncExternalStore } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 import { LayoutDashboard, Package, DollarSign, Layers, Boxes, ShoppingCart, ClipboardList, ClipboardCheck, Scissors, LogOut, UserCircle, Users } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -41,7 +41,11 @@ const ROLE_LABELS: Record<string, string> = {
 }
 
 function useCurrentRole(): string | null {
-  return useMemo(() => getCurrentRoleFromCookie(), [])
+  return useSyncExternalStore(
+    () => () => {},
+    () => getCurrentRoleFromCookie(),
+    () => null,
+  )
 }
 
 export function SideNav() {

--- a/src/components/kiosk/bottom-nav.tsx
+++ b/src/components/kiosk/bottom-nav.tsx
@@ -1,10 +1,19 @@
 'use client'
 
+import { useSyncExternalStore } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { Scissors, ClipboardList, Package, User, QrCode } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
+
+function useCurrentRole(): string | null {
+  return useSyncExternalStore(
+    () => () => {},
+    () => getCurrentRoleFromCookie(),
+    () => null,
+  )
+}
 
 // cnc is the only kiosk role — all items are visible to every kiosk user.
 const NAV_ITEMS = [
@@ -17,7 +26,7 @@ const NAV_ITEMS = [
 
 export function BottomNav() {
   const pathname = usePathname()
-  const role = getCurrentRoleFromCookie()
+  const role = useCurrentRole()
   const navItems = NAV_ITEMS.filter((item) => can(role, 'read', item.resource))
 
   return (

--- a/src/components/kiosk/logout-button.tsx
+++ b/src/components/kiosk/logout-button.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo } from 'react'
+import { useSyncExternalStore } from 'react'
 import { useRouter } from 'next/navigation'
 import { LogOut, UserCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -18,8 +18,16 @@ const ROLE_LABELS: Record<string, string> = {
   cnc_manager: 'QL CNC',
 }
 
+// useSyncExternalStore is the React-idiomatic way to read a browser-only value
+// (document.cookie) without causing a hydration mismatch.
+// getServerSnapshot returns null so SSR and initial client render agree;
+// getSnapshot reads the actual cookie after hydration completes.
 function useCurrentRole(): string | null {
-  return useMemo(() => getCurrentRoleFromCookie(), [])
+  return useSyncExternalStore(
+    () => () => {},
+    () => getCurrentRoleFromCookie(),
+    () => null,
+  )
 }
 
 export function KioskLogoutButton() {


### PR DESCRIPTION
## Summary
- `KioskLogoutButton` was causing a React hydration mismatch on every page load
- Server rendered only the logout button (role = null, badge skipped); client rendered the role badge too → DOM mismatch → console hydration error

## Root cause
`useCurrentRole` called `useMemo(() => getCurrentRoleFromCookie(), [])`. `getCurrentRoleFromCookie` reads `document.cookie` and guards with `typeof document === 'undefined'` → returns `null` on the server. But `useMemo` runs synchronously during render on the client before hydration completes, reading the real cookie value → server HTML and client render differ.

## Fix
Replace `useMemo` with `useSyncExternalStore`:
- `getServerSnapshot = () => null` → server and initial hydration render agree on null (no badge)
- `getSnapshot = () => getCurrentRoleFromCookie()` → reads the real cookie after hydration
- React performs a clean client-side re-render to show the badge — no hydration error

## Technical notes
- New API types added: no
- New query keys: no
- Breaking changes: no

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx eslint src/components/kiosk/logout-button.tsx --max-warnings=0` — clean
- [x] `npm run build` — succeeds
- [x] Open any kiosk page while logged in — no hydration error in console, role badge renders after mount