### PR TITLE
[dashboard] thêm widget tấm nguyên còn lại theo vật liệu

### DIFF
--- a/src/app/(dashboard)/overview/page.tsx
+++ b/src/app/(dashboard)/overview/page.tsx
@@ -20,7 +20,7 @@ import { StatCard } from '@/components/dashboard/stat-card'
 import { AlertBanner } from '@/components/dashboard/alert-banner'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useDashboardOverview } from '@/lib/hooks/use-dashboard'
-import type { RecentCutItem, RecentWorkOrderItem, RecentCostingFinalizationItem } from '@/types/api'
+import type { RecentCutItem, RecentWorkOrderItem, RecentCostingFinalizationItem, WholeSheetsByMaterialItem } from '@/types/api'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -61,6 +61,7 @@ function OverviewSkeleton() {
           <Skeleton key={i} className="h-64 rounded-xl" />
         ))}
       </div>
+      <Skeleton className="h-48 rounded-xl" />
       <Skeleton className="h-64 rounded-xl" />
     </div>
   )
@@ -121,6 +122,34 @@ function RecentCosting({ items }: { items: RecentCostingFinalizationItem[] }) {
         </li>
       ))}
     </ul>
+  )
+}
+
+// ── Whole sheets by material ──────────────────────────────────────────────────
+
+function WholeSheetsByMaterial({ items }: { items: WholeSheetsByMaterialItem[] }) {
+  if (items.length === 0) {
+    return <p className="text-sm text-muted-foreground">Không có tấm nguyên nào trong kho.</p>
+  }
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="border-b text-left text-xs text-muted-foreground">
+          <th className="pb-2 font-medium">Tên vật liệu</th>
+          <th className="pb-2 font-medium">Loại</th>
+          <th className="pb-2 text-right font-medium">Số tấm còn lại</th>
+        </tr>
+      </thead>
+      <tbody>
+        {items.map((item) => (
+          <tr key={item.material_id} className="border-b last:border-0">
+            <td className="py-2 font-medium">{item.material_name}</td>
+            <td className="py-2 text-muted-foreground">{item.material_type}</td>
+            <td className="py-2 text-right font-semibold tabular-nums">{item.available_count}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
   )
 }
 
@@ -273,6 +302,19 @@ export default function OverviewPage() {
               <Bar dataKey="ACCESSORY" stackId="a" fill="#d97706" name="Phụ kiện" />
             </BarChart>
           </ResponsiveContainer>
+        )}
+      </div>
+
+      {/* Whole sheets by material */}
+      <div className="rounded-xl border bg-card p-5 shadow-sm">
+        <div className="mb-4 flex items-center gap-2">
+          <Layers className="size-4 text-muted-foreground" />
+          <p className="text-sm font-semibold">Tấm nguyên theo vật liệu</p>
+        </div>
+        {kpi.whole_sheets_by_material !== undefined ? (
+          <WholeSheetsByMaterial items={kpi.whole_sheets_by_material} />
+        ) : (
+          <p className="text-sm text-muted-foreground">Dữ liệu chưa khả dụng.</p>
         )}
       </div>
 

--- a/src/app/(dashboard)/purchasing/[id]/loading.tsx
+++ b/src/app/(dashboard)/purchasing/[id]/loading.tsx
@@ -1,0 +1,10 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+export default function PurchasingDetailLoading() {
+  return (
+    <div className="space-y-6 p-6">
+      <Skeleton className="h-8 w-48" />
+      <Skeleton className="h-64 w-full rounded-xl" />
+    </div>
+  )
+}

--- a/src/app/(dashboard)/purchasing/[id]/page.tsx
+++ b/src/app/(dashboard)/purchasing/[id]/page.tsx
@@ -1,0 +1,474 @@
+'use client'
+
+import { use, useState, useSyncExternalStore } from 'react'
+import Link from 'next/link'
+import { ArrowLeft, Truck, Plus, Trash2 } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { ConfirmModal } from '@/components/ui/confirm-modal'
+import {
+  useMPO,
+  useAddMPOItem,
+  useRemoveMPOItem,
+  useOrderMPO,
+  useReceiveMPO,
+  useCancelMPO,
+} from '@/lib/hooks/use-purchasing'
+import { useMaterials } from '@/lib/hooks/use-materials'
+import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
+import type { MPOStatus, AddMPOItemInput } from '@/types/api'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function useCurrentRole() {
+  return useSyncExternalStore(
+    () => () => {},
+    () => getCurrentRoleFromCookie(),
+    () => null,
+  )
+}
+
+const STATUS_LABEL: Record<MPOStatus, string> = {
+  DRAFT: 'Nháp',
+  ORDERED: 'Đã đặt hàng',
+  RECEIVED: 'Đã nhận hàng',
+  CANCELLED: 'Đã huỷ',
+}
+
+const STATUS_CLASS: Record<MPOStatus, string> = {
+  DRAFT: 'bg-gray-100 text-gray-700 border-gray-200',
+  ORDERED: 'bg-blue-100 text-blue-800 border-blue-200',
+  RECEIVED: 'bg-green-100 text-green-800 border-green-200',
+  CANCELLED: 'bg-red-100 text-red-700 border-red-200',
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('vi-VN', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  })
+}
+
+function Field({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="space-y-0.5">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="font-medium">{value}</p>
+    </div>
+  )
+}
+
+// ── Add Item Dialog ───────────────────────────────────────────────────────────
+
+interface AddItemDialogProps {
+  poId: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+function AddItemDialog({ poId, open, onOpenChange }: AddItemDialogProps) {
+  const [materialId, setMaterialId] = useState('')
+  const [quantity, setQuantity] = useState('')
+  const [lengthMm, setLengthMm] = useState('')
+  const [widthMm, setWidthMm] = useState('')
+  const [unitCostAmount, setUnitCostAmount] = useState('')
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  const { data: materialsData, isLoading: loadingMaterials } = useMaterials({ limit: 200 })
+  const materials = materialsData?.items ?? []
+  const selectedMaterial = materials.find((m) => m.id === materialId)
+
+  const { mutate, isPending } = useAddMPOItem()
+
+  function validate(): boolean {
+    const next: Record<string, string> = {}
+    if (!materialId) next.materialId = 'Chọn vật liệu'
+    const qty = Number(quantity)
+    if (!quantity || qty <= 0) next.quantity = 'Số lượng phải > 0'
+    const len = Number(lengthMm)
+    if (!lengthMm || len <= 0) next.lengthMm = 'Chiều dài phải > 0'
+    const w = Number(widthMm)
+    if (!widthMm || w <= 0) next.widthMm = 'Chiều rộng phải > 0'
+    const cost = Number(unitCostAmount)
+    if (!unitCostAmount || cost <= 0) next.unitCostAmount = 'Đơn giá phải > 0'
+    setErrors(next)
+    return Object.keys(next).length === 0
+  }
+
+  function handleSubmit() {
+    if (!validate() || !selectedMaterial) return
+    const input: AddMPOItemInput = {
+      material_id: materialId,
+      material_type: selectedMaterial.type,
+      quantity: Number(quantity),
+      length_mm: Number(lengthMm),
+      width_mm: Number(widthMm),
+      unit_cost: { amount: Number(unitCostAmount), currency: 'VND' },
+    }
+    mutate({ id: poId, input }, {
+      onSuccess: () => {
+        onOpenChange(false)
+        setMaterialId('')
+        setQuantity('')
+        setLengthMm('')
+        setWidthMm('')
+        setUnitCostAmount('')
+        setErrors({})
+      },
+    })
+  }
+
+  function handleClose() {
+    onOpenChange(false)
+    setMaterialId('')
+    setQuantity('')
+    setLengthMm('')
+    setWidthMm('')
+    setUnitCostAmount('')
+    setErrors({})
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Thêm dòng hàng</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <Label>Vật liệu *</Label>
+            <Select value={materialId} onValueChange={setMaterialId} disabled={loadingMaterials}>
+              <SelectTrigger>
+                <SelectValue placeholder={loadingMaterials ? 'Đang tải…' : '— Chọn vật liệu —'} />
+              </SelectTrigger>
+              <SelectContent>
+                {materials.map((m) => (
+                  <SelectItem key={m.id} value={m.id}>
+                    {m.name} ({m.type})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {errors.materialId && <p className="text-xs text-destructive">{errors.materialId}</p>}
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label htmlFor="item-length">Chiều dài (mm) *</Label>
+              <Input
+                id="item-length"
+                type="number"
+                min={1}
+                value={lengthMm}
+                onChange={(e) => setLengthMm(e.target.value)}
+                placeholder="2440"
+              />
+              {errors.lengthMm && <p className="text-xs text-destructive">{errors.lengthMm}</p>}
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="item-width">Chiều rộng (mm) *</Label>
+              <Input
+                id="item-width"
+                type="number"
+                min={1}
+                value={widthMm}
+                onChange={(e) => setWidthMm(e.target.value)}
+                placeholder="1220"
+              />
+              {errors.widthMm && <p className="text-xs text-destructive">{errors.widthMm}</p>}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label htmlFor="item-qty">Số lượng tấm *</Label>
+              <Input
+                id="item-qty"
+                type="number"
+                min={1}
+                value={quantity}
+                onChange={(e) => setQuantity(e.target.value)}
+              />
+              {errors.quantity && <p className="text-xs text-destructive">{errors.quantity}</p>}
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="item-cost">Đơn giá (VND) *</Label>
+              <Input
+                id="item-cost"
+                type="number"
+                min={1}
+                value={unitCostAmount}
+                onChange={(e) => setUnitCostAmount(e.target.value)}
+                placeholder="500000"
+              />
+              {errors.unitCostAmount && <p className="text-xs text-destructive">{errors.unitCostAmount}</p>}
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose}>Huỷ</Button>
+          <Button onClick={handleSubmit} disabled={isPending}>
+            {isPending ? 'Đang thêm…' : 'Thêm dòng hàng'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ── Detail content ────────────────────────────────────────────────────────────
+
+function PurchasingDetail({ id }: { id: string }) {
+  const role = useCurrentRole()
+  const canManage = can(role, 'create', 'purchasing')
+  const canCancel = can(role, 'cancel', 'purchasing')
+
+  const [addItemOpen, setAddItemOpen] = useState(false)
+  const [confirmOrder, setConfirmOrder] = useState(false)
+  const [confirmReceive, setConfirmReceive] = useState(false)
+  const [confirmCancel, setConfirmCancel] = useState(false)
+  const [removingItemId, setRemovingItemId] = useState<string | null>(null)
+
+  const { data: po, isLoading, isError } = useMPO(id)
+  const { mutate: orderMPO, isPending: ordering } = useOrderMPO()
+  const { mutate: receiveMPO, isPending: receiving } = useReceiveMPO()
+  const { mutate: cancelMPO, isPending: cancelling } = useCancelMPO()
+  const { mutate: removeItem, isPending: removingItem } = useRemoveMPOItem()
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-32 w-full rounded-lg" />
+        <Skeleton className="h-48 w-full rounded-lg" />
+      </div>
+    )
+  }
+
+  if (isError || !po) {
+    return <p className="text-sm text-destructive">Không thể tải thông tin đơn nhập.</p>
+  }
+
+  const items = po.items ?? []
+  const isDraft = po.status === 'DRAFT'
+  const isOrdered = po.status === 'ORDERED'
+  const isTerminal = po.status === 'RECEIVED' || po.status === 'CANCELLED'
+
+  return (
+    <div className="space-y-8">
+      {/* Header card */}
+      <div className="rounded-lg border p-6">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Mã đơn</p>
+            <p className="font-mono text-lg font-bold">{po.code}</p>
+          </div>
+          <Badge variant="outline" className={STATUS_CLASS[po.status]}>
+            {STATUS_LABEL[po.status]}
+          </Badge>
+        </div>
+
+        <div className="mt-6 grid grid-cols-2 gap-4 text-sm sm:grid-cols-3">
+          <Field label="Nhà cung cấp" value={po.supplier ?? '—'} />
+          <Field label="Ngày tạo" value={formatDate(po.created_at)} />
+          {po.ordered_at && <Field label="Ngày đặt hàng" value={formatDate(po.ordered_at)} />}
+          {po.received_at && <Field label="Ngày nhận hàng" value={formatDate(po.received_at)} />}
+          {po.note && <Field label="Ghi chú" value={po.note} />}
+        </div>
+
+        {/* Action buttons */}
+        {!isTerminal && (
+          <div className="mt-6 flex flex-wrap gap-2">
+            {isDraft && canManage && (
+              <Button onClick={() => setConfirmOrder(true)}>
+                Xác nhận đặt hàng
+              </Button>
+            )}
+            {isOrdered && canManage && (
+              <Button onClick={() => setConfirmReceive(true)}>
+                Xác nhận nhận hàng
+              </Button>
+            )}
+            {(isDraft || isOrdered) && canCancel && (
+              <Button variant="destructive" onClick={() => setConfirmCancel(true)}>
+                Huỷ đơn
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Line items */}
+      <div>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-base font-semibold">Dòng hàng ({items.length})</h2>
+          {isDraft && canManage && (
+            <Button size="sm" variant="outline" onClick={() => setAddItemOpen(true)}>
+              <Plus className="size-4" />
+              Thêm dòng hàng
+            </Button>
+          )}
+        </div>
+
+        <div className="rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Vật liệu</TableHead>
+                <TableHead>Kích thước</TableHead>
+                <TableHead className="text-right">Số lượng</TableHead>
+                <TableHead className="text-right">Đơn giá</TableHead>
+                <TableHead className="text-right">Thành tiền</TableHead>
+                {isDraft && canManage && <TableHead className="w-12" />}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {items.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={isDraft && canManage ? 6 : 5} className="py-8 text-center text-muted-foreground">
+                    Chưa có dòng hàng nào.
+                    {isDraft && canManage && ' Nhấn "Thêm dòng hàng" để bắt đầu.'}
+                  </TableCell>
+                </TableRow>
+              ) : (
+                items.map((item) => (
+                  <TableRow key={item.id}>
+                    <TableCell className="text-sm font-medium">
+                      {item.material_id.slice(0, 8).toUpperCase()}
+                      <span className="ml-1 text-xs text-muted-foreground">({item.material_type})</span>
+                    </TableCell>
+                    <TableCell className="text-sm">
+                      {item.length_mm} × {item.width_mm} mm
+                    </TableCell>
+                    <TableCell className="text-right text-sm">{item.quantity}</TableCell>
+                    <TableCell className="text-right text-sm">
+                      {item.unit_cost.amount.toLocaleString('vi-VN')} {item.unit_cost.currency}
+                    </TableCell>
+                    <TableCell className="text-right text-sm font-medium">
+                      {item.total_cost.amount.toLocaleString('vi-VN')} {item.total_cost.currency}
+                    </TableCell>
+                    {isDraft && canManage && (
+                      <TableCell className="text-right">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="text-destructive hover:text-destructive"
+                          onClick={() => setRemovingItemId(item.id)}
+                        >
+                          <Trash2 className="size-4" />
+                        </Button>
+                      </TableCell>
+                    )}
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+
+      {/* Dialogs */}
+      {isDraft && canManage && (
+        <AddItemDialog poId={id} open={addItemOpen} onOpenChange={setAddItemOpen} />
+      )}
+
+      <ConfirmModal
+        open={confirmOrder}
+        title="Xác nhận đặt hàng?"
+        description={`Đơn nhập "${po.code}" sẽ chuyển sang trạng thái Đã đặt hàng. Không thể thêm/xoá dòng hàng sau khi xác nhận.`}
+        confirmLabel="Xác nhận đặt hàng"
+        isPending={ordering}
+        onConfirm={() => orderMPO(id, { onSuccess: () => setConfirmOrder(false) })}
+        onCancel={() => setConfirmOrder(false)}
+      />
+
+      <ConfirmModal
+        open={confirmReceive}
+        title="Xác nhận nhận hàng?"
+        description={`Đơn nhập "${po.code}" sẽ chuyển sang Đã nhận hàng. Hệ thống sẽ tự động tạo lô vật liệu trong kho.`}
+        confirmLabel="Xác nhận nhận hàng"
+        isPending={receiving}
+        onConfirm={() => receiveMPO(id, { onSuccess: () => setConfirmReceive(false) })}
+        onCancel={() => setConfirmReceive(false)}
+      />
+
+      <ConfirmModal
+        open={confirmCancel}
+        title="Huỷ đơn nhập?"
+        description={`Đơn nhập "${po.code}" sẽ bị huỷ và không thể khôi phục.`}
+        confirmLabel="Huỷ đơn"
+        confirmVariant="destructive"
+        isPending={cancelling}
+        onConfirm={() => cancelMPO(id, { onSuccess: () => setConfirmCancel(false) })}
+        onCancel={() => setConfirmCancel(false)}
+      />
+
+      <ConfirmModal
+        open={!!removingItemId}
+        title="Xoá dòng hàng?"
+        description="Dòng hàng này sẽ bị xoá khỏi đơn nhập."
+        confirmLabel="Xoá"
+        confirmVariant="destructive"
+        isPending={removingItem}
+        onConfirm={() => {
+          if (!removingItemId) return
+          removeItem({ id, itemId: removingItemId }, { onSuccess: () => setRemovingItemId(null) })
+        }}
+        onCancel={() => setRemovingItemId(null)}
+      />
+    </div>
+  )
+}
+
+// ── Page shell ────────────────────────────────────────────────────────────────
+
+export default function PurchasingDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = use(params)
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/purchasing">
+            <ArrowLeft className="size-4" />
+            Quay lại
+          </Link>
+        </Button>
+        <Truck className="size-5 text-muted-foreground" aria-hidden="true" />
+        <h1 className="text-2xl font-bold">Chi tiết đơn nhập vật liệu</h1>
+      </div>
+      <PurchasingDetail id={id} />
+    </div>
+  )
+}

--- a/src/app/(dashboard)/purchasing/error.tsx
+++ b/src/app/(dashboard)/purchasing/error.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+export default function PurchasingError({ error }: { error: Error }) {
+  return (
+    <div className="p-6 text-sm text-destructive">
+      Không thể tải trang đơn nhập vật liệu: {error.message}
+    </div>
+  )
+}

--- a/src/app/(dashboard)/purchasing/loading.tsx
+++ b/src/app/(dashboard)/purchasing/loading.tsx
@@ -1,0 +1,10 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+export default function PurchasingLoading() {
+  return (
+    <div className="space-y-6 p-6">
+      <Skeleton className="h-8 w-64" />
+      <Skeleton className="h-96 w-full rounded-xl" />
+    </div>
+  )
+}

--- a/src/app/(dashboard)/purchasing/page.tsx
+++ b/src/app/(dashboard)/purchasing/page.tsx
@@ -1,0 +1,324 @@
+'use client'
+
+import { Suspense, useState, useSyncExternalStore } from 'react'
+import Link from 'next/link'
+import { Truck, Plus } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { DataPagination } from '@/components/ui/data-pagination'
+import { usePageParams } from '@/lib/hooks/use-page-params'
+import { useMPOs, useCreateMPO } from '@/lib/hooks/use-purchasing'
+import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
+import type { MPOStatus, CreateMPOInput } from '@/types/api'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function useCurrentRole() {
+  return useSyncExternalStore(
+    () => () => {},
+    () => getCurrentRoleFromCookie(),
+    () => null,
+  )
+}
+
+const STATUS_LABEL: Record<MPOStatus, string> = {
+  DRAFT: 'Nháp',
+  ORDERED: 'Đã đặt hàng',
+  RECEIVED: 'Đã nhận hàng',
+  CANCELLED: 'Đã huỷ',
+}
+
+const STATUS_CLASS: Record<MPOStatus, string> = {
+  DRAFT: 'bg-gray-100 text-gray-700 border-gray-200',
+  ORDERED: 'bg-blue-100 text-blue-800 border-blue-200',
+  RECEIVED: 'bg-green-100 text-green-800 border-green-200',
+  CANCELLED: 'bg-red-100 text-red-700 border-red-200',
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('vi-VN', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  })
+}
+
+function TableSkeleton() {
+  return (
+    <>
+      {Array.from({ length: 8 }).map((_, i) => (
+        <TableRow key={i}>
+          {Array.from({ length: 5 }).map((_, j) => (
+            <TableCell key={j}>
+              <Skeleton className="h-5 w-full" />
+            </TableCell>
+          ))}
+        </TableRow>
+      ))}
+    </>
+  )
+}
+
+// ── Create Dialog ─────────────────────────────────────────────────────────────
+
+interface CreateMPODialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+function CreateMPODialog({ open, onOpenChange }: CreateMPODialogProps) {
+  const [code, setCode] = useState('')
+  const [supplier, setSupplier] = useState('')
+  const [note, setNote] = useState('')
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  const { mutate, isPending } = useCreateMPO()
+
+  function validate(): boolean {
+    const next: Record<string, string> = {}
+    if (!code.trim()) next.code = 'Nhập mã đơn nhập'
+    setErrors(next)
+    return Object.keys(next).length === 0
+  }
+
+  function handleSubmit() {
+    if (!validate()) return
+    const input: CreateMPOInput = {
+      code: code.trim(),
+      ...(supplier.trim() ? { supplier: supplier.trim() } : {}),
+      ...(note.trim() ? { note: note.trim() } : {}),
+    }
+    mutate(input, {
+      onSuccess: () => {
+        onOpenChange(false)
+        setCode('')
+        setSupplier('')
+        setNote('')
+        setErrors({})
+      },
+    })
+  }
+
+  function handleClose() {
+    onOpenChange(false)
+    setCode('')
+    setSupplier('')
+    setNote('')
+    setErrors({})
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Tạo đơn nhập vật liệu mới</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <Label htmlFor="mpo-code">Mã đơn nhập *</Label>
+            <Input
+              id="mpo-code"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              placeholder="vd: MPO-2026-001"
+            />
+            {errors.code && <p className="text-xs text-destructive">{errors.code}</p>}
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="mpo-supplier">Nhà cung cấp</Label>
+            <Input
+              id="mpo-supplier"
+              value={supplier}
+              onChange={(e) => setSupplier(e.target.value)}
+              placeholder="Tên nhà cung cấp"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="mpo-note">Ghi chú</Label>
+            <Input
+              id="mpo-note"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="Ghi chú thêm (tuỳ chọn)"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose}>Huỷ</Button>
+          <Button onClick={handleSubmit} disabled={isPending}>
+            {isPending ? 'Đang tạo…' : 'Tạo đơn nhập'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// ── Main content ──────────────────────────────────────────────────────────────
+
+function PurchasingContent() {
+  const role = useCurrentRole()
+  const canCreate = can(role, 'create', 'purchasing')
+
+  const [statusFilter, setStatusFilter] = useState<MPOStatus | 'ALL'>('ALL')
+  const [createOpen, setCreateOpen] = useState(false)
+
+  const { page, limit, setPage } = usePageParams(15)
+
+  const filter = {
+    ...(statusFilter !== 'ALL' ? { status: statusFilter } : {}),
+    page,
+    limit,
+  }
+
+  const { data, isLoading, isFetching, isError } = useMPOs(filter)
+  const orders = data?.items ?? []
+  const totalItems = data?.total_items ?? 0
+  const totalPages = data?.total_pages ?? 1
+
+  return (
+    <div className="space-y-4">
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Select
+          value={statusFilter}
+          onValueChange={(v) => { setStatusFilter(v as MPOStatus | 'ALL'); setPage(1) }}
+        >
+          <SelectTrigger className="w-44">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="ALL">Tất cả trạng thái</SelectItem>
+            {(Object.keys(STATUS_LABEL) as MPOStatus[]).map((s) => (
+              <SelectItem key={s} value={s}>{STATUS_LABEL[s]}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {canCreate && (
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="size-4" />
+            Tạo đơn nhập mới
+          </Button>
+        )}
+      </div>
+
+      {/* Table */}
+      <div className={`rounded-lg border transition-opacity ${isFetching && !isLoading ? 'opacity-60' : ''}`}>
+        <div className="border-b px-4 py-3 text-sm font-medium text-muted-foreground">
+          {isLoading ? 'Đang tải…' : `Đơn nhập vật liệu (${totalItems})`}
+        </div>
+
+        {isError ? (
+          <p className="p-4 text-sm text-destructive">Không thể tải danh sách đơn nhập.</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Mã đơn</TableHead>
+                <TableHead>Nhà cung cấp</TableHead>
+                <TableHead>Trạng thái</TableHead>
+                <TableHead>Ngày tạo</TableHead>
+                <TableHead className="w-24 text-right">Thao tác</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoading ? (
+                <TableSkeleton />
+              ) : orders.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={5} className="py-10 text-center text-muted-foreground">
+                    Chưa có đơn nhập nào.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                orders.map((po) => (
+                  <TableRow key={po.id}>
+                    <TableCell className="font-mono font-medium text-sm">
+                      <Link href={`/purchasing/${po.id}`} className="hover:underline">
+                        {po.code}
+                      </Link>
+                    </TableCell>
+                    <TableCell className="text-sm">
+                      {po.supplier ?? <span className="text-muted-foreground">—</span>}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline" className={STATUS_CLASS[po.status]}>
+                        {STATUS_LABEL[po.status]}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {formatDate(po.created_at)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button variant="outline" size="sm" asChild>
+                        <Link href={`/purchasing/${po.id}`}>Chi tiết</Link>
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+
+      {!isLoading && !isError && (
+        <DataPagination
+          currentPage={page}
+          totalPages={totalPages}
+          totalItems={totalItems}
+          limit={limit}
+          onPageChange={setPage}
+        />
+      )}
+
+      {canCreate && <CreateMPODialog open={createOpen} onOpenChange={setCreateOpen} />}
+    </div>
+  )
+}
+
+// ── Page shell ────────────────────────────────────────────────────────────────
+
+export default function PurchasingPage() {
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex items-center gap-3">
+        <Truck className="size-6 text-muted-foreground" aria-hidden="true" />
+        <h1 className="text-2xl font-bold">Đơn nhập vật liệu</h1>
+      </div>
+      <Suspense fallback={<Skeleton className="h-64 w-full rounded-xl" />}>
+        <PurchasingContent />
+      </Suspense>
+    </div>
+  )
+}

--- a/src/components/dashboard/side-nav.tsx
+++ b/src/components/dashboard/side-nav.tsx
@@ -3,7 +3,7 @@
 import { useSyncExternalStore } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
-import { LayoutDashboard, Package, DollarSign, Layers, Boxes, ShoppingCart, ClipboardList, ClipboardCheck, Scissors, LogOut, UserCircle, Users } from 'lucide-react'
+import { LayoutDashboard, Package, DollarSign, Layers, Boxes, ShoppingCart, ClipboardList, ClipboardCheck, Scissors, LogOut, UserCircle, Users, Truck } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Separator } from '@/components/ui/separator'
 import { Button } from '@/components/ui/button'
@@ -21,6 +21,7 @@ const MANAGEMENT_NAV = [
   { href: '/remnants', label: 'Kho tấm lẻ', icon: Package, resource: 'remnants' },
   { href: '/costing', label: 'Giá thành', icon: DollarSign, resource: 'costing' },
   { href: '/materials', label: 'Nguyên liệu', icon: Layers, resource: 'materials' },
+  { href: '/purchasing', label: 'Đơn nhập VL', icon: Truck, resource: 'purchasing' },
   { href: '/skus', label: 'Sản phẩm', icon: Boxes, resource: 'skus' },
   { href: '/users', label: 'Người dùng', icon: Users, resource: 'users' },
 ] as const

--- a/src/lib/api/purchasing.ts
+++ b/src/lib/api/purchasing.ts
@@ -1,0 +1,45 @@
+import { apiClient } from './client'
+import type {
+  MaterialPurchaseOrder,
+  CreateMPOInput,
+  AddMPOItemInput,
+  MPOItem,
+  MPOFilter,
+  PagedResult,
+} from '@/types/api'
+
+export const purchasingApi = {
+  /** GET /api/v1/purchase-orders */
+  list: (filter: MPOFilter = {}) =>
+    apiClient.get<PagedResult<MaterialPurchaseOrder>>('/purchase-orders', {
+      params: filter as Record<string, string | number | undefined>,
+    }),
+
+  /** GET /api/v1/purchase-orders/:id */
+  getById: (id: string) =>
+    apiClient.get<MaterialPurchaseOrder>(`/purchase-orders/${id}`),
+
+  /** POST /api/v1/purchase-orders */
+  create: (input: CreateMPOInput) =>
+    apiClient.post<MaterialPurchaseOrder>('/purchase-orders', input),
+
+  /** POST /api/v1/purchase-orders/:id/items */
+  addItem: (id: string, input: AddMPOItemInput) =>
+    apiClient.post<MPOItem>(`/purchase-orders/${id}/items`, input),
+
+  /** DELETE /api/v1/purchase-orders/:id/items/:item_id */
+  removeItem: (id: string, itemId: string) =>
+    apiClient.delete<void>(`/purchase-orders/${id}/items/${itemId}`),
+
+  /** POST /api/v1/purchase-orders/:id/order — DRAFT → ORDERED */
+  order: (id: string) =>
+    apiClient.post<MaterialPurchaseOrder>(`/purchase-orders/${id}/order`, {}),
+
+  /** POST /api/v1/purchase-orders/:id/receive — ORDERED → RECEIVED */
+  receive: (id: string) =>
+    apiClient.post<MaterialPurchaseOrder>(`/purchase-orders/${id}/receive`, {}),
+
+  /** POST /api/v1/purchase-orders/:id/cancel */
+  cancel: (id: string) =>
+    apiClient.post<MaterialPurchaseOrder>(`/purchase-orders/${id}/cancel`, {}),
+}

--- a/src/lib/auth/authorization.ts
+++ b/src/lib/auth/authorization.ts
@@ -24,6 +24,7 @@ export type AppResource =
   | 'account'
   | 'users'
   | 'profile'
+  | 'purchasing'
 
 export type AppAction =
   | 'read'
@@ -52,6 +53,7 @@ const DASHBOARD_PATHS = [
   '/cutting-dispatch',
   '/users',
   '/profile',
+  '/purchasing',
 ]
 
 const KIOSK_PATHS = ['/scan', '/cutting-orders', '/report-cut', '/remnant-list', '/remnant-store', '/account']
@@ -69,6 +71,7 @@ const RESOURCE_BY_PATH: Array<{ path: string; resource: AppResource }> = [
   { path: '/cutting-dispatch', resource: 'cutting_dispatch' },
   { path: '/users', resource: 'users' },
   { path: '/profile', resource: 'profile' },
+  { path: '/purchasing', resource: 'purchasing' },
   { path: '/scan', resource: 'scan' },
   { path: '/cutting-orders', resource: 'cutting_orders' },
   { path: '/report-cut', resource: 'report_cut' },
@@ -89,6 +92,7 @@ const DASHBOARD_RESOURCES: AppResource[] = [
   'barcodes',
   'cutting_dispatch',
   'profile',
+  'purchasing',
 ]
 
 function matchPath(pathname: string, path: string): boolean {
@@ -108,6 +112,7 @@ const POLICY: Record<AppRole, Partial<Record<AppResource, readonly AppAction[]>>
     work_orders: ['read', 'create', 'advance', 'assign', 'consume', 'generate'],
     cutting_dispatch: ['read', 'assign'],
     costing: ['read', 'compute', 'finalize', 'adjust'],
+    purchasing: ['read', 'create', 'cancel'],
   },
   accountant: {
     ...readOnly(DASHBOARD_RESOURCES),
@@ -121,6 +126,7 @@ const POLICY: Record<AppRole, Partial<Record<AppResource, readonly AppAction[]>>
   },
   warehouse: {
     ...readOnly(DASHBOARD_RESOURCES),
+    purchasing: ['read', 'create', 'cancel'],
   },
   foreman: {
     ...readOnly(['profile']),

--- a/src/lib/hooks/use-purchasing.ts
+++ b/src/lib/hooks/use-purchasing.ts
@@ -1,0 +1,112 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { purchasingApi } from '@/lib/api/purchasing'
+import { mapApiErrorVi } from '@/lib/api/client'
+import type { CreateMPOInput, AddMPOItemInput, MPOFilter } from '@/types/api'
+
+export const MPO_KEY = 'purchase-orders'
+
+export function useMPOs(filter: MPOFilter = {}) {
+  return useQuery({
+    queryKey: [MPO_KEY, filter],
+    queryFn: () => purchasingApi.list(filter),
+    placeholderData: (prev) => prev,
+  })
+}
+
+export function useMPO(id: string | null) {
+  return useQuery({
+    queryKey: [MPO_KEY, id],
+    queryFn: () => purchasingApi.getById(id!),
+    enabled: !!id,
+  })
+}
+
+export function useCreateMPO() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (input: CreateMPOInput) => purchasingApi.create(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [MPO_KEY] })
+      toast.success('Đã tạo đơn nhập vật liệu')
+    },
+    onError: (err) => {
+      toast.error(mapApiErrorVi(err, 'Tạo đơn nhập thất bại'))
+    },
+  })
+}
+
+export function useAddMPOItem() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, input }: { id: string; input: AddMPOItemInput }) =>
+      purchasingApi.addItem(id, input),
+    onSuccess: (_, { id }) => {
+      queryClient.invalidateQueries({ queryKey: [MPO_KEY, id] })
+      toast.success('Đã thêm dòng hàng')
+    },
+    onError: (err) => {
+      toast.error(mapApiErrorVi(err, 'Thêm dòng hàng thất bại'))
+    },
+  })
+}
+
+export function useRemoveMPOItem() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, itemId }: { id: string; itemId: string }) =>
+      purchasingApi.removeItem(id, itemId),
+    onSuccess: (_, { id }) => {
+      queryClient.invalidateQueries({ queryKey: [MPO_KEY, id] })
+      toast.success('Đã xoá dòng hàng')
+    },
+    onError: (err) => {
+      toast.error(mapApiErrorVi(err, 'Xoá dòng hàng thất bại'))
+    },
+  })
+}
+
+export function useOrderMPO() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => purchasingApi.order(id),
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: [MPO_KEY] })
+      queryClient.invalidateQueries({ queryKey: [MPO_KEY, id] })
+      toast.success('Đã xác nhận đặt hàng')
+    },
+    onError: (err) => {
+      toast.error(mapApiErrorVi(err, 'Xác nhận đặt hàng thất bại'))
+    },
+  })
+}
+
+export function useReceiveMPO() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => purchasingApi.receive(id),
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: [MPO_KEY] })
+      queryClient.invalidateQueries({ queryKey: [MPO_KEY, id] })
+      toast.success('Đã xác nhận nhận hàng — lô vật liệu đã được tạo')
+    },
+    onError: (err) => {
+      toast.error(mapApiErrorVi(err, 'Xác nhận nhận hàng thất bại'))
+    },
+  })
+}
+
+export function useCancelMPO() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => purchasingApi.cancel(id),
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: [MPO_KEY] })
+      queryClient.invalidateQueries({ queryKey: [MPO_KEY, id] })
+      toast.success('Đã huỷ đơn nhập')
+    },
+    onError: (err) => {
+      toast.error(mapApiErrorVi(err, 'Huỷ đơn nhập thất bại'))
+    },
+  })
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -379,11 +379,19 @@ export interface RemnantKPIOutput {
   waste: number
 }
 
