### PR TITLE
[ui-kit] Confirm modal: đỏ cho destructive actions (#115)

### DIFF
--- a/src/app/(dashboard)/plans/[id]/page.tsx
+++ b/src/app/(dashboard)/plans/[id]/page.tsx
@@ -17,16 +17,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog'
+import { ConfirmModal } from '@/components/ui/confirm-modal'
 import { usePlan, useApprovePlan, useCancelPlan } from '@/lib/hooks/use-plans'
 import { useSKUs } from '@/lib/hooks/use-skus'
 import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
@@ -229,44 +220,30 @@ export default function PlanDetailPage({
       </Card>
 
       {/* Approve confirm */}
-      <AlertDialog open={canApprovePlan && approveOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Duyệt kế hoạch sản xuất?</AlertDialogTitle>
-            <AlertDialogDescription>
-              Kế hoạch sẽ chuyển sang trạng thái <strong>Đã duyệt</strong>. Hành động này không thể hoàn tác.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel onClick={() => setApproveOpen(false)}>Hủy</AlertDialogCancel>
-            <AlertDialogAction onClick={handleApprove} disabled={approving}>
-              {approving ? 'Đang duyệt…' : 'Duyệt'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <ConfirmModal
+        open={canApprovePlan && approveOpen}
+        title="Duyệt kế hoạch sản xuất?"
+        description="Kế hoạch sẽ chuyển sang trạng thái Đã duyệt. Hành động này không thể hoàn tác."
+        confirmLabel="Duyệt"
+        pendingLabel="Đang duyệt…"
+        isPending={approving}
+        onConfirm={handleApprove}
+        onCancel={() => setApproveOpen(false)}
+      />
 
       {/* Cancel confirm */}
-      <AlertDialog open={canCancelPlan && cancelOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Hủy kế hoạch sản xuất?</AlertDialogTitle>
-            <AlertDialogDescription>
-              Kế hoạch sẽ bị hủy và không thể khôi phục.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel onClick={() => setCancelOpen(false)}>Không</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleCancel}
-              disabled={canceling}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              {canceling ? 'Đang hủy…' : 'Hủy kế hoạch'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <ConfirmModal
+        open={canCancelPlan && cancelOpen}
+        title="Hủy kế hoạch sản xuất?"
+        description="Kế hoạch sẽ bị hủy và không thể khôi phục."
+        confirmLabel="Hủy kế hoạch"
+        cancelLabel="Không"
+        confirmVariant="destructive"
+        pendingLabel="Đang hủy…"
+        isPending={canceling}
+        onConfirm={handleCancel}
+        onCancel={() => setCancelOpen(false)}
+      />
     </div>
   )
 }

--- a/src/app/(dashboard)/plans/page.tsx
+++ b/src/app/(dashboard)/plans/page.tsx
@@ -14,16 +14,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog'
+import { ConfirmModal } from '@/components/ui/confirm-modal'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
@@ -307,55 +298,6 @@ function CreatePlanDialog({ open, onOpenChange }: CreatePlanDialogProps) {
   )
 }
 
-// ── Confirm action dialog ─────────────────────────────────────────────────────
-
-interface ConfirmActionDialogProps {
-  open: boolean
-  title: string
-  description: string
-  actionLabel: string
-  actionVariant?: 'default' | 'destructive'
-  isPending: boolean
-  onConfirm: () => void
-  onCancel: () => void
-}
-
-function ConfirmActionDialog({
-  open,
-  title,
-  description,
-  actionLabel,
-  actionVariant = 'default',
-  isPending,
-  onConfirm,
-  onCancel,
-}: ConfirmActionDialogProps) {
-  return (
-    <AlertDialog open={open}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>{title}</AlertDialogTitle>
-          <AlertDialogDescription>{description}</AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel onClick={onCancel}>Hủy</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={onConfirm}
-            disabled={isPending}
-            className={
-              actionVariant === 'destructive'
-                ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
-                : ''
-            }
-          >
-            {isPending ? 'Đang xử lý…' : actionLabel}
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-  )
-}
-
 // ── Table skeleton ────────────────────────────────────────────────────────────
 
 function TableSkeleton() {
@@ -538,22 +480,22 @@ function PlansContent() {
 
       {canCreatePlan && <CreatePlanDialog open={createOpen} onOpenChange={setCreateOpen} />}
 
-      <ConfirmActionDialog
+      <ConfirmModal
         open={canApprovePlan && approveTarget !== null}
         title="Duyệt kế hoạch sản xuất?"
         description={`Kế hoạch cho đơn hàng "${approveTarget ? (poMap.get(approveTarget.po_id) ?? approveTarget.po_id.slice(0, 8)) : ''}" sẽ chuyển sang trạng thái Đã duyệt. Hành động này không thể hoàn tác.`}
-        actionLabel="Duyệt"
+        confirmLabel="Duyệt"
         isPending={approving}
         onConfirm={handleApprove}
         onCancel={() => setApproveTarget(null)}
       />
 
-      <ConfirmActionDialog
+      <ConfirmModal
         open={canCancelPlan && cancelTarget !== null}
         title="Hủy kế hoạch sản xuất?"
         description={`Kế hoạch cho đơn hàng "${cancelTarget ? (poMap.get(cancelTarget.po_id) ?? cancelTarget.po_id.slice(0, 8)) : ''}" sẽ bị hủy và không thể khôi phục.`}
-        actionLabel="Hủy kế hoạch"
-        actionVariant="destructive"
+        confirmLabel="Hủy kế hoạch"
+        confirmVariant="destructive"
         isPending={canceling}
         onConfirm={handleCancel}
         onCancel={() => setCancelTarget(null)}

--- a/src/app/(dashboard)/users/page.tsx
+++ b/src/app/(dashboard)/users/page.tsx
@@ -17,16 +17,7 @@ import {
   DialogFooter,
   DialogDescription,
 } from '@/components/ui/dialog'
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog'
+import { ConfirmModal } from '@/components/ui/confirm-modal'
 import { Label } from '@/components/ui/label'
 import { Input } from '@/components/ui/input'
 import {
@@ -364,36 +355,18 @@ function UsersContent() {
 
       <CreateUserDialog open={createOpen} onOpenChange={setCreateOpen} />
 
-      <AlertDialog
+      <ConfirmModal
         open={toggleDialog.open}
-        onOpenChange={(open) => !open && setToggleDialog({ open: false, user: null })}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {toggleDialog.user?.is_active ? 'Khóa tài khoản?' : 'Mở khóa tài khoản?'}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {toggleDialog.user?.is_active
-                ? `Bạn có chắc chắn muốn khóa tài khoản "${toggleDialog.user.username}"? Người dùng này sẽ không thể đăng nhập vào hệ thống.`
-                : `Bạn có chắc chắn muốn mở khóa tài khoản "${toggleDialog.user?.username}"?`}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isToggling}>Hủy</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={(e) => {
-                e.preventDefault()
-                handleToggleStatus()
-              }}
-              className={toggleDialog.user?.is_active ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90' : 'bg-emerald-600 text-white hover:bg-emerald-700'}
-              disabled={isToggling}
-            >
-              {isToggling ? 'Đang xử lý…' : 'Xác nhận'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        title={toggleDialog.user?.is_active ? 'Khóa tài khoản?' : 'Mở khóa tài khoản?'}
+        description={toggleDialog.user?.is_active
+          ? `Bạn có chắc chắn muốn khóa tài khoản "${toggleDialog.user.username}"? Người dùng này sẽ không thể đăng nhập vào hệ thống.`
+          : `Bạn có chắc chắn muốn mở khóa tài khoản "${toggleDialog.user?.username}"?`}
+        confirmLabel="Xác nhận"
+        confirmVariant={toggleDialog.user?.is_active ? 'destructive' : 'default'}
+        isPending={isToggling}
+        onConfirm={handleToggleStatus}
+        onCancel={() => setToggleDialog({ open: false, user: null })}
+      />
     </>
   )
 }

--- a/src/components/ui/confirm-modal.stories.tsx
+++ b/src/components/ui/confirm-modal.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { useState } from 'react'
+import { Button } from './button'
+import { ConfirmModal } from './confirm-modal'
+
+function ConfirmModalStory(props: {
+  title: string
+  description: string
+  confirmLabel: string
+  cancelLabel?: string
+  confirmVariant?: 'default' | 'destructive'
+  isPending?: boolean
+  pendingLabel?: string
+}) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="flex items-center gap-3">
+      <Button
+        variant={props.confirmVariant === 'destructive' ? 'destructive' : 'default'}
+        onClick={() => setOpen(true)}
+      >
+        Mở confirm modal
+      </Button>
+      <ConfirmModal
+        {...props}
+        open={open}
+        onCancel={() => setOpen(false)}
+        onConfirm={() => setOpen(false)}
+      />
+    </div>
+  )
+}
+
+const meta = {
+  title: 'UI/ConfirmModal',
+  component: ConfirmModalStory,
+  tags: ['autodocs'],
+  args: {
+    title: 'Xác nhận hành động?',
+    description: 'Hành động này sẽ cập nhật dữ liệu trong hệ thống.',
+    confirmLabel: 'Xác nhận',
+    cancelLabel: 'Hủy',
+    confirmVariant: 'default',
+    isPending: false,
+  },
+} satisfies Meta<typeof ConfirmModalStory>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Destructive: Story = {
+  args: {
+    title: 'Hủy kế hoạch sản xuất?',
+    description: 'Kế hoạch sẽ bị hủy và không thể khôi phục.',
+    confirmLabel: 'Hủy kế hoạch',
+    confirmVariant: 'destructive',
+  },
+}

--- a/src/components/ui/confirm-modal.tsx
+++ b/src/components/ui/confirm-modal.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { AlertTriangle } from 'lucide-react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { cn } from '@/lib/utils'
+
+export interface ConfirmModalProps {
+  open: boolean
+  title: string
+  description: string
+  confirmLabel: string
+  cancelLabel?: string
+  confirmVariant?: 'default' | 'destructive'
+  isPending?: boolean
+  pendingLabel?: string
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ConfirmModal({
+  open,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel = 'Hủy',
+  confirmVariant = 'default',
+  isPending = false,
+  pendingLabel = 'Đang xử lý…',
+  onConfirm,
+  onCancel,
+}: ConfirmModalProps) {
+  const isDestructive = confirmVariant === 'destructive'
+
+  return (
+    <AlertDialog open={open}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle
+            className={cn(
+              isDestructive && 'flex items-center gap-2 text-lg font-bold text-foreground',
+            )}
+          >
+            {isDestructive && (
+              <AlertTriangle className="size-5 shrink-0 text-destructive" aria-hidden="true" />
+            )}
+            <span>{title}</span>
+          </AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel} disabled={isPending}>
+            {cancelLabel}
+          </AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm} disabled={isPending} variant={confirmVariant}>
+            {isPending ? pendingLabel : confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}


### PR DESCRIPTION
## Tóm tắt
- thêm shared `ConfirmModal` với `confirmVariant: 'default' | 'destructive'`
- destructive variant hiển thị nút confirm màu đỏ, title nổi bật hơn và icon cảnh báo
- migrate các flow confirm hiện có ở dashboard users và plans sang shared component mới
- thêm Storybook demo cho 2 variants

## Files changed
- `src/components/ui/confirm-modal.tsx`
- `src/components/ui/confirm-modal.stories.tsx`
- `src/app/(dashboard)/users/page.tsx`
- `src/app/(dashboard)/plans/page.tsx`
- `src/app/(dashboard)/plans/[id]/page.tsx`

## Phạm vi áp dụng
Đã apply cho các destructive flows hiện thấy rõ trong codebase hiện tại:
- khóa tài khoản
- hủy kế hoạch (list page)
- hủy kế hoạch (detail page)

Giữ variant mặc định cho các confirm không-destructive như duyệt kế hoạch.

## Business rule notes
- Tăng mức độ cảnh báo cho các destructive action
- Phù hợp với yêu cầu xác nhận thủ công ở các flow như waste remnant theo tinh thần BR-K04

## Validation
- ✅ `npx tsc --noEmit`
- ✅ `npm run build`
- ⚠️ `npm run lint` đang fail bởi baseline Storybook/import issues đã tồn tại sẵn trong repo, không phát sinh riêng từ change này

## Issue
Closes #115
