### PR TITLE
[report-cut] fix endpoint label PDF và UX fallback (#131)

### DIFF
--- a/src/components/kiosk/report-cut-form.tsx
+++ b/src/components/kiosk/report-cut-form.tsx
@@ -4,6 +4,7 @@ import { useState, useId, useMemo, useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useForm, Controller, useWatch } from 'react-hook-form'
 import QRCode from 'react-qr-code'
+import { toast } from 'sonner'
 import { AlertTriangle, CheckCircle2, ChevronLeft, Copy, Check, Printer } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
@@ -226,6 +227,7 @@ function SuccessModal({
       setPdfUrl(labelUrl)
       window.open(labelUrl, '_blank', 'noopener,noreferrer')
     } catch {
+      toast.info('Không mở được file PDF, đang in trực tiếp từ màn hình.')
       window.print()
     }
   }

--- a/src/lib/api/barcode.ts
+++ b/src/lib/api/barcode.ts
@@ -47,7 +47,7 @@ export const barcodeApi = {
         ? normalizeAuthToken(localStorage.getItem('auth_token'))
         : null
 
-    const response = await fetch(buildApiUrl(`/barcodes/${barcodeId}/label`), {
+    const response = await fetch(buildApiUrl(`/barcodes/${barcodeId}/label.pdf`), {
       method: 'GET',
       headers: {
         Accept: 'application/pdf',

--- a/src/lib/hooks/use-barcode.ts
+++ b/src/lib/hooks/use-barcode.ts
@@ -54,8 +54,5 @@ export function useOpenBarcodeLabelPdf() {
       const blob = await barcodeApi.getLabelPdfBlob(barcodeId)
       return URL.createObjectURL(blob)
     },
-    onError: (err: unknown) => {
-      toast.error(mapApiErrorVi(err, 'Mở file in tem thất bại'))
-    },
   })
 }


### PR DESCRIPTION
## Summary

- Sửa path API từ `/barcodes/:id/label` → `/barcodes/:id/label.pdf` để khớp với backend route thực tế
- Xóa `onError` toast trong `useOpenBarcodeLabelPdf` — tránh double toast khi component đã tự handle lỗi
- Thêm `toast.info()` trong catch block của `handlePrintLabel` để user biết đây là fallback in trực tiếp, không phải lỗi thật

## Root cause

FE gọi sai endpoint → `useOpenBarcodeLabelPdf` nổ `onError` → toast "thất bại" → component catch → `window.print()`. User thấy lỗi dù file vẫn được tạo.

## Test plan

- [ ] Nhấn **In tem** sau khi báo cáo cắt thành công → file PDF mở đúng, không có toast lỗi
- [ ] Khi API thực sự lỗi (tắt backend) → toast fallback hiện "Không mở được file PDF, đang in trực tiếp từ màn hình." → browser print dialog mở
- [ ] Không còn double toast (lỗi + fallback cùng lúc)

Closes #131

<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/6725248f-3dd1-4968-a9e6-f69fb1fc8de8" />
<img width="636" height="1298" alt="image" src="https://github.com/user-attachments/assets/8690f332-429c-4932-b809-a408df74dacf" />
