### PR TITLE
[cutting-dispatch] mặc định lọc PLANNED + chưa phân công (#165)

### DIFF
--- a/src/app/(dashboard)/cutting-dispatch/page.tsx
+++ b/src/app/(dashboard)/cutting-dispatch/page.tsx
@@ -244,25 +244,39 @@ function AssignDialog({ wo, onClose }: AssignDialogProps) {
 
 // ── Main content ──────────────────────────────────────────────────────────────
 
+type AssignmentFilter = 'unassigned' | 'all'
+
 function CuttingDispatchContent() {
   const role = useCurrentRole()
   const canAssignWorkOrder = can(role, 'assign', 'cutting_dispatch')
 
-  const [statusFilter, setStatusFilter] = useState<WorkOrderStatus | 'ALL'>('ALL')
+  // Default view mirrors BE precondition (`production/service.go:199`): only
+  // PLANNED + unassigned WOs are dispatchable, so the operator-friendly
+  // landing matches that shape. Reviewers can still toggle to other statuses.
+  const [statusFilter, setStatusFilter] = useState<WorkOrderStatus | 'ALL'>('PLANNED')
+  const [assignmentFilter, setAssignmentFilter] = useState<AssignmentFilter>('unassigned')
   const [assignTarget, setAssignTarget] = useState<WorkOrder | null>(null)
 
   const { page, limit, setPage } = usePageParams(15)
 
   const filter = {
     ...(statusFilter !== 'ALL' ? { status: statusFilter } : {}),
+    ...(assignmentFilter === 'unassigned' ? { assigned: 'null' as const } : {}),
     page,
     limit,
   }
 
   const { data, isLoading, isFetching, isError } = useWorkOrders(filter)
-  const workOrders = useMemo(() => data?.items ?? [], [data?.items])
+  // Defensive client-side filter: if the backend ignores `assigned=null`
+  // (Spec §5.1 notes the param is pending BE confirmation), fall back to
+  // filtering the page in the client so the UX promise still holds.
+  const workOrders = useMemo(() => {
+    const items = data?.items ?? []
+    return assignmentFilter === 'unassigned' ? items.filter((wo) => !wo.assigned_to) : items
+  }, [data?.items, assignmentFilter])
   const totalItems = data?.total_items ?? 0
   const totalPages = data?.total_pages ?? 1
+  const isDefaultDispatchView = statusFilter === 'PLANNED' && assignmentFilter === 'unassigned'
 
   return (
     <div className="space-y-4">
@@ -284,12 +298,29 @@ function CuttingDispatchContent() {
             ))}
           </SelectContent>
         </Select>
+
+        <Select
+          value={assignmentFilter}
+          onValueChange={(v) => { setAssignmentFilter(v as AssignmentFilter); setPage(1) }}
+        >
+          <SelectTrigger className="w-44">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="unassigned">Chưa phân công</SelectItem>
+            <SelectItem value="all">Tất cả phân công</SelectItem>
+          </SelectContent>
+        </Select>
       </div>
 
       {/* Table */}
       <div className={`rounded-lg border transition-opacity ${isFetching && !isLoading ? 'opacity-60' : ''}`}>
         <div className="border-b px-4 py-3 text-sm font-medium text-muted-foreground">
-          {isLoading ? 'Đang tải…' : `Tất cả lệnh cắt (${totalItems})`}
+          {isLoading
+            ? 'Đang tải…'
+            : isDefaultDispatchView
+              ? `Lệnh chờ điều phối (${workOrders.length})`
+              : `Lệnh cắt (${totalItems})`}
         </div>
 
         {isError ? (
@@ -312,7 +343,9 @@ function CuttingDispatchContent() {
               ) : workOrders.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={6} className="py-10 text-center text-muted-foreground">
-                    Không có lệnh cắt nào.
+                    {isDefaultDispatchView
+                      ? 'Không có lệnh nào chờ điều phối.'
+                      : 'Không có lệnh cắt nào.'}
                   </TableCell>
                 </TableRow>
               ) : (

--- a/src/lib/api/work-orders.ts
+++ b/src/lib/api/work-orders.ts
@@ -16,6 +16,13 @@ export interface WorkOrdersFilter {
   date?: string
   from?: string
   to?: string
+  /**
+   * Assignment filter for /cutting-dispatch. Pass `'null'` to fetch only WOs
+   * with `assigned_to IS NULL`; omit to include all. Backend may not yet honor
+   * this — callers should apply a client-side fallback when defensiveness
+   * matters.
+   */
+  assigned?: 'null' | string
   page?: number
   limit?: number
 }


### PR DESCRIPTION
## Summary
- Mặc định `statusFilter='PLANNED'` + `assignmentFilter='unassigned'` trên `/cutting-dispatch`, khớp đúng precondition BE (`production/service.go:199` — chỉ assign được WO PLANNED) và intent điều phối (chỉ WO chưa có người làm).
- Thêm Select phụ "Chưa phân công | Tất cả phân công"; user vẫn toggle được sang xem toàn bộ để re-assign.
- Truyền `assigned=null` xuống BE qua `GET /work-orders?...&assigned=null`, kèm **client-side fallback filter** trên trang hiện tại để UX vẫn đúng nếu BE chưa hỗ trợ tham số (theo Notes của issue).
- Counter tiêu đề đổi sang **"Lệnh chờ điều phối (N)"** khi đang ở default view; ngược lại giữ "Lệnh cắt (N)". Empty state nói rõ "Không có lệnh nào chờ điều phối."

## ⚠️ BE coordination needed
- Issue gốc đề nghị verify `assigned=null` query trên `GET /work-orders`. Nếu BE chưa hỗ trợ, fallback client-side hiện tại làm việc trên trang đã trả về → có thể khiến trang thưa thớt và pagination total không khớp với số dòng thực hiển thị. Đề xuất mở follow-up BE: hỗ trợ `?assigned=null` (và optionally `?assigned=<user_id>`) cho `/work-orders` để pagination chính xác.

## Files
- `src/app/(dashboard)/cutting-dispatch/page.tsx` — defaults + assignment Select + counter + fallback filter
- `src/lib/api/work-orders.ts` — thêm `assigned?: 'null' | string` vào `WorkOrdersFilter`

## Test plan
- [x] `npx tsc --noEmit` sạch
- [x] `npx eslint` sạch
- [x] `npm run build` → compile thành công
- [ ] Manual @ 375 / 768 / 1280 px:
  - [ ] Vào `/cutting-dispatch` → mặc định chỉ thấy WO PLANNED, chưa phân công; counter "Lệnh chờ điều phối (N)".
  - [ ] Toggle "Tất cả phân công" → thấy WO PLANNED đã có người làm, có nút "Phân công lại".
  - [ ] Toggle Status sang IN_CUTTING → counter trở về "Lệnh cắt (N)" (BE total), không còn nút Phân công.
  - [ ] Click CTA "Điều phối" từ `/work-orders` (#164) tới `/cutting-dispatch?focus=<id>` vẫn vào trang đúng default.

## Spec / BR
- Spec §5.1 — Quy tắc Giao việc
- BR-P01 — assignment là precondition cho IN_CUTTING

Closes #165