### PR TITLE
[kiosk] fix: sort remnant list oldest first (FIFO)

### DIFF
--- a/src/app/(kiosk)/remnant-list/client.tsx
+++ b/src/app/(kiosk)/remnant-list/client.tsx
@@ -235,7 +235,7 @@ export function RemnantListClient() {
     min_length_mm: serverDims.minLength || undefined,
     min_width_mm: serverDims.minWidth || undefined,
     sort_by: 'created_at',
-    order: 'desc',
+    order: 'asc',
     limit: PAGE_SIZE,
   })
 
@@ -252,9 +252,7 @@ export function RemnantListClient() {
     [allItems],
   )
 
-  // Client-side filters: search + quality grade, then sort newest first.
-  // Client-side sort is the source of truth — server sort_by param is a hint
-  // only; backend may not honour it for all fields.
+  // Client-side filters: search + quality grade, then sort oldest first (FIFO).
   const filtered = useMemo(() => {
     const q = filters.search.toLowerCase()
     return allItems
@@ -269,7 +267,7 @@ export function RemnantListClient() {
           `${r.dimensions.width_mm}`.includes(q)
         )
       })
-      .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+      .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
   }, [allItems, filters.search, filters.quality])
 
   const hasActiveFilter =


### PR DESCRIPTION
## Summary
- Sửa lỗi danh sách tồn kho tấm lẻ hiển thị mới nhất lên đầu thay vì cũ nhất
- Route: `(kiosk)/remnant-list`

## Root cause
2 chỗ sort ngược nhau cùng tồn tại trong `client.tsx`:
- Query param `order: 'desc'` gửi lên server → backend sort mới nhất trước
- Client-side `.sort((a, b) => new Date(b) - new Date(a))` → cũng giữ mới nhất đầu

## Changes
- `src/app/(kiosk)/remnant-list/client.tsx`: `order: 'desc'` → `'asc'`; comparator `b - a` → `a - b`

## Technical notes
- New API types added: no
- New query keys: no
- Breaking changes: no

## Test plan
- [ ] `npx tsc --noEmit` — 0 errors
- [ ] `npm run build` — succeeds
- [ ] Trang `/remnant-list` hiển thị tấm lẻ cũ nhất (nhiều ngày nhất) ở đầu danh sách
- [ ] Bộ lọc kích thước và tìm kiếm vẫn hoạt động đúng sau fix

Closes #(liên quan FIFO sort issue)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)