### PR TITLE
[planning] Hiển thị PO code + summary trong modal tạo kế hoạch

### DIFF
--- a/src/app/(dashboard)/plans/page.tsx
+++ b/src/app/(dashboard)/plans/page.tsx
@@ -63,6 +63,13 @@ function formatDate(iso: string) {
   })
 }
 
+function poSummary(po: { total_skus?: number; total_quantity?: number }): string {
+  const parts: string[] = []
+  if (po.total_skus != null) parts.push(`${po.total_skus} SKU`)
+  if (po.total_quantity != null) parts.push(`${po.total_quantity} sp`)
+  return parts.join(' · ')
+}
+
 const STATUS_LABEL: Record<PlanStatus, string> = {
   DRAFT: 'Nháp',
   APPROVED: 'Đã duyệt',
@@ -214,17 +221,24 @@ function CreatePlanDialog({ open, onOpenChange }: CreatePlanDialogProps) {
                 <SelectValue placeholder="— Chọn đơn hàng —" />
               </SelectTrigger>
               <SelectContent>
-                {pos.map((po) => (
-                  <SelectItem key={po.id} value={po.id}>
-                    {po.code}
-                  </SelectItem>
-                ))}
+                {pos.map((po) => {
+                  const summary = poSummary(po)
+                  return (
+                    <SelectItem key={po.id} value={po.id}>
+                      <span className="font-medium">{po.code}</span>
+                      {summary && (
+                        <span className="ml-2 text-muted-foreground">{summary}</span>
+                      )}
+                    </SelectItem>
+                  )
+                })}
               </SelectContent>
             </Select>
             {errors.po_id && <p className="text-xs text-destructive">{errors.po_id}</p>}
             {selectedPO && (
               <p className="text-xs text-muted-foreground">
                 Hạn giao hàng: {formatDate(selectedPO.expected_delivery)}
+                {poSummary(selectedPO) && ` · ${poSummary(selectedPO)}`}
               </p>
             )}
           </div>

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -133,6 +133,9 @@ export interface PO {
   code: string
   expected_delivery: string
   created_at: string
+  /** Summary fields added by backend issue #195 */
+  total_skus?: number
+  total_quantity?: number
   /** Included when fetched via GET /pos/:id */
   line_items?: LineItem[]
 }


### PR DESCRIPTION
## Closes

Closes #127

## Tóm tắt

Cải thiện khả năng nhận diện PO trong modal tạo kế hoạch sản xuất. Người dùng không cần nhớ mã PO — dropdown nay hiển thị thêm số SKU và tổng số lượng sản phẩm ngay bên cạnh code.

## Thay đổi

- **`src/types/api.ts`**: Thêm `total_skus?: number` và `total_quantity?: number` vào interface `PO` — mirrors backend issue #195 (đã merge)
- **`src/app/(dashboard)/plans/page.tsx`**:
  - Thêm helper `poSummary()` format label phụ `"5 SKU · 42 sp"`
  - `SelectItem` PO render `PO-001 · 5 SKU · 42 sp`
  - Hint bên dưới dropdown kèm summary sau hạn giao hàng
  - Gracefully fallback về chỉ `po.code` nếu backend chưa trả metadata

## Test plan

- [x] Mở modal tạo kế hoạch — dropdown PO hiển thị `code + summary` đúng định dạng
- [x] Khi chọn PO, hint bên dưới hiển thị `Hạn giao hàng: ... · N SKU · M sp`
- [x] Nếu PO không có `total_skus`/`total_quantity` (backend cũ), chỉ hiện code — không crash
- [x] Label readable trong modal width hiện tại với ≥ 10 PO có mã gần giống nhau

<img width="2144" height="1186" alt="image" src="https://github.com/user-attachments/assets/3a7ea380-d652-40e1-969a-26693924a0b7" />
 