### PR TITLE
[kiosk] add explicit manual input arrow CTA

### DIFF
--- a/src/components/kiosk/scanner-view.stories.tsx
+++ b/src/components/kiosk/scanner-view.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
-import { Camera, CameraOff, Lock, ShieldAlert } from 'lucide-react'
+import { ArrowRight, Camera, CameraOff, Lock, ShieldAlert } from 'lucide-react'
 import { fn } from 'storybook/test'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -106,7 +106,12 @@ function ManualWithError({
           <p className="text-xs text-muted-foreground">{description}</p>
         </div>
       </div>
-      <Input placeholder="Nhập mã rồi nhấn Enter..." className="h-12 text-base" readOnly />
+      <div className="flex gap-2">
+        <Input placeholder="Nhập mã rồi bấm nút →" className="h-12 flex-1 text-base" readOnly />
+        <Button type="button" size="default" className="h-12 shrink-0 px-4" aria-label="Xác nhận mã">
+          <ArrowRight className="size-5" />
+        </Button>
+      </div>
       <Button size="sm" variant="ghost">
         <Camera className="size-4" />
         Thử lại camera

--- a/src/components/kiosk/scanner-view.tsx
+++ b/src/components/kiosk/scanner-view.tsx
@@ -326,6 +326,7 @@ export function ScannerView({ onScan, className, disabled = false, showControls 
               Nhập mã thủ công (camera không khả dụng)
             </p>
           )}
+          {/* Keep a dedicated arrow CTA next to manual input so kiosk workers do not need the mobile keyboard Enter key. */}
           <div className="flex gap-2">
             <Input
               value={manualInput}


### PR DESCRIPTION
## Summary
- align kiosk manual-input UX with the issue expectation: workers should have an explicit arrow CTA next to the input instead of depending on the mobile keyboard Enter key
- update the ScannerView story/example so Storybook reflects the real kiosk flow
- Closes #119

## Technical notes
- Updated `src/components/kiosk/scanner-view.tsx` to explicitly document the dedicated manual-input arrow CTA expectation
- Updated `src/components/kiosk/scanner-view.stories.tsx` to render the adjacent arrow button in the manual/error example
- No backend/API contract changes
- No route changes

## Test plan
- [ ] `npx tsc --noEmit`
- [ ] `npm run lint`
- [ ] `npm run build`
- [x] Verified the runtime kiosk scanner already exposes a dedicated arrow CTA in manual-input mode
- [x] Verified the Storybook manual/error example now matches the runtime UI expectation
- [x] Confirmed the issue-closing line is explicit for this PR

## Manual validation
- Manual input mode in `ScannerView` shows input + adjacent `->` button
- Story/example no longer tells users to rely on pressing Enter on the mobile keyboard
