### PR TITLE
[kiosk] feat: implement account profile and link to dashboard

### DIFF
--- a/src/app/(dashboard)/profile/page.tsx
+++ b/src/app/(dashboard)/profile/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next'
+import { ProfileContent } from './profile-content'
+
+export const metadata: Metadata = { title: 'Thông tin tài khoản' }
+
+export default function ProfilePage() {
+  return (
+    <div className="flex flex-col gap-6 p-8">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Thông tin tài khoản</h1>
+        <p className="text-muted-foreground">
+          Chi tiết hồ sơ và quyền hạn của bạn trong hệ thống
+        </p>
+      </div>
+      <ProfileContent />
+    </div>
+  )
+}

--- a/src/app/(dashboard)/profile/profile-content.tsx
+++ b/src/app/(dashboard)/profile/profile-content.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+import { UserCircle } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { useMe } from '@/lib/hooks/use-auth'
+import { getCurrentRoleFromCookie } from '@/lib/auth/authorization'
+
+const ROLE_LABELS: Record<string, string> = {
+  admin: 'Admin',
+  accountant: 'Kế toán',
+  planner: 'Kế hoạch',
+  warehouse: 'Kho',
+  cnc: 'CNC',
+  foreman: 'Quản đốc',
+  cnc_manager: 'QL CNC',
+}
+
+function useCurrentRole(): string | null {
+  return useSyncExternalStore(
+    () => () => {},
+    () => getCurrentRoleFromCookie(),
+    () => null,
+  )
+}
+
+export function ProfileContent() {
+  const role = useCurrentRole()
+  const { data: me, isLoading, isError } = useMe()
+
+  if (!role || isLoading) {
+    return (
+      <div className="flex animate-pulse flex-col gap-8 max-w-2xl">
+        <div className="h-64 w-full rounded-xl bg-muted" />
+      </div>
+    )
+  }
+
+  const username = me?.username ?? '—'
+  const fullName = me?.full_name ?? '—'
+
+  return (
+    <div className="max-w-2xl">
+      <div className="flex flex-col gap-8 rounded-xl border bg-card p-8 shadow-sm">
+        <div className="flex items-center gap-6">
+          <UserCircle className="size-24 text-muted-foreground" aria-hidden="true" />
+          <div className="flex flex-col gap-2">
+            <h2 className="text-2xl font-bold">{username}</h2>
+            <div>
+              <Badge variant="secondary" className="text-base">
+                {ROLE_LABELS[role] ?? role}
+              </Badge>
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-6 pt-6 border-t">
+          <div className="grid grid-cols-3 gap-4 text-sm">
+            <span className="text-muted-foreground">Họ tên</span>
+            <span className="col-span-2 font-medium">{fullName}</span>
+          </div>
+          <div className="grid grid-cols-3 gap-4 text-sm">
+            <span className="text-muted-foreground">Quyền truy cập</span>
+            <span className="col-span-2 font-medium">{ROLE_LABELS[role] ?? role}</span>
+          </div>
+        </div>
+        
+        {isError && (
+          <p className="text-sm text-destructive mt-4" role="alert">
+            Không thể tải thông tin tài khoản đầy đủ. Vui lòng đăng nhập lại.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(kiosk)/account/account-profile.tsx
+++ b/src/app/(kiosk)/account/account-profile.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+import { useRouter } from 'next/navigation'
+import { LogOut, UserCircle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { logout, useMe } from '@/lib/hooks/use-auth'
+import { getCurrentRoleFromCookie } from '@/lib/auth/authorization'
+
+const ROLE_LABELS: Record<string, string> = {
+  admin: 'Admin',
+  accountant: 'Kế toán',
+  planner: 'Kế hoạch',
+  warehouse: 'Kho',
+  cnc: 'CNC',
+  foreman: 'Quản đốc',
+  cnc_manager: 'QL CNC',
+}
+
+function useCurrentRole(): string | null {
+  return useSyncExternalStore(
+    () => () => {},
+    () => getCurrentRoleFromCookie(),
+    () => null,
+  )
+}
+
+export function AccountProfile() {
+  const router = useRouter()
+  const role = useCurrentRole()
+  const { data: me, isLoading, isError } = useMe()
+
+  const handleLogout = () => {
+    logout()
+    router.push('/login')
+    router.refresh()
+  }
+
+  // Prevent hydration mismatch by returning a skeleton if role isn't loaded
+  if (!role || isLoading) {
+    return (
+      <div className="flex animate-pulse flex-col gap-8">
+        <div className="h-64 w-full rounded-xl bg-muted" />
+        <div className="h-12 w-full rounded-md bg-muted" />
+      </div>
+    )
+  }
+
+  const username = me?.username ?? '—'
+  const fullName = me?.full_name ?? '—'
+  
+  // Optional: tracking last login date might be added later, for now hide or fallback.
+  // const lastLogin = '—' 
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-col items-center gap-4 rounded-xl border bg-card p-6 shadow-sm">
+        <UserCircle className="size-20 text-muted-foreground" aria-hidden="true" />
+
+        <div className="flex flex-col items-center gap-2">
+          <h2 className="text-xl font-bold">{username}</h2>
+          <Badge variant="secondary" className="text-base">
+            {ROLE_LABELS[role] ?? role}
+          </Badge>
+        </div>
+
+        <div className="w-full space-y-4 pt-4 text-left">
+          <div className="flex justify-between border-b pb-2 text-sm">
+            <span className="text-muted-foreground">Họ tên</span>
+            <span className="font-medium">{fullName}</span>
+          </div>
+        </div>
+      </div>
+
+      {isError && (
+        <p className="text-center text-sm text-destructive" role="alert">
+          Không thể tải thông tin tài khoản. Vui lòng đăng nhập lại.
+        </p>
+      )}
+
+      <Button
+        type="button"
+        variant="outline"
+        size="lg"
+        className="min-h-[48px] w-full gap-2 text-base text-destructive hover:bg-destructive/10 hover:text-destructive"
+        onClick={handleLogout}
+      >
+        <LogOut className="size-5" aria-hidden="true" />
+        Đăng xuất
+      </Button>
+    </div>
+  )
+}

--- a/src/app/(kiosk)/account/page.tsx
+++ b/src/app/(kiosk)/account/page.tsx
@@ -1,16 +1,13 @@
 import type { Metadata } from 'next'
-import { User } from 'lucide-react'
+import { AccountProfile } from './account-profile'
 
 export const metadata: Metadata = { title: 'Tài khoản' }
 
 export default function AccountPage() {
   return (
-    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-8 text-center">
-      <User className="size-12 text-muted-foreground" aria-hidden="true" />
-      <h1 className="text-xl font-bold">Tài khoản</h1>
-      <p className="text-sm text-muted-foreground">
-        Tính năng sẽ ra mắt trong Sprint 3.
-      </p>
+    <div className="flex min-h-[calc(100vh-140px)] flex-col gap-6 p-4">
+      <h1 className="text-2xl font-bold">Tài khoản</h1>
+      <AccountProfile />
     </div>
   )
 }

--- a/src/components/dashboard/side-nav.tsx
+++ b/src/components/dashboard/side-nav.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useSyncExternalStore } from 'react'
+import { useSyncExternalStore } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import { LayoutDashboard, Package, DollarSign, Layers, Boxes, ShoppingCart, ClipboardList, ClipboardCheck, Scissors, LogOut, UserCircle, Users } from 'lucide-react'
@@ -8,7 +8,7 @@ import { cn } from '@/lib/utils'
 import { Separator } from '@/components/ui/separator'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { logout } from '@/lib/hooks/use-auth'
+import { logout, useMe } from '@/lib/hooks/use-auth'
 import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
 
 // Full management nav — visible to admin, accountant, planner, warehouse, cnc_manager
@@ -49,21 +49,18 @@ function useCurrentRole(): string | null {
 }
 
 export function SideNav() {
-  const [mounted, setMounted] = useState(false)
   const pathname = usePathname()
   const router = useRouter()
   const role = useCurrentRole()
-
-  // Set mounted to true after initial render
-  useEffect(() => {
-    setMounted(true)
-  }, [])
+  const { data: me } = useMe()
 
   const handleLogout = () => {
     logout()
     router.push('/login')
     router.refresh()
   }
+
+  const displayName = me?.full_name || me?.username || ROLE_LABELS[role!] || role
 
   return (
     <aside className="fixed inset-y-0 left-0 z-20 flex w-60 flex-col border-r bg-sidebar">
@@ -78,7 +75,7 @@ export function SideNav() {
 
       {/* Nav links */}
       <nav className="flex flex-col gap-1 p-3">
-        {mounted && navItemsForRole(role).map(({ href, label, icon: Icon }) => {
+        {navItemsForRole(role).map(({ href, label, icon: Icon }) => {
           const active = pathname.startsWith(href)
           return (
             <Link
@@ -98,23 +95,29 @@ export function SideNav() {
         })}
       </nav>
 
-      <div className="mt-auto space-y-1 p-3">
+      <div className="mt-auto space-y-1 p-3 border-t">
         {/* Identity chip */}
-        {mounted && role && (
-          <div className="flex items-center gap-2 rounded-lg px-3 py-2">
-            <UserCircle className="size-5 shrink-0 text-sidebar-foreground/60" aria-hidden="true" />
-            <div className="min-w-0 flex-1">
-              <Badge variant="secondary" className="text-xs">
+        {role && (
+          <Link
+            href="/profile"
+            className="flex items-center gap-3 rounded-lg px-3 py-2 text-sidebar-foreground hover:bg-sidebar-accent/60 transition-colors"
+          >
+            <UserCircle className="size-8 shrink-0 text-sidebar-foreground/60" aria-hidden="true" />
+            <div className="min-w-0 flex-1 flex flex-col">
+              <span className="truncate text-sm font-medium leading-none mb-1">
+                {displayName}
+              </span>
+              <Badge variant="secondary" className="w-fit text-[10px] px-1 py-0 h-4 leading-none">
                 {ROLE_LABELS[role] ?? role}
               </Badge>
             </div>
-          </div>
+          </Link>
         )}
 
         <Button
           type="button"
           variant="ghost"
-          className="w-full justify-start gap-3"
+          className="w-full justify-start gap-3 mt-1 text-sidebar-foreground"
           onClick={handleLogout}
         >
           <LogOut className="size-5 shrink-0" aria-hidden="true" />

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -6,6 +6,9 @@
  * call it from the browser without CORS issues.
  */
 
+import { apiClient } from './client'
+import { User } from '@/types/api'
+
 export interface LoginRequest {
   username: string
   password: string
@@ -32,4 +35,6 @@ export const authApi = {
 
     return res.json() as Promise<LoginResponse>
   },
+
+  getMe: () => apiClient.get<User>('/users/me'),
 }

--- a/src/lib/auth/authorization.ts
+++ b/src/lib/auth/authorization.ts
@@ -23,6 +23,7 @@ export type AppResource =
   | 'remnant_store'
   | 'account'
   | 'users'
+  | 'profile'
 
 export type AppAction =
   | 'read'
@@ -50,6 +51,7 @@ const DASHBOARD_PATHS = [
   '/barcodes',
   '/cutting-dispatch',
   '/users',
+  '/profile',
 ]
 
 const KIOSK_PATHS = ['/scan', '/cutting-orders', '/report-cut', '/remnant-list', '/remnant-store', '/account']
@@ -66,6 +68,7 @@ const RESOURCE_BY_PATH: Array<{ path: string; resource: AppResource }> = [
   { path: '/barcodes', resource: 'barcodes' },
   { path: '/cutting-dispatch', resource: 'cutting_dispatch' },
   { path: '/users', resource: 'users' },
+  { path: '/profile', resource: 'profile' },
   { path: '/scan', resource: 'scan' },
   { path: '/cutting-orders', resource: 'cutting_orders' },
   { path: '/report-cut', resource: 'report_cut' },
@@ -85,6 +88,7 @@ const DASHBOARD_RESOURCES: AppResource[] = [
   'work_orders',
   'barcodes',
   'cutting_dispatch',
+  'profile',
 ]
 
 function matchPath(pathname: string, path: string): boolean {
@@ -119,10 +123,12 @@ const POLICY: Record<AppRole, Partial<Record<AppResource, readonly AppAction[]>>
     ...readOnly(DASHBOARD_RESOURCES),
   },
   foreman: {
+    ...readOnly(['profile']),
     work_orders: ['read', 'advance', 'consume', 'generate'],
     barcodes: ['read'],
   },
   cnc_manager: {
+    ...readOnly(['profile']),
     work_orders: ['read'],
     cutting_dispatch: ['read', 'assign'],
   },

--- a/src/lib/hooks/use-auth.ts
+++ b/src/lib/hooks/use-auth.ts
@@ -2,12 +2,15 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { useQuery } from '@tanstack/react-query'
 import { authApi, type LoginRequest } from '@/lib/api/auth'
 import { getDefaultRouteForRole } from '@/lib/auth/authorization'
 import { normalizeAuthToken } from '@/lib/auth/token'
 
 const TOKEN_KEY = 'auth_token'
 const ROLE_KEY = 'auth_role'
+const USERNAME_KEY = 'auth_username'
+const LAST_LOGIN_KEY = 'auth_last_login'
 
 // ── Cookie helpers ────────────────────────────────────────────────────────────
 // We store the token in BOTH:
@@ -32,8 +35,20 @@ export function getStoredToken(): string | null {
   return normalizeAuthToken(localStorage.getItem(TOKEN_KEY))
 }
 
+export function getStoredUsername(): string | null {
+  if (typeof window === 'undefined') return null
+  return localStorage.getItem(USERNAME_KEY)
+}
+
+export function getStoredLastLogin(): string | null {
+  if (typeof window === 'undefined') return null
+  return localStorage.getItem(LAST_LOGIN_KEY)
+}
+
 export function logout() {
   localStorage.removeItem(TOKEN_KEY)
+  localStorage.removeItem(USERNAME_KEY)
+  localStorage.removeItem(LAST_LOGIN_KEY)
   clearAuthCookies()
 }
 
@@ -76,4 +91,12 @@ export function useLogin(): UseLoginReturn {
   }
 
   return { login, isPending, error }
+}
+
+export function useMe() {
+  return useQuery({
+    queryKey: ['me'],
+    queryFn: () => authApi.getMe(),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  })
 }


### PR DESCRIPTION
## Summary
- Tạo trang profile cho Worker ở phân hệ Kiosk (`/kiosk/account`).
- Thêm trang profile tương tự cho các vai trò sử dụng Dashboard (`/profile`).
- Thay đổi trạng thái hiển thị User trên thanh SideNav (Dashboard) thành link điều hướng tới trang profile.
- Kết nối thành công tới API `GET /users/me` qua `useMe()` để hiển thị tên và họ người dùng thực tế.

## Technical notes
- New API types added: Không
- New query keys: `['me']`
- Breaking changes: Không

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] Tested trên local

Resolves #116