### PR TITLE
[work-orders] ẩn 'Bắt đầu cắt' khi không phải CNC được phân công (#164)

### DIFF
--- a/src/app/(dashboard)/work-orders/[id]/page.tsx
+++ b/src/app/(dashboard)/work-orders/[id]/page.tsx
@@ -44,6 +44,8 @@ import { useGenerateBarcode, useBarcodesForWorkOrder, useBarcodeScanEvents } fro
 import { useWorkOrderCosting, useComputeCosting } from '@/lib/hooks/use-costing'
 import { ApiClientError } from '@/lib/api/client'
 import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
+import { evaluateStartCutGate, startCutTooltip } from '@/lib/auth/work-order-gate'
+import { useMe } from '@/lib/hooks/use-auth'
 import type {
   WorkOrderStatus,
   BarcodeRecord,
@@ -339,6 +341,7 @@ function GenerateBarcodeDialog({ wo, open, onClose }: {
 
 function WorkOrderDetail({ id }: { id: string }) {
   const role = useCurrentRole()
+  const { data: me } = useMe()
   const canGenerateBarcode = can(role, 'generate', 'work_orders')
   const canConsume = can(role, 'consume', 'work_orders')
 
@@ -510,25 +513,53 @@ function WorkOrderDetail({ id }: { id: string }) {
                   <Field label="Nhân công" value={`${costingRecord.labor_cost.amount} ${costingRecord.labor_cost.currency}`} />
                   <Field label="Tổng chi phí" value={<span className="font-bold">{costingRecord.total_cost.amount} {costingRecord.total_cost.currency}</span>} />
                 </div>
-                <Button
-                  size="sm"
-                  onClick={() => {
-                    const input: AdvanceStatusInput = { status: 'IN_CUTTING' }
-                    advance(
-                      { id: wo.id, input },
-                      {
-                        onError: (err) => {
-                          if (err instanceof ApiClientError && err.status === 412) {
-                            toast.error('Chưa đủ điều kiện để bắt đầu cắt. Kiểm tra lại giá thành hoặc phân công.')
-                          }
-                        },
-                      },
+                {(() => {
+                  const gate = evaluateStartCutGate({ wo, currentUserId: me?.id ?? null, role })
+
+                  if (gate.kind === 'unassigned-dispatchable') {
+                    return (
+                      <div className="flex items-center gap-3">
+                        <Button size="sm" variant="outline" asChild>
+                          <Link href={`/cutting-dispatch?focus=${wo.id}`}>Điều phối</Link>
+                        </Button>
+                        <p className="text-xs text-muted-foreground">Lệnh chưa phân công CNC</p>
+                      </div>
                     )
-                  }}
-                  disabled={advancing}
-                >
-                  {advancing ? 'Đang xử lý…' : 'Bắt đầu cắt'}
-                </Button>
+                  }
+
+                  if (gate.kind !== 'allowed') {
+                    return (
+                      <div className="flex items-center gap-3">
+                        <Button size="sm" variant="outline" disabled title={startCutTooltip(gate)}>
+                          Bắt đầu cắt
+                        </Button>
+                        <p className="text-xs text-muted-foreground">{startCutTooltip(gate)}</p>
+                      </div>
+                    )
+                  }
+
+                  return (
+                    <Button
+                      size="sm"
+                      onClick={() => {
+                        const input: AdvanceStatusInput = { status: 'IN_CUTTING' }
+                        advance(
+                          { id: wo.id, input },
+                          {
+                            onError: (err) => {
+                              if (err instanceof ApiClientError && err.status === 412) {
+                                toast.error('Chưa đủ điều kiện để bắt đầu cắt. Kiểm tra lại giá thành hoặc phân công.')
+                              }
+                            },
+                          },
+                        )
+                      }}
+                      disabled={advancing}
+                    >
+                      {advancing ? 'Đang xử lý…' : 'Bắt đầu cắt'}
+                    </Button>
+                  )
+                })()}
               </div>
             ) : (
               <div className="space-y-3">

--- a/src/app/(dashboard)/work-orders/page.tsx
+++ b/src/app/(dashboard)/work-orders/page.tsx
@@ -59,6 +59,8 @@ import { DataPagination } from '@/components/ui/data-pagination'
 import { cn } from '@/lib/utils'
 import { useDebounce } from '@/lib/hooks/use-debounce'
 import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
+import { evaluateStartCutGate, startCutTooltip } from '@/lib/auth/work-order-gate'
+import { useMe } from '@/lib/hooks/use-auth'
 import type {
   WorkOrderStatus,
   WorkOrder,
@@ -758,6 +760,7 @@ function PlanFilterCombobox({
 
 function WorkOrdersContent() {
   const role = useCurrentRole()
+  const { data: me } = useMe()
   const canCreateWorkOrder = can(role, 'create', 'work_orders')
   const canAdvanceWorkOrder = can(role, 'advance', 'work_orders')
 
@@ -833,6 +836,53 @@ function WorkOrdersContent() {
     )
   }
 
+  function renderAdvanceCell(wo: WorkOrder) {
+    if (wo.status !== 'PLANNED') {
+      return (
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => setAdvanceTarget(wo)}
+        >
+          {ADVANCE_LABEL[wo.status]}
+        </Button>
+      )
+    }
+
+    const gate = evaluateStartCutGate({
+      wo,
+      currentUserId: me?.id ?? null,
+      role,
+    })
+
+    if (gate.kind === 'allowed') {
+      return (
+        <Button size="sm" onClick={() => setAdvanceTarget(wo)}>
+          {ADVANCE_LABEL.PLANNED}
+        </Button>
+      )
+    }
+
+    if (gate.kind === 'unassigned-dispatchable') {
+      return (
+        <Button size="sm" variant="outline" asChild>
+          <Link href={`/cutting-dispatch?focus=${wo.id}`}>Điều phối</Link>
+        </Button>
+      )
+    }
+
+    return (
+      <Button
+        size="sm"
+        variant="outline"
+        disabled
+        title={startCutTooltip(gate)}
+      >
+        {ADVANCE_LABEL.PLANNED}
+      </Button>
+    )
+  }
+
   function renderWorkOrderRow(wo: WorkOrder, muted = false) {
     const canAdvance = NEXT_STATUS[wo.status] !== null
     return (
@@ -865,15 +915,7 @@ function WorkOrdersContent() {
             <Button variant="outline" size="sm" asChild>
               <Link href={`/work-orders/${wo.id}`}>Chi tiết</Link>
             </Button>
-            {canAdvance && canAdvanceWorkOrder && (
-              <Button
-                size="sm"
-                variant={wo.status === 'PLANNED' ? 'default' : 'outline'}
-                onClick={() => setAdvanceTarget(wo)}
-              >
-                {ADVANCE_LABEL[wo.status]}
-              </Button>
-            )}
+            {canAdvance && canAdvanceWorkOrder && renderAdvanceCell(wo)}
           </div>
         </TableCell>
       </TableRow>

--- a/src/lib/auth/work-order-gate.test.ts
+++ b/src/lib/auth/work-order-gate.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { evaluateStartCutGate, startCutTooltip } from './work-order-gate'
+
+describe('evaluateStartCutGate', () => {
+  it('returns unassigned-dispatchable for cnc_manager when WO has no assignee', () => {
+    const gate = evaluateStartCutGate({
+      wo: { assigned_to: null },
+      currentUserId: 'u-1',
+      role: 'cnc_manager',
+    })
+    expect(gate.kind).toBe('unassigned-dispatchable')
+  })
+
+  it('returns unassigned-dispatchable for planner and admin too', () => {
+    expect(evaluateStartCutGate({ wo: { assigned_to: null }, currentUserId: 'u', role: 'planner' }).kind).toBe(
+      'unassigned-dispatchable',
+    )
+    expect(evaluateStartCutGate({ wo: { assigned_to: null }, currentUserId: 'u', role: 'admin' }).kind).toBe(
+      'unassigned-dispatchable',
+    )
+  })
+
+  it('returns unassigned-blocked for foreman/cnc when WO has no assignee', () => {
+    expect(evaluateStartCutGate({ wo: { assigned_to: null }, currentUserId: 'u', role: 'foreman' }).kind).toBe(
+      'unassigned-blocked',
+    )
+    expect(evaluateStartCutGate({ wo: { assigned_to: null }, currentUserId: 'u', role: 'cnc' }).kind).toBe(
+      'unassigned-blocked',
+    )
+  })
+
+  it('returns allowed when caller matches assigned_to', () => {
+    const gate = evaluateStartCutGate({
+      wo: { assigned_to: 'op-42' },
+      currentUserId: 'op-42',
+      role: 'cnc',
+    })
+    expect(gate.kind).toBe('allowed')
+  })
+
+  it('returns wrong-user when caller is not assignee and not admin', () => {
+    const gate = evaluateStartCutGate({
+      wo: { assigned_to: 'op-42' },
+      currentUserId: 'op-99',
+      role: 'foreman',
+    })
+    expect(gate.kind).toBe('wrong-user')
+  })
+
+  it('returns allowed for admin even when not assigned to them', () => {
+    const gate = evaluateStartCutGate({
+      wo: { assigned_to: 'op-42' },
+      currentUserId: 'admin-1',
+      role: 'admin',
+    })
+    expect(gate.kind).toBe('allowed')
+  })
+
+  it('treats undefined currentUserId as wrong-user when WO is assigned', () => {
+    const gate = evaluateStartCutGate({
+      wo: { assigned_to: 'op-42' },
+      currentUserId: null,
+      role: 'cnc',
+    })
+    expect(gate.kind).toBe('wrong-user')
+  })
+})
+
+describe('startCutTooltip', () => {
+  it('maps each gate to the expected Vietnamese hint', () => {
+    expect(startCutTooltip({ kind: 'unassigned-blocked' })).toBe('Lệnh chưa phân công CNC')
+    expect(startCutTooltip({ kind: 'wrong-user' })).toBe('Lệnh chưa được điều phối cho bạn')
+    expect(startCutTooltip({ kind: 'unassigned-dispatchable' })).toMatch(/điều phối/i)
+    expect(startCutTooltip({ kind: 'allowed' })).toBe('')
+  })
+})

--- a/src/lib/auth/work-order-gate.ts
+++ b/src/lib/auth/work-order-gate.ts
@@ -1,0 +1,52 @@
+import type { WorkOrder } from '@/types/api'
+
+/**
+ * Mirrors backend `production/service.go` AdvanceStatus precondition for
+ * PLANNED → IN_CUTTING: only the assigned CNC operator can start, with admin
+ * bypass. Use to decide whether the FE shows or disables the "Bắt đầu cắt"
+ * action so users don't trigger a 412 ErrPreconditionFailed they can't fix.
+ *
+ * Spec §5.1 — Quy tắc Giao việc; BR-P02.
+ */
+export type StartCutGate =
+  /** Unassigned WO; current role can dispatch it from /cutting-dispatch. */
+  | { kind: 'unassigned-dispatchable' }
+  /** Unassigned WO; current role can't dispatch — show disabled hint. */
+  | { kind: 'unassigned-blocked' }
+  /** Assigned to someone else, caller is not admin. */
+  | { kind: 'wrong-user' }
+  /** Caller may start cutting (assignee match or admin bypass). */
+  | { kind: 'allowed' }
+
+const DISPATCH_ROLES = new Set(['admin', 'planner', 'cnc_manager'])
+
+export function evaluateStartCutGate(args: {
+  wo: Pick<WorkOrder, 'assigned_to'>
+  currentUserId: string | null | undefined
+  role: string | null | undefined
+}): StartCutGate {
+  const { wo, currentUserId, role } = args
+  const isAdmin = role === 'admin'
+
+  if (!wo.assigned_to) {
+    return DISPATCH_ROLES.has(role ?? '')
+      ? { kind: 'unassigned-dispatchable' }
+      : { kind: 'unassigned-blocked' }
+  }
+  if (isAdmin) return { kind: 'allowed' }
+  if (currentUserId && wo.assigned_to === currentUserId) return { kind: 'allowed' }
+  return { kind: 'wrong-user' }
+}
+
+export function startCutTooltip(gate: StartCutGate): string {
+  switch (gate.kind) {
+    case 'unassigned-blocked':
+      return 'Lệnh chưa phân công CNC'
+    case 'wrong-user':
+      return 'Lệnh chưa được điều phối cho bạn'
+    case 'unassigned-dispatchable':
+      return 'Lệnh chưa phân công CNC — bấm để điều phối'
+    case 'allowed':
+      return ''
+  }
+}


### PR DESCRIPTION
## Summary
- Khớp UX với precondition BE (`production/service.go` AdvanceStatus): chỉ CNC được phân công mới chuyển PLANNED → IN_CUTTING, admin bypass; mọi role khác/WO chưa phân công sẽ bị 412.
- Thêm helper `evaluateStartCutGate` (Spec §5.1, BR-P02) trả về 1 trong 4 trạng thái: `allowed`, `wrong-user`, `unassigned-blocked`, `unassigned-dispatchable`.
- Áp dụng trên cả `/work-orders` (list) và `/work-orders/[id]` (detail) cho WO PLANNED:
  - admin/planner/cnc_manager + WO chưa phân công → CTA **"Điều phối"** → `/cutting-dispatch?focus=<wo_id>`.
  - role khác + WO chưa phân công → nút disable, tooltip *"Lệnh chưa phân công CNC"*.
  - WO đã phân công cho người khác (không phải admin) → nút disable, tooltip *"Lệnh chưa được điều phối cho bạn"*.
  - Match assignee hoặc admin → nút bật bình thường.
- Detail page giữ nguyên gate giá thành; chỉ thay nhánh "đã có giá thành" để áp gate mới.

## Files
- `src/lib/auth/work-order-gate.ts` (new — pure helper, không phụ thuộc React)
- `src/lib/auth/work-order-gate.test.ts` (new — vitest, 8 cases)
- `src/app/(dashboard)/work-orders/page.tsx` (renderAdvanceCell áp gate cho PLANNED)
- `src/app/(dashboard)/work-orders/[id]/page.tsx` (gate cho costing-record branch)

## Test plan
- [x] `npx tsc --noEmit` sạch
- [x] `npx eslint` sạch trên file thay đổi (chỉ còn warning a11y có sẵn từ trước)
- [x] `npm run test:unit -- --run src/lib/auth/work-order-gate.test.ts` → 8 passed
- [x] `npm run build` → compile thành công
- [ ] Manual @ 375 / 768 / 1280 px:
  - [ ] CNC `op-A` thấy nút bật trên WO của mình, disable + tooltip trên WO của `op-B`.
  - [ ] cnc_manager/planner thấy CTA *Điều phối* trên WO chưa phân công, dẫn đúng tới `/cutting-dispatch?focus=<id>`.
  - [ ] Admin luôn thấy nút bật bất kể assigned_to.
  - [ ] Detail page: trang đã có giá thành — nút *Bắt đầu cắt* tuân gate; trang chưa có giá thành giữ nguyên flow tính giá.

## Spec / BR
- Spec §5.1 — Quy tắc Giao việc (manual assign trước khi cắt)
- BR-P02 — state machine PLANNED → IN_CUTTING

Closes #164