### PR TITLE
[codex] tighten skill automation flow

### DIFF
--- a/.codex/agents/add-api-route/SKILL.md
+++ b/.codex/agents/add-api-route/SKILL.md
@@ -102,7 +102,7 @@ export const myDomainApi = {
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { myDomainApi, type MyEntityFilter } from '@/lib/api/my-domain'
 import type { ApiClientError } from '@/lib/api/client'
-import type { MyEntity } from '@/types/api'
+import type { CreateMyEntityInput, MyEntity } from '@/types/api'
 
 // ── Query key constants ───────────────────────────────────────────────────────
 // Keep keys as constants — prevents typos and helps with invalidation

--- a/.codex/agents/add-shadcn-component/SKILL.md
+++ b/.codex/agents/add-shadcn-component/SKILL.md
@@ -29,7 +29,7 @@ After adding, import from `@/components/ui/<component>`.
 | Style | `new-york` |
 | Base color | `neutral` |
 | CSS variables | `true` (oklch color space) |
-| Icon library | `lucide-react` |
+| Icon library | `lucide` in `components.json` (generates imports from `lucide-react`) |
 | Alias | `@/components/ui` |
 | Utils | `@/lib/utils` (exports `cn`) |
 

--- a/.codex/agents/product-manager/SKILL.md
+++ b/.codex/agents/product-manager/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: product-manager
 description: >
-  Use to analyze the backlog from a user perspective (Kiosk/Dashboard), break down tasks, manage FE issues, and drive next-task triage when the user says "Làm task tiếp theo", "task tiếp theo", "Start next task", or asks Codex to pick an issue from the GitHub Projects Kanban board. In that trigger flow, identify the highest-priority open issue first, then hand the selected issue into the audit and implementation workflow.
+  Use to analyze the backlog from a user perspective (Kiosk/Dashboard), break down tasks, manage FE issues, and drive next-task triage when the user says "Làm task tiếp theo", "task tiếp theo", "Start next task", asks Codex to pick an issue from the GitHub Projects Kanban board, or hands Codex a concrete issue to execute end-to-end. In that trigger flow, identify or confirm the issue first, then hand the selected issue into the audit, implementation, and PR workflow.
 ---
 
 # Product Manager - Frontend Backlog & UX
@@ -38,8 +38,10 @@ For the chosen issue, summarize:
 ### 3. Hand off cleanly
 After selecting the issue, pass control to:
 - `business-auditor` for BR-* mapping
-- `senior-workflow` for requirements-first implementation
+- `senior-workflow` for requirements-first implementation through self-QA and PR
 - `integration-architect` if the issue changes backend contracts
+
+The chosen issue becomes the single execution anchor for the rest of the automation flow. Do not re-triage unless new user input changes scope.
 
 ## FE issue drafting workflow
 

--- a/.codex/agents/senior-workflow-frontend/SKILL.md
+++ b/.codex/agents/senior-workflow-frontend/SKILL.md
@@ -6,7 +6,7 @@ description: >
   technical design → task breakdown → implement → self-QA → PR.
   ALWAYS trigger this skill when the user says "implement", "add feature",
   "build page", "add component", "create hook", "fix", "fix bug", "find root cause",
-  "plan and implement", or pastes a GitHub issue/ticket number.
+  "plan and implement", pastes a GitHub issue/ticket number or URL, or asks Codex to take a selected issue all the way from intake to PR.
   Do NOT skip phases — Phase 5 (Self-QA) is the gate before PR and the phase
   most commonly skipped; skipping it is the #1 source of rework.
 ---
@@ -15,6 +15,12 @@ description: >
 
 Run these 6 phases **in order**. Mark each one done before moving to the next.
 Phase 5 is mandatory — do not open a PR without completing it.
+
+---
+
+## Issue-driven automation rule
+
+When the user provides a concrete issue/ticket/URL or this skill is reached from the next-task automation flow, treat that issue as the single source of truth and run Phases 1 → 6 continuously. Do not stop at implementation if the user expectation is end-to-end delivery; continue into commit/PR preparation after self-QA unless blocked.
 
 ---
 
@@ -293,12 +299,15 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 ```
 
 ### Branch rules
+- If this started from an issue-driven automation flow and you are still on `dev`, create the feature/chore branch from `dev` before the final commit/PR step.
 - Feature branch from `dev`: `git checkout -b feat/area-brief-description dev`
 - Never push directly to `main` or `dev`
 - PR: feature → `dev` (approval optional)
 - `dev` → `main` requires 1 approval
 
 ### PR body template
+Include the issue number/link, touched BR-* rules, and any contract-sync notes when relevant.
+
 ```markdown
 ## Summary
 - What was changed and why

--- a/.codex/agents/senior-workflow/SKILL.md
+++ b/.codex/agents/senior-workflow/SKILL.md
@@ -6,9 +6,9 @@ description: >
   technical design → task breakdown → implement + test → self-QA → PR.
   Always trigger this skill when the user says "implement", "add feature",
   "build page", "add component", "create hook", "fix", "fix bug",
-  "find root cause", pastes a GitHub issue/ticket, or enters the
+  "find root cause", pastes a GitHub issue/ticket/URL, asks Codex to continue a selected issue from intake to PR, or enters the
   "Làm task tiếp theo" / "Start next task" automation flow after issue
-  selection. Start at Phase 1 and never jump straight to coding.
+  selection. Start at Phase 1 and never jump straight to coding or stop before the PR phase unless blocked.
 ---
 
 # Senior Engineer Workflow — Next.js Frontend
@@ -19,13 +19,14 @@ Never skip Phase 5 — it is the gate before PR.
 
 ---
 
-## Automation handoff rule
+## Issue-driven automation rule
 
-When this skill is invoked from `start-next-task`:
+When this skill is invoked from `start-next-task`, or when the user directly provides an issue/ticket/URL and asks Codex to implement it:
 1. Start from the selected issue body and DoD.
 2. Incorporate the `business-auditor` findings before design.
 3. If contract changes are present, schedule `integration-architect` checks before finalizing implementation.
 4. Begin at **Phase 1 — Requirements Clarification**. Do not open files for coding first.
+5. Continue through Phases 1 → 6 in one flow unless a blocker, failed validation, or missing approval forces a stop.
 
 ---
 
@@ -142,7 +143,7 @@ supplier_code: string | null
 ```typescript
 // Read hook — always guard undefined
 const { data, isLoading, error } = useMyEntities(filter)
-const items = data ?? []   // never data.filter() without ?? []
+const items = data?.items ?? []   // never data?.items!.filter(...) without ?? []
 
 // Mutation — always invalidate on success
 useMutation({
@@ -173,7 +174,7 @@ if (items.length === 0) return <EmptyState />   // empty state
 This phase is the gate before PR. Run through **all** of these.
 
 ### Type mismatch checklist (most common bugs)
-- [ ] API returns `PagedResult<T>` but code treats it as `T[]`? → add `.then(res => res.items)`
+- [ ] API returns `PagedResult<T>` but code treats it as `T[]`? → unwrap with `data?.items ?? []` (or return `items` from a specialized hook)
 - [ ] Used `data!.items` without null guard? → change to `data?.items ?? []`
 - [ ] `useRef<HTMLDivElement>(null)` typed as `RefObject<HTMLDivElement>`? → must be `RefObject<HTMLDivElement | null>` in React 19
 - [ ] Hook file has `'use client'` at top unnecessarily? → remove if no browser APIs used
@@ -184,7 +185,7 @@ This phase is the gate before PR. Run through **all** of these.
 - [ ] `any` type anywhere? → replace with `unknown` + narrowing or proper type
 - [ ] `fetch()` called directly instead of `apiClient`? → replace
 - [ ] Same type declared in two places? → consolidate to `src/types/api.ts`
-- [ ] Query key as bare string `"remnants"`? → use exported constant `REMNANT_KEY`
+- [ ] Query key as bare string `"remnants"`? → use the exported domain constant (for example `REMNANTS_KEY`)
 - [ ] Missing `enabled: !!id` on query that depends on a param?
 
 ### Silly bug checklist

--- a/.codex/agents/start-next-task/SKILL.md
+++ b/.codex/agents/start-next-task/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: start-next-task
 description: >
-  Use when the user says "Làm task tiếp theo", "task tiếp theo", "Start next task", asks Codex to pick the next issue, or wants Codex to continue from a GitHub Projects Kanban item. Orchestrate the automation workflow in order: fetch the highest-priority open issue from giangdq202/Vmarble-Warehouse-Management-Service via the product-manager workflow, read the full issue and Definition of Done, run a business-auditor pass against docs/backend-business-logic-vi.md to identify every touched BR-* rule and block if any rule is unclear, then hand off to senior-workflow starting at Phase 1, and invoke integration-architect whenever the task adds or changes an endpoint, a DTO mirrored from iface.go, or a deps.go interface.
+  Use when the user says "Làm task tiếp theo", "task tiếp theo", "Start next task", asks Codex to pick the next issue, wants Codex to continue from a GitHub Projects Kanban item, or wants Codex to take a selected issue from intake all the way to branch/commit/PR. Orchestrate the automation workflow in order: fetch or accept the chosen issue, read the full issue and Definition of Done, run a business-auditor pass against docs/backend-business-logic-vi.md to identify every touched BR-* rule and block if any rule is unclear, then hand off to senior-workflow starting at Phase 1, invoke integration-architect whenever the task adds or changes an endpoint, a DTO mirrored from iface.go, or a deps.go interface, and continue through self-QA into the standard branch/commit/PR flow when implementation is done.
 ---
 
 # Start Next Task Automation
@@ -16,6 +16,7 @@ Turn a vague "next task" request into a disciplined execution flow:
 3. Audit business-rule impact before coding.
 4. Start implementation from requirements clarification, not from code.
 5. Enforce frontend-backend contract checks when integration changes are involved.
+6. After self-QA passes, finish delivery with branch/commit/PR instead of stopping at "code complete".
 
 ## Workflow
 
@@ -84,9 +85,19 @@ Confirm:
 - Query hooks and invalidation still align with the contract
 - Any frontend type updates remain synchronized with backend expectations before merge
 
+### 6. Finish delivery after implementation
+
+Do not stop once the code is written. If the user asked to implement/continue an issue end-to-end, continue into the delivery workflow after Phase 5 self-QA passes:
+
+- Create a feature/chore branch from `dev` if work is not already on a non-protected branch
+- Commit all intended changes with a clear `[area]` commit message tied to the issue
+- Open a PR to `dev` with summary, technical notes, test evidence, and the issue reference
+- If validation fails, approvals are blocked, or required issue details are still unclear, stop and surface the blocker instead of opening the PR
+
 ## Execution notes
 
 - Prefer the issue number from the board or issue list as the single source of truth.
 - Treat issue title alone as insufficient; always read the full issue body.
 - If `gh` access is unavailable, report the blockage and ask the user for the issue number or issue text.
-- When this workflow finishes analysis, continue naturally into implementation using the triggered skills instead of restating the whole process again.
+- When this workflow starts from a concrete issue number/URL/board card, treat that issue as the execution anchor from intake through PR unless the user explicitly changes scope.
+- When this workflow finishes analysis, continue naturally into implementation, self-QA, and PR preparation using the triggered skills instead of restating the whole process again.

--- a/.codex/agents/typescript-patterns/SKILL.md
+++ b/.codex/agents/typescript-patterns/SKILL.md
@@ -11,7 +11,7 @@ All API DTOs are in **`src/types/api.ts`**. Import them everywhere:
 
 ```typescript
 // ✅ Correct
-import type { Remnant, WorkOrder, PaginatedResponse } from '@/types/api'
+import type { PagedResult, Remnant, WorkOrder } from '@/types/api'
 
 // ❌ Wrong — re-declaring inline creates divergence with the backend
 interface Remnant { id: string; ... }
@@ -60,15 +60,16 @@ Always specify the generic types for full type inference and better error handli
 
 ```typescript
 import { useQuery, useMutation } from '@tanstack/react-query'
-import type { Remnant, PaginatedResponse } from '@/types/api'
 import type { ApiClientError } from '@/lib/api/client'
+import { remnantsApi } from '@/lib/api/remnants'
+import type { PagedResult, Remnant } from '@/types/api'
 
 // useQuery<TData, TError>
-const { data } = useQuery<PaginatedResponse<Remnant>, ApiClientError>({
+const { data } = useQuery<PagedResult<Remnant>, ApiClientError>({
   queryKey: ['remnants'],
   queryFn: () => remnantsApi.list(),
 })
-// data is typed as PaginatedResponse<Remnant> | undefined
+// data is typed as PagedResult<Remnant> | undefined
 
 // useMutation<TData, TError, TVariables>
 const mutation = useMutation<Remnant, ApiClientError, { id: string; locationId: string }>({
@@ -87,8 +88,8 @@ The project uses `"strict": true`. Always handle nullable values:
 const { data } = useRemnants()
 
 // ✅ Optional chaining
-const count = data?.total ?? 0
-const items = data?.data ?? []
+const count = data?.total_items ?? 0
+const items = data?.items ?? []
 
 // ✅ Early return in JSX
 if (!data) return <Skeleton />

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -39,3 +39,7 @@ web_search = "cached"
 approval_policy = "never"
 sandbox_mode = "workspace-write"
 web_search = "live"
+[mcp_servers.github]
+  command = "npx"
+  args = ["-y", "@modelcontextprotocol/server-github"]
+  startup_timeout_sec = 30

--- a/.codex/skills/add-api-route/SKILL.md
+++ b/.codex/skills/add-api-route/SKILL.md
@@ -102,7 +102,7 @@ export const myDomainApi = {
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { myDomainApi, type MyEntityFilter } from '@/lib/api/my-domain'
 import type { ApiClientError } from '@/lib/api/client'
-import type { MyEntity } from '@/types/api'
+import type { CreateMyEntityInput, MyEntity } from '@/types/api'
 
 // ── Query key constants ───────────────────────────────────────────────────────
 // Keep keys as constants — prevents typos and helps with invalidation

--- a/.codex/skills/add-shadcn-component/SKILL.md
+++ b/.codex/skills/add-shadcn-component/SKILL.md
@@ -29,7 +29,7 @@ After adding, import from `@/components/ui/<component>`.
 | Style | `new-york` |
 | Base color | `neutral` |
 | CSS variables | `true` (oklch color space) |
-| Icon library | `lucide-react` |
+| Icon library | `lucide` in `components.json` (generates imports from `lucide-react`) |
 | Alias | `@/components/ui` |
 | Utils | `@/lib/utils` (exports `cn`) |
 

--- a/.codex/skills/product-manager/SKILL.md
+++ b/.codex/skills/product-manager/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: product-manager
 description: >
-  Use to analyze the backlog from a user perspective (Kiosk/Dashboard), break down tasks, manage FE issues, and drive next-task triage when the user says "Làm task tiếp theo", "task tiếp theo", "Start next task", or asks Codex to pick an issue from the GitHub Projects Kanban board. In that trigger flow, identify the highest-priority open issue first, then hand the selected issue into the audit and implementation workflow.
+  Use to analyze the backlog from a user perspective (Kiosk/Dashboard), break down tasks, manage FE issues, and drive next-task triage when the user says "Làm task tiếp theo", "task tiếp theo", "Start next task", asks Codex to pick an issue from the GitHub Projects Kanban board, or hands Codex a concrete issue to execute end-to-end. In that trigger flow, identify or confirm the issue first, then hand the selected issue into the audit, implementation, and PR workflow.
 ---
 
 # Product Manager - Frontend Backlog & UX
@@ -38,8 +38,10 @@ For the chosen issue, summarize:
 ### 3. Hand off cleanly
 After selecting the issue, pass control to:
 - `business-auditor` for BR-* mapping
-- `senior-workflow` for requirements-first implementation
+- `senior-workflow` for requirements-first implementation through self-QA and PR
 - `integration-architect` if the issue changes backend contracts
+
+The chosen issue becomes the single execution anchor for the rest of the automation flow. Do not re-triage unless new user input changes scope.
 
 ## FE issue drafting workflow
 

--- a/.codex/skills/senior-workflow-frontend/SKILL.md
+++ b/.codex/skills/senior-workflow-frontend/SKILL.md
@@ -6,7 +6,7 @@ description: >
   technical design → task breakdown → implement → self-QA → PR.
   ALWAYS trigger this skill when the user says "implement", "add feature",
   "build page", "add component", "create hook", "fix", "fix bug", "find root cause",
-  "plan and implement", or pastes a GitHub issue/ticket number.
+  "plan and implement", pastes a GitHub issue/ticket number or URL, or asks Codex to take a selected issue all the way from intake to PR.
   Do NOT skip phases — Phase 5 (Self-QA) is the gate before PR and the phase
   most commonly skipped; skipping it is the #1 source of rework.
 ---
@@ -15,6 +15,12 @@ description: >
 
 Run these 6 phases **in order**. Mark each one done before moving to the next.
 Phase 5 is mandatory — do not open a PR without completing it.
+
+---
+
+## Issue-driven automation rule
+
+When the user provides a concrete issue/ticket/URL or this skill is reached from the next-task automation flow, treat that issue as the single source of truth and run Phases 1 → 6 continuously. Do not stop at implementation if the user expectation is end-to-end delivery; continue into commit/PR preparation after self-QA unless blocked.
 
 ---
 
@@ -293,12 +299,15 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 ```
 
 ### Branch rules
+- If this started from an issue-driven automation flow and you are still on `dev`, create the feature/chore branch from `dev` before the final commit/PR step.
 - Feature branch from `dev`: `git checkout -b feat/area-brief-description dev`
 - Never push directly to `main` or `dev`
 - PR: feature → `dev` (approval optional)
 - `dev` → `main` requires 1 approval
 
 ### PR body template
+Include the issue number/link, touched BR-* rules, and any contract-sync notes when relevant.
+
 ```markdown
 ## Summary
 - What was changed and why

--- a/.codex/skills/senior-workflow/SKILL.md
+++ b/.codex/skills/senior-workflow/SKILL.md
@@ -6,9 +6,9 @@ description: >
   technical design → task breakdown → implement + test → self-QA → PR.
   Always trigger this skill when the user says "implement", "add feature",
   "build page", "add component", "create hook", "fix", "fix bug",
-  "find root cause", pastes a GitHub issue/ticket, or enters the
+  "find root cause", pastes a GitHub issue/ticket/URL, asks Codex to continue a selected issue from intake to PR, or enters the
   "Làm task tiếp theo" / "Start next task" automation flow after issue
-  selection. Start at Phase 1 and never jump straight to coding.
+  selection. Start at Phase 1 and never jump straight to coding or stop before the PR phase unless blocked.
 ---
 
 # Senior Engineer Workflow — Next.js Frontend
@@ -19,13 +19,14 @@ Never skip Phase 5 — it is the gate before PR.
 
 ---
 
-## Automation handoff rule
+## Issue-driven automation rule
 
-When this skill is invoked from `start-next-task`:
+When this skill is invoked from `start-next-task`, or when the user directly provides an issue/ticket/URL and asks Codex to implement it:
 1. Start from the selected issue body and DoD.
 2. Incorporate the `business-auditor` findings before design.
 3. If contract changes are present, schedule `integration-architect` checks before finalizing implementation.
 4. Begin at **Phase 1 — Requirements Clarification**. Do not open files for coding first.
+5. Continue through Phases 1 → 6 in one flow unless a blocker, failed validation, or missing approval forces a stop.
 
 ---
 
@@ -142,7 +143,7 @@ supplier_code: string | null
 ```typescript
 // Read hook — always guard undefined
 const { data, isLoading, error } = useMyEntities(filter)
-const items = data ?? []   // never data.filter() without ?? []
+const items = data?.items ?? []   // never data?.items!.filter(...) without ?? []
 
 // Mutation — always invalidate on success
 useMutation({
@@ -173,7 +174,7 @@ if (items.length === 0) return <EmptyState />   // empty state
 This phase is the gate before PR. Run through **all** of these.
 
 ### Type mismatch checklist (most common bugs)
-- [ ] API returns `PagedResult<T>` but code treats it as `T[]`? → add `.then(res => res.items)`
+- [ ] API returns `PagedResult<T>` but code treats it as `T[]`? → unwrap with `data?.items ?? []` (or return `items` from a specialized hook)
 - [ ] Used `data!.items` without null guard? → change to `data?.items ?? []`
 - [ ] `useRef<HTMLDivElement>(null)` typed as `RefObject<HTMLDivElement>`? → must be `RefObject<HTMLDivElement | null>` in React 19
 - [ ] Hook file has `'use client'` at top unnecessarily? → remove if no browser APIs used
@@ -184,7 +185,7 @@ This phase is the gate before PR. Run through **all** of these.
 - [ ] `any` type anywhere? → replace with `unknown` + narrowing or proper type
 - [ ] `fetch()` called directly instead of `apiClient`? → replace
 - [ ] Same type declared in two places? → consolidate to `src/types/api.ts`
-- [ ] Query key as bare string `"remnants"`? → use exported constant `REMNANT_KEY`
+- [ ] Query key as bare string `"remnants"`? → use the exported domain constant (for example `REMNANTS_KEY`)
 - [ ] Missing `enabled: !!id` on query that depends on a param?
 
 ### Silly bug checklist

--- a/.codex/skills/start-next-task/SKILL.md
+++ b/.codex/skills/start-next-task/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: start-next-task
 description: >
-  Use when the user says "Làm task tiếp theo", "task tiếp theo", "Start next task", asks Codex to pick the next issue, or wants Codex to continue from a GitHub Projects Kanban item. Orchestrate the automation workflow in order: fetch the highest-priority open issue from giangdq202/Vmarble-Warehouse-Management-Service via the product-manager workflow, read the full issue and Definition of Done, run a business-auditor pass against docs/backend-business-logic-vi.md to identify every touched BR-* rule and block if any rule is unclear, then hand off to senior-workflow starting at Phase 1, and invoke integration-architect whenever the task adds or changes an endpoint, a DTO mirrored from iface.go, or a deps.go interface.
+  Use when the user says "Làm task tiếp theo", "task tiếp theo", "Start next task", asks Codex to pick the next issue, wants Codex to continue from a GitHub Projects Kanban item, or wants Codex to take a selected issue from intake all the way to branch/commit/PR. Orchestrate the automation workflow in order: fetch or accept the chosen issue, read the full issue and Definition of Done, run a business-auditor pass against docs/backend-business-logic-vi.md to identify every touched BR-* rule and block if any rule is unclear, then hand off to senior-workflow starting at Phase 1, invoke integration-architect whenever the task adds or changes an endpoint, a DTO mirrored from iface.go, or a deps.go interface, and continue through self-QA into the standard branch/commit/PR flow when implementation is done.
 ---
 
 # Start Next Task Automation
@@ -16,6 +16,7 @@ Turn a vague "next task" request into a disciplined execution flow:
 3. Audit business-rule impact before coding.
 4. Start implementation from requirements clarification, not from code.
 5. Enforce frontend-backend contract checks when integration changes are involved.
+6. After self-QA passes, finish delivery with branch/commit/PR instead of stopping at "code complete".
 
 ## Workflow
 
@@ -84,9 +85,19 @@ Confirm:
 - Query hooks and invalidation still align with the contract
 - Any frontend type updates remain synchronized with backend expectations before merge
 
+### 6. Finish delivery after implementation
+
+Do not stop once the code is written. If the user asked to implement/continue an issue end-to-end, continue into the delivery workflow after Phase 5 self-QA passes:
+
+- Create a feature/chore branch from `dev` if work is not already on a non-protected branch
+- Commit all intended changes with a clear `[area]` commit message tied to the issue
+- Open a PR to `dev` with summary, technical notes, test evidence, and the issue reference
+- If validation fails, approvals are blocked, or required issue details are still unclear, stop and surface the blocker instead of opening the PR
+
 ## Execution notes
 
 - Prefer the issue number from the board or issue list as the single source of truth.
 - Treat issue title alone as insufficient; always read the full issue body.
 - If `gh` access is unavailable, report the blockage and ask the user for the issue number or issue text.
-- When this workflow finishes analysis, continue naturally into implementation using the triggered skills instead of restating the whole process again.
+- When this workflow starts from a concrete issue number/URL/board card, treat that issue as the execution anchor from intake through PR unless the user explicitly changes scope.
+- When this workflow finishes analysis, continue naturally into implementation, self-QA, and PR preparation using the triggered skills instead of restating the whole process again.

--- a/.codex/skills/typescript-patterns/SKILL.md
+++ b/.codex/skills/typescript-patterns/SKILL.md
@@ -11,7 +11,7 @@ All API DTOs are in **`src/types/api.ts`**. Import them everywhere:
 
 ```typescript
 // ✅ Correct
-import type { Remnant, WorkOrder, PaginatedResponse } from '@/types/api'
+import type { PagedResult, Remnant, WorkOrder } from '@/types/api'
 
 // ❌ Wrong — re-declaring inline creates divergence with the backend
 interface Remnant { id: string; ... }
@@ -60,15 +60,16 @@ Always specify the generic types for full type inference and better error handli
 
 ```typescript
 import { useQuery, useMutation } from '@tanstack/react-query'
-import type { Remnant, PaginatedResponse } from '@/types/api'
 import type { ApiClientError } from '@/lib/api/client'
+import { remnantsApi } from '@/lib/api/remnants'
+import type { PagedResult, Remnant } from '@/types/api'
 
 // useQuery<TData, TError>
-const { data } = useQuery<PaginatedResponse<Remnant>, ApiClientError>({
+const { data } = useQuery<PagedResult<Remnant>, ApiClientError>({
   queryKey: ['remnants'],
   queryFn: () => remnantsApi.list(),
 })
-// data is typed as PaginatedResponse<Remnant> | undefined
+// data is typed as PagedResult<Remnant> | undefined
 
 // useMutation<TData, TError, TVariables>
 const mutation = useMutation<Remnant, ApiClientError, { id: string; locationId: string }>({
@@ -87,8 +88,8 @@ The project uses `"strict": true`. Always handle nullable values:
 const { data } = useRemnants()
 
 // ✅ Optional chaining
-const count = data?.total ?? 0
-const items = data?.data ?? []
+const count = data?.total_items ?? 0
+const items = data?.items ?? []
 
 // ✅ Early return in JSX
 if (!data) return <Skeleton />


### PR DESCRIPTION
## Summary
- tighten repo-local Codex skills so issue-driven requests route through the full automation flow from issue intake to self-QA and PR
- scope `làm task tiếp theo` / `start next task` to frontend issues in `giangdq202/Vmarble-Warehouse-Management-Client` by default
- require issue-driven PR guidance to include an explicit closing line such as `Closes #123`, `Fixes #123`, or `Resolves #123`
- fix stale `.codex` guidance around `PagedResult`, hook examples, query-key naming, and shadcn config details
- keep mirrored agent skills in sync with the primary `.codex/skills` copies and include the local Codex config update already in this branch

## Technical notes
- Updated automation skills: `start-next-task`, `product-manager`, `senior-workflow`, `senior-workflow-frontend`
- Refined supporting skills: `add-api-route`, `add-shadcn-component`, `typescript-patterns`
- Updated `.codex/AGENTS.md` to match the frontend-only next-task flow
- Synced mirrored files under `.codex/agents/*/SKILL.md`
- Included `.codex/config.toml` change already present on this branch
- Breaking changes: no runtime app changes; repo-local Codex workflow/config only

## Test plan
- [x] Verified `.codex/skills/*` and `.codex/agents/*` mirrors match after edits
- [x] Re-ran local self-QA checks for stale skill references (`PagedResult`, query-key naming, automation wording)
- [x] Confirmed next-task instructions now target the frontend repo by default
- [x] Confirmed `senior-workflow-frontend` now requires an explicit issue-closing line in PR guidance
- [ ] `npx tsc --noEmit` — not run (no app source/runtime code changed)
- [ ] `npm run lint` — not run (no app source/runtime code changed)
- [ ] `npm run build` — not run (no app source/runtime code changed)

## Manual validation
- Confirmed the automation-related skills now explicitly cover issue/ticket/URL driven flow through branch/commit/PR
- Confirmed frontend-only triage wording is consistent across `start-next-task`, `product-manager`, and `.codex/AGENTS.md`
- Confirmed mirrored agent skill files remain in lockstep with the primary skill files