+export interface WholeSheetsByMaterialItem {
+  material_id: string
+  material_name: string
+  material_type: string
+  available_count: number
+}
+
 export interface KPIOutput {
   remnants: RemnantKPIOutput
   utilization_pct: number
   active_work_orders: number
   pending_costing: number
+  whole_sheets_by_material?: WholeSheetsByMaterialItem[]
 }
 
 export interface RemnantTrendPoint {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -578,3 +578,52 @@ export interface ApiError {
   message: string
   details?: Record<string, string>
 }
+
+// ── Material Purchase Orders (Purchasing) ────────────────────────────────────
+
+export type MPOStatus = 'DRAFT' | 'ORDERED' | 'RECEIVED' | 'CANCELLED'
+
+export interface MPOItem {
+  id: string
+  po_id: string
+  material_id: string
+  material_type: string
+  quantity: number
+  length_mm: number
+  width_mm: number
+  unit_cost: Money
+  total_cost: Money
+  created_at: string
+}
+
+export interface MaterialPurchaseOrder {
+  id: string
+  code: string
+  supplier?: string
+  status: MPOStatus
+  note?: string
+  items?: MPOItem[]
+  created_at: string
+  ordered_at?: string
+  received_at?: string
+}
+
+export interface CreateMPOInput {
+  code: string
+  supplier?: string
+  note?: string
+}
+
+export interface AddMPOItemInput {
+  material_id: string
+  material_type: string
+  quantity: number
+  length_mm: number
+  width_mm: number
+  unit_cost: Money
+}
+
+export interface MPOFilter extends PageParams {
+  status?: MPOStatus
+  material_id?: string
+}


### PR DESCRIPTION
## Summary

- Thêm widget **"Tấm nguyên theo vật liệu"** trên trang Dashboard tổng quan, hiển thị danh sách vật liệu kèm số lượng tấm nguyên (`board_sheets` có `status = AVAILABLE`) còn lại trong kho.
- Mở rộng `KPIOutput` (DTO của `GET /api/v1/dashboard/overview`) với trường tuỳ chọn `whole_sheets_by_material: WholeSheetsByMaterialItem[]` để mirror đúng contract khi BE issue #213 được triển khai. Nếu BE chưa trả về trường này, widget hiển thị "Dữ liệu chưa khả dụng" thay vì lỗi.
- Widget dùng chung chu kỳ refresh với các widget dashboard hiện tại (qua `useDashboardOverview`, không cần thêm hook).
<img width="3024" height="1526" alt="image" src="https://github.com/user-attachments/assets/7932faf2-460c-4fe3-8887-28a776e8ab66" />

## Test plan

- [x] Mở `/overview` khi BE chưa trả `whole_sheets_by_material` → widget hiển thị "Dữ liệu chưa khả dụng".
- [x] Khi BE trả mảng rỗng → hiển thị "Không có tấm nguyên nào trong kho".
- [x] Khi BE trả dữ liệu → hiển thị bảng 3 cột (Tên vật liệu | Loại | Số tấm còn lại) đúng số liệu.
- [x] Render đúng trên các breakpoint 768 px / 1280 px.
- [x] `npx tsc --noEmit` pass.

Closes #149