### PR TITLE
[inventory] khoá xuất tấm mới khi tràn kho + ghi đè admin (#157)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,16 @@
 import type { NextConfig } from 'next'
+import path from 'node:path'
 
 const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8080'
 
 const nextConfig: NextConfig = {
+  // Pin Turbopack's workspace root to this project. Without this, Turbopack
+  // walks up and picks /Users/.../Vmarble-project (which contains a stray
+  // package-lock.json) as the root, which then fails to resolve `tailwindcss`.
+  turbopack: {
+    root: path.resolve(__dirname),
+  },
+
   // Images from the Go API
   images: {
     remotePatterns: [

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { SideNav } from '@/components/dashboard/side-nav'
+import { OverflowBanner } from '@/components/inventory/overflow-banner'
 
 export const metadata: Metadata = {
   title: {
@@ -20,6 +21,7 @@ export default function DashboardLayout({
 
       {/* Main content */}
       <main className="flex-1 overflow-y-auto bg-muted/30 p-6 md:ml-60">
+        <OverflowBanner className="-mx-6 -mt-6 mb-6" />
         {children}
       </main>
     </div>

--- a/src/app/(kiosk)/layout.tsx
+++ b/src/app/(kiosk)/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { BottomNav } from '@/components/kiosk/bottom-nav'
 import { KioskLogoutButton } from '@/components/kiosk/logout-button'
+import { OverflowBanner } from '@/components/inventory/overflow-banner'
 
 export const metadata: Metadata = {
   title: {
@@ -21,6 +22,8 @@ export default function KioskLayout({
         <span className="text-base font-semibold">Vmarble Kiosk</span>
         <KioskLogoutButton />
       </header>
+
+      <OverflowBanner />
 
       {/* Page content — padded bottom for fixed nav */}
       <main className="flex-1 overflow-y-auto pb-20">{children}</main>

--- a/src/components/inventory/issue-new-sheet-button.tsx
+++ b/src/components/inventory/issue-new-sheet-button.tsx
@@ -1,0 +1,195 @@
+'use client'
+
+import { useState, useSyncExternalStore } from 'react'
+import { Lock, AlertTriangle, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { ApiClientError, mapApiErrorVi } from '@/lib/api/client'
+import { getCurrentRoleFromCookie } from '@/lib/auth/authorization'
+import { useOverflowStatus, usePreAssignSheet } from '@/lib/hooks/use-inventory'
+
+function useCurrentRole(): string | null {
+  return useSyncExternalStore(
+    () => () => {},
+    () => getCurrentRoleFromCookie(),
+    () => null,
+  )
+}
+
+interface IssueNewSheetButtonProps {
+  sheetId: string
+  workOrderId: string
+  /** Visible button label, e.g. "Cấp tấm cho lệnh cắt" */
+  label?: string
+  /** Override variant; defaults to default (primary) */
+  variant?: React.ComponentProps<typeof Button>['variant']
+  size?: React.ComponentProps<typeof Button>['size']
+  className?: string
+  onSuccess?: () => void
+}
+
+/**
+ * Pre-assigns a board sheet to a work order. Honours the overflow lock:
+ * when overflow status is RED the button is disabled for everyone, and only
+ * admins see a "Ghi đè (admin)" link that opens a reason-input modal and
+ * retries with `force=true`.
+ */
+export function IssueNewSheetButton({
+  sheetId,
+  workOrderId,
+  label = 'Cấp tấm cho lệnh cắt',
+  variant = 'default',
+  size = 'default',
+  className,
+  onSuccess,
+}: IssueNewSheetButtonProps) {
+  const role = useCurrentRole()
+  const isAdmin = role === 'admin'
+  const { data: overflow } = useOverflowStatus()
+  const blocked = overflow?.block_new_sheet_issue ?? false
+
+  const [overrideOpen, setOverrideOpen] = useState(false)
+  const { mutate, isPending } = usePreAssignSheet()
+
+  const issue = (force: boolean, reason?: string) => {
+    mutate(
+      { sheetId, workOrderId, force, reason },
+      {
+        onSuccess: () => {
+          toast.success(force ? 'Đã ghi đè và cấp tấm mới' : 'Đã cấp tấm cho lệnh cắt')
+          setOverrideOpen(false)
+          onSuccess?.()
+        },
+        onError: (err) => {
+          if (err instanceof ApiClientError && err.status === 412) {
+            toast.error('Kho tấm lẻ đang quá tải — không thể xuất tấm mới.')
+            return
+          }
+          toast.error(mapApiErrorVi(err, 'Không thể cấp tấm. Vui lòng thử lại.'))
+        },
+      },
+    )
+  }
+
+  if (blocked) {
+    return (
+      <div className={className}>
+        <div className="inline-flex items-center gap-2">
+          <Button variant={variant} size={size} disabled>
+            <Lock className="size-4" aria-hidden="true" />
+            {label}
+          </Button>
+          <span className="text-xs text-muted-foreground">
+            Khoá do kho tấm lẻ vượt {overflow?.threshold_pct?.toFixed(0) ?? '15'}%
+          </span>
+        </div>
+        {isAdmin && (
+          <button
+            type="button"
+            onClick={() => setOverrideOpen(true)}
+            className="mt-1 block text-xs font-medium text-red-700 underline-offset-2 hover:underline"
+          >
+            Ghi đè (admin)
+          </button>
+        )}
+
+        <OverflowBypassDialog
+          open={overrideOpen}
+          onOpenChange={setOverrideOpen}
+          isPending={isPending}
+          onConfirm={(reason) => issue(true, reason)}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <Button
+      variant={variant}
+      size={size}
+      className={className}
+      disabled={isPending}
+      onClick={() => issue(false)}
+    >
+      {isPending ? <Loader2 className="size-4 animate-spin" /> : null}
+      {label}
+    </Button>
+  )
+}
+
+interface OverflowBypassDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  isPending: boolean
+  onConfirm: (reason: string) => void
+}
+
+function OverflowBypassDialog({ open, onOpenChange, isPending, onConfirm }: OverflowBypassDialogProps) {
+  const [reason, setReason] = useState('')
+  const [touched, setTouched] = useState(false)
+  const reasonInvalid = reason.trim().length < 10
+
+  const handleClose = () => {
+    setReason('')
+    setTouched(false)
+    onOpenChange(false)
+  }
+
+  const handleSubmit = () => {
+    setTouched(true)
+    if (reasonInvalid) return
+    onConfirm(reason.trim())
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => (o ? onOpenChange(true) : handleClose())}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-red-800">
+            <AlertTriangle className="size-5" aria-hidden="true" />
+            Ghi đè khoá tràn kho?
+          </DialogTitle>
+          <DialogDescription>
+            Hành động này sẽ xuất một tấm nguyên trong khi kho tấm lẻ đang vượt ngưỡng. Lý do sẽ
+            được ghi vào nhật ký kiểm toán (<code>OVERFLOW_BYPASSED</code>).
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-1">
+          <Label htmlFor="overflow-bypass-reason">Lý do ghi đè *</Label>
+          <Textarea
+            id="overflow-bypass-reason"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            onBlur={() => setTouched(true)}
+            rows={3}
+            placeholder="vd: Lệnh gấp cho khách VIP, không có tấm lẻ phù hợp kích thước"
+          />
+          {touched && reasonInvalid && (
+            <p className="text-xs text-destructive">Lý do phải dài ít nhất 10 ký tự.</p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose} disabled={isPending}>
+            Huỷ
+          </Button>
+          <Button variant="destructive" onClick={handleSubmit} disabled={isPending}>
+            {isPending ? <Loader2 className="size-4 animate-spin" /> : null}
+            Ghi đè & xuất tấm
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/inventory/overflow-banner.test.tsx
+++ b/src/components/inventory/overflow-banner.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+const mockUseOverflowStatus = vi.fn()
+
+vi.mock('@/lib/hooks/use-inventory', () => ({
+  useOverflowStatus: () => mockUseOverflowStatus(),
+}))
+
+import { OverflowBanner } from '@/components/inventory/overflow-banner'
+
+describe('OverflowBanner', () => {
+  it('renders nothing when query has no data', () => {
+    mockUseOverflowStatus.mockReturnValue({ data: undefined })
+    const { container } = render(<OverflowBanner />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when status is GREEN (block flag false)', () => {
+    mockUseOverflowStatus.mockReturnValue({
+      data: {
+        status: 'GREEN',
+        overflow_pct: 8.2,
+        threshold_pct: 15,
+        block_new_sheet_issue: false,
+        total_remnant_area_mm2: 0,
+        total_sheet_area_mm2: 0,
+      },
+    })
+    const { container } = render(<OverflowBanner />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the red sticky banner when block_new_sheet_issue is true', () => {
+    mockUseOverflowStatus.mockReturnValue({
+      data: {
+        status: 'RED',
+        overflow_pct: 18.4,
+        threshold_pct: 15,
+        block_new_sheet_issue: true,
+        total_remnant_area_mm2: 0,
+        total_sheet_area_mm2: 0,
+      },
+    })
+    render(<OverflowBanner />)
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText(/Kho tấm lẻ vượt 15%/)).toBeInTheDocument()
+    expect(screen.getByText(/18\.4%/)).toBeInTheDocument()
+  })
+})

--- a/src/components/inventory/overflow-banner.tsx
+++ b/src/components/inventory/overflow-banner.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { AlertTriangle } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useOverflowStatus } from '@/lib/hooks/use-inventory'
+
+/**
+ * Sticky red banner shown across kiosk + dashboard layouts when remnant
+ * inventory exceeds the overflow threshold (BR-K05). The banner forces the
+ * shop floor to consume remnants before issuing a new whole sheet.
+ *
+ * Renders nothing when status is GREEN/YELLOW or while the query is pending.
+ */
+export function OverflowBanner({ className }: { className?: string }) {
+  const { data } = useOverflowStatus()
+  if (!data || !data.block_new_sheet_issue) return null
+
+  const pct = Number.isFinite(data.overflow_pct) ? data.overflow_pct.toFixed(1) : '—'
+  const threshold = Number.isFinite(data.threshold_pct) ? data.threshold_pct.toFixed(0) : '15'
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        'sticky top-0 z-30 flex items-start gap-3 border-b border-red-300 bg-red-50 px-4 py-3 text-red-900 shadow-sm dark:border-red-800 dark:bg-red-950 dark:text-red-100',
+        className,
+      )}
+    >
+      <AlertTriangle className="mt-0.5 size-5 shrink-0" aria-hidden="true" />
+      <div className="text-sm leading-snug">
+        <p className="font-semibold">
+          Kho tấm lẻ vượt {threshold}% — phải tiêu thụ trước khi xuất tấm mới
+        </p>
+        <p className="text-xs opacity-90">
+          Tỷ lệ hiện tại: {pct}%. Nút &ldquo;Xuất tấm mới&rdquo; / &ldquo;Cấp tấm cho lệnh cắt&rdquo; tạm khoá. Quản trị viên có thể ghi đè kèm lý do.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/api/inventory.ts
+++ b/src/lib/api/inventory.ts
@@ -1,0 +1,32 @@
+import type { OverflowStatus } from '@/types/api'
+import { apiClient } from './client'
+
+export interface PreAssignSheetInput {
+  sheetId: string
+  workOrderId: string
+  /** Set true with a non-empty reason to bypass overflow lock (admin only) */
+  force?: boolean
+  reason?: string
+}
+
+export const inventoryApi = {
+  /** GET /api/v1/inventory/overflow-status */
+  getOverflowStatus: () => apiClient.get<OverflowStatus>('/inventory/overflow-status'),
+
+  /**
+   * POST /api/v1/inventory/sheets/{id}/pre-assign?force=true&reason=...
+   * Reserves a board sheet for a work order. Returns 412 when overflow is RED
+   * and `force` is not set; admin can bypass by passing force + reason.
+   */
+  preAssignSheet: ({ sheetId, workOrderId, force, reason }: PreAssignSheetInput) =>
+    apiClient.post<void>(
+      `/inventory/sheets/${sheetId}/pre-assign`,
+      { work_order_id: workOrderId },
+      {
+        params: {
+          force: force ? 'true' : undefined,
+          reason: reason && reason.length > 0 ? reason : undefined,
+        },
+      },
+    ),
+}

--- a/src/lib/hooks/use-inventory.ts
+++ b/src/lib/hooks/use-inventory.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { inventoryApi, type PreAssignSheetInput } from '@/lib/api/inventory'
+
+export const OVERFLOW_KEY = 'inventory-overflow-status'
+
+/**
+ * Polls `GET /inventory/overflow-status` every 30s. The hook is used both by
+ * the global red banner and by every "Issue new sheet" button to gate UI.
+ */
+export function useOverflowStatus() {
+  return useQuery({
+    queryKey: [OVERFLOW_KEY],
+    queryFn: inventoryApi.getOverflowStatus,
+    staleTime: 15_000,
+    refetchInterval: 30_000,
+    refetchOnWindowFocus: true,
+  })
+}
+
+export function usePreAssignSheet() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (input: PreAssignSheetInput) => inventoryApi.preAssignSheet(input),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: [OVERFLOW_KEY] })
+      qc.invalidateQueries({ queryKey: ['inventory-sheets'] })
+    },
+  })
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -105,13 +105,17 @@ export interface StorageLocation {
   isActive: boolean
 }
 
+/** GET /api/v1/inventory/overflow-status — mirrors Go inventory.OverflowStatus */
 export interface OverflowStatus {
   status: 'GREEN' | 'YELLOW' | 'RED'
-  remnantAreaM2: number
-  rawStockAreaM2: number
-  utilizationPct: number
-  blockNewSheetIssue: boolean
-  message: string
+  /** Total remnant area / total raw stock area, expressed as percent (0–100+) */
+  overflow_pct: number
+  /** Threshold percent above which `status` flips to RED (default 15) */
+  threshold_pct: number
+  /** True when sheet pre-assignment must be blocked (status === 'RED') */
+  block_new_sheet_issue: boolean
+  total_remnant_area_mm2: number
+  total_sheet_area_mm2: number
 }
 
 // ── Purchase Orders ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Thêm **OverflowBanner** đỏ ở cả layout `(kiosk)` và `(dashboard)` — hiển thị khi `block_new_sheet_issue=true`, ẩn hoàn toàn khi GREEN/YELLOW (BR-K05).
- Thêm component dùng chung **IssueNewSheetButton**: tự đọc trạng thái overflow, khoá nút khi RED, admin có link "Ghi đè (admin)" mở dialog yêu cầu lý do ≥10 ký tự rồi gọi pre-assign với `force=true`.
- Đồng bộ DTO `OverflowStatus` với BE Go (snake_case): `status / overflow_pct / threshold_pct / block_new_sheet_issue / total_remnant_area_mm2 / total_sheet_area_mm2`.
- Hot-fix `next.config.ts`: pin `turbopack.root` để Turbopack không trượt workspace ra parent dir → khắc phục lỗi `Can't resolve 'tailwindcss'` khi `npm run dev`.

## Files
- `src/components/inventory/overflow-banner.tsx` (new)
- `src/components/inventory/overflow-banner.test.tsx` (new — vitest, 3 cases)
- `src/components/inventory/issue-new-sheet-button.tsx` (new)
- `src/lib/api/inventory.ts` (new — `getOverflowStatus`, `preAssignSheet`)
- `src/lib/hooks/use-inventory.ts` (new — `useOverflowStatus` poll 30s, `usePreAssignSheet` invalidate)
- `src/types/api.ts` (snake_case `OverflowStatus`)
- `src/app/(kiosk)/layout.tsx` + `src/app/(dashboard)/layout.tsx` (gắn banner)
- `next.config.ts` (turbopack root pin)

## API hợp đồng (đồng bộ với BE)
- `GET /inventory/overflow-status` → đã có ở BE.
- `POST /inventory/sheets/:sheetId/pre-assign?force=true&reason=...` body `{ work_order_id }` — chờ BE handler #222 wire vào router; FE đã sẵn sàng tiêu thụ.
- 412 PreconditionFailed → toast tiếng Việt "Kho tấm lẻ đang quá tải — không thể xuất tấm mới."

## Test plan
- [x] `npx tsc --noEmit` sạch
- [x] `npx eslint` sạch trên file mới/sửa
- [x] `npm run test:unit -- --run src/components/inventory/overflow-banner.test.tsx` → 3 passed (empty / GREEN / RED)
- [x] `npm run dev` khởi động sạch sau khi pin `turbopack.root`
- [ ] Manual @ 375 / 768 / 1280 px:
  - [ ] BE trả `block_new_sheet_issue=false` → banner ẩn, nút bình thường.
  - [ ] BE trả `block_new_sheet_issue=true` → banner đỏ ở đầu kiosk + dashboard, nút khoá kèm icon Lock và chú thích ngưỡng.
  - [ ] Role admin → thấy "Ghi đè (admin)", dialog từ chối lý do <10 ký tự, gọi pre-assign với `force=true`.
  - [ ] Role non-admin → không thấy link override.
  - [ ] BE trả 412 → toast cảnh báo, banner vẫn giữ.

Closes #157