### PR TITLE
fix(work-orders): restore missing plan option label helper

### DIFF
--- a/src/app/(dashboard)/work-orders/page.tsx
+++ b/src/app/(dashboard)/work-orders/page.tsx
@@ -134,6 +134,28 @@ function formatDate(iso: string) {
   })
 }
 
+function formatPlanOptionLabel(plan: {
+  id: string
+  code?: string
+  po_code?: string
+  deadline?: string
+  status?: string
+}) {
+  const code = plan.code?.trim() || `KH-${shortId(plan.id)}`
+  const parts = [code]
+  if (plan.po_code?.trim()) parts.push(`PO ${plan.po_code}`)
+  if (plan.deadline) {
+    const deadline = new Date(plan.deadline).toLocaleDateString('vi-VN', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    })
+    parts.push(`HH ${deadline}`)
+  }
+  if (plan.status) parts.push(plan.status)
+  return parts.join(' · ')
+}
+
 function useCurrentRole() {
   return useSyncExternalStore(
     () => () => {},


### PR DESCRIPTION
## Summary
- Restore the missing `formatPlanOptionLabel()` helper on `(dashboard)/work-orders`
- Fix the GitHub Actions TypeScript failure where the page referenced the helper but it was no longer defined
- Keep the async plan filter UI intact while restoring a shared label formatter used by the combobox

## Technical notes
- Route group affected: `(dashboard)`
- File touched: `src/app/(dashboard)/work-orders/page.tsx`
- No API contract change
- No query-key or mutation behavior changes

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — succeeds
- [x] Manual code review confirms both combobox label call sites now resolve to a defined helper

## Context
This is a focused follow-up hotfix for the TypeScript error seen in GitHub Actions:
- `Cannot find name 'formatPlanOptionLabel'`
