### PR TITLE
[accounting] trang báo cáo hao hụt theo vật liệu (xuất CSV)

### DIFF
--- a/src/app/(dashboard)/waste-report/page.tsx
+++ b/src/app/(dashboard)/waste-report/page.tsx
@@ -1,0 +1,380 @@
+'use client'
+
+import { Suspense, useMemo, useState, useSyncExternalStore } from 'react'
+import { Calendar, Download, Loader2, RotateCcw, Trash2 } from 'lucide-react'
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { mapApiErrorVi } from '@/lib/api/client'
+import { costingApi } from '@/lib/api/costing'
+import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
+import { useMaterials } from '@/lib/hooks/use-materials'
+import { useWasteReport } from '@/lib/hooks/use-waste-report'
+import type { WasteReportFilter, WasteReportRow } from '@/types/api'
+
+const ALL_MATERIALS = '__all__'
+
+function useCurrentRole() {
+  return useSyncExternalStore(
+    () => () => {},
+    () => getCurrentRoleFromCookie(),
+    () => null,
+  )
+}
+
+function isoDate(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function defaultFromDate(): string {
+  const d = new Date()
+  d.setDate(d.getDate() - 30)
+  return isoDate(d)
+}
+
+function formatM2(mm2: number): string {
+  return (mm2 / 1_000_000).toLocaleString('vi-VN', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+}
+
+function formatVND(amount: number): string {
+  return amount.toLocaleString('vi-VN', { style: 'currency', currency: 'VND' })
+}
+
+function formatCostPerM2(row: WasteReportRow): string {
+  if (row.waste_area_mm2 <= 0) return '—'
+  const m2 = row.waste_area_mm2 / 1_000_000
+  return formatVND(row.total_waste_cost.amount / m2)
+}
+
+function buildCsvFilename(filter: WasteReportFilter): string {
+  const from = filter.from ?? 'all'
+  const to = filter.to ?? 'all'
+  return `waste-report_${from}_${to}.csv`
+}
+
+function triggerCsvDownload(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  URL.revokeObjectURL(url)
+}
+
+// ── Page content ──────────────────────────────────────────────────────────────
+
+function WasteReportContent() {
+  const role = useCurrentRole()
+  const canRead = can(role, 'read', 'waste_report')
+  const canExport = can(role, 'generate', 'waste_report')
+
+  const today = isoDate(new Date())
+  const [from, setFrom] = useState<string>(defaultFromDate())
+  const [to, setTo] = useState<string>(today)
+  const [materialId, setMaterialId] = useState<string>(ALL_MATERIALS)
+  const [downloading, setDownloading] = useState(false)
+
+  const filter: WasteReportFilter = useMemo(
+    () => ({
+      from,
+      to,
+      ...(materialId !== ALL_MATERIALS ? { material_id: materialId } : {}),
+    }),
+    [from, to, materialId],
+  )
+
+  const { data: materialsData } = useMaterials({ limit: 200 })
+  const materials = useMemo(() => materialsData?.items ?? [], [materialsData?.items])
+
+  const {
+    data: rows,
+    isLoading,
+    isFetching,
+    isError,
+    error,
+  } = useWasteReport(canRead ? filter : {})
+
+  const reportRows: WasteReportRow[] = useMemo(() => rows ?? [], [rows])
+
+  const totals = useMemo(() => {
+    return reportRows.reduce(
+      (acc, r) => ({
+        sheets: acc.sheets + r.sheets_consumed,
+        areaMm2: acc.areaMm2 + r.waste_area_mm2,
+        cost: acc.cost + r.total_waste_cost.amount,
+      }),
+      { sheets: 0, areaMm2: 0, cost: 0 },
+    )
+  }, [reportRows])
+
+  const chartData = useMemo(
+    () =>
+      reportRows.map((r) => ({
+        name: r.material_name || r.material_id.slice(0, 8),
+        cost: r.total_waste_cost.amount,
+      })),
+    [reportRows],
+  )
+
+  async function handleDownloadCsv() {
+    setDownloading(true)
+    try {
+      const blob = await costingApi.wasteReportCsvBlob(filter)
+      triggerCsvDownload(blob, buildCsvFilename(filter))
+      toast.success('Đã tải báo cáo CSV')
+    } catch (err) {
+      toast.error(mapApiErrorVi(err, 'Tải CSV thất bại'))
+    } finally {
+      setDownloading(false)
+    }
+  }
+
+  function resetRange() {
+    setFrom(defaultFromDate())
+    setTo(today)
+  }
+
+  if (!canRead) {
+    return (
+      <div className="rounded-lg border bg-muted/20 p-6 text-sm text-muted-foreground">
+        Bạn không có quyền xem báo cáo hao hụt. Liên hệ quản trị viên nếu cần truy cập.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="space-y-1">
+            <Label htmlFor="waste-from" className="text-xs text-muted-foreground">
+              Từ ngày
+            </Label>
+            <div className="flex items-center gap-1.5">
+              <Calendar className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+              <input
+                id="waste-from"
+                type="date"
+                value={from}
+                max={to}
+                onChange={(e) => setFrom(e.target.value)}
+                className="h-9 rounded-md border bg-transparent px-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+              <span className="text-muted-foreground text-sm" aria-hidden="true">–</span>
+              <input
+                aria-label="Đến ngày"
+                type="date"
+                value={to}
+                min={from}
+                onChange={(e) => setTo(e.target.value)}
+                className="h-9 rounded-md border bg-transparent px-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+              <Button variant="outline" size="sm" onClick={resetRange} className="gap-1">
+                <RotateCcw className="size-3" />
+                30 ngày
+              </Button>
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <Label className="text-xs text-muted-foreground">Vật liệu</Label>
+            <Select value={materialId} onValueChange={setMaterialId}>
+              <SelectTrigger className="w-56">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ALL_MATERIALS}>Tất cả vật liệu</SelectItem>
+                {materials.map((m) => (
+                  <SelectItem key={m.id} value={m.id}>
+                    {m.name} ({m.type})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {canExport && (
+          <Button onClick={handleDownloadCsv} disabled={downloading || isLoading}>
+            {downloading ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Download className="size-4" />
+            )}
+            Tải CSV
+          </Button>
+        )}
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid gap-3 md:grid-cols-3">
+        <Card>
+          <CardHeader className="pb-1">
+            <CardTitle className="text-xs font-medium text-muted-foreground">Số tấm tiêu thụ</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-semibold">
+              {isLoading ? <Skeleton className="h-7 w-20" /> : totals.sheets.toLocaleString('vi-VN')}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-1">
+            <CardTitle className="text-xs font-medium text-muted-foreground">Tổng diện tích hao hụt</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-semibold">
+              {isLoading ? <Skeleton className="h-7 w-24" /> : `${formatM2(totals.areaMm2)} m²`}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-1">
+            <CardTitle className="text-xs font-medium text-muted-foreground">Tổng chi phí hao hụt</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-semibold text-red-700">
+              {isLoading ? <Skeleton className="h-7 w-32" /> : formatVND(totals.cost)}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Bar chart */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Chi phí hao hụt theo vật liệu</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <Skeleton className="h-60 w-full" />
+          ) : chartData.length === 0 ? (
+            <p className="py-10 text-center text-sm text-muted-foreground">
+              Không có dữ liệu hao hụt trong khoảng thời gian đã chọn.
+            </p>
+          ) : (
+            <ResponsiveContainer width="100%" height={260}>
+              <BarChart data={chartData} margin={{ top: 12, right: 12, left: 12, bottom: 8 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                <XAxis dataKey="name" tick={{ fontSize: 11 }} />
+                <YAxis
+                  tick={{ fontSize: 11 }}
+                  tickFormatter={(v: number) => (v / 1_000_000).toLocaleString('vi-VN') + 'tr'}
+                />
+                <Tooltip formatter={(v: number) => formatVND(v)} />
+                <Bar dataKey="cost" fill="#dc2626" name="Chi phí hao hụt" />
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Table */}
+      <div className={`rounded-lg border transition-opacity ${isFetching && !isLoading ? 'opacity-60' : ''}`}>
+        <div className="border-b px-4 py-3 text-sm font-medium text-muted-foreground">
+          {isLoading ? 'Đang tải…' : `Chi tiết theo vật liệu (${reportRows.length})`}
+        </div>
+
+        {isError ? (
+          <p className="p-4 text-sm text-destructive">{mapApiErrorVi(error, 'Không thể tải báo cáo.')}</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Vật liệu</TableHead>
+                <TableHead className="text-right">Số tấm</TableHead>
+                <TableHead className="text-right">Hao hụt (m²)</TableHead>
+                <TableHead className="text-right">Chi phí TB / m²</TableHead>
+                <TableHead className="text-right">Tổng chi phí hao hụt</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoading ? (
+                Array.from({ length: 4 }).map((_, i) => (
+                  <TableRow key={i}>
+                    {Array.from({ length: 5 }).map((__, j) => (
+                      <TableCell key={j}>
+                        <Skeleton className="h-5 w-full" />
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : reportRows.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={5} className="py-10 text-center text-muted-foreground">
+                    Không có dữ liệu hao hụt trong khoảng thời gian đã chọn.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                reportRows.map((r) => (
+                  <TableRow key={r.material_id}>
+                    <TableCell className="font-medium">{r.material_name}</TableCell>
+                    <TableCell className="text-right">{r.sheets_consumed.toLocaleString('vi-VN')}</TableCell>
+                    <TableCell className="text-right">{formatM2(r.waste_area_mm2)}</TableCell>
+                    <TableCell className="text-right">{formatCostPerM2(r)}</TableCell>
+                    <TableCell className="text-right font-medium text-red-700">
+                      {formatVND(r.total_waste_cost.amount)}
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── Page shell ────────────────────────────────────────────────────────────────
+
+export default function WasteReportPage() {
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex items-center gap-3">
+        <Trash2 className="size-6 text-muted-foreground" aria-hidden="true" />
+        <div>
+          <h1 className="text-2xl font-bold">Báo cáo hao hụt</h1>
+          <p className="text-sm text-muted-foreground">
+            Tổng hợp chi phí hao hụt theo vật liệu (BR-C03). Phân bổ chi phí dựa trên giá tấm gốc.
+          </p>
+        </div>
+      </div>
+      <Suspense fallback={<Skeleton className="h-64 w-full rounded-xl" />}>
+        <WasteReportContent />
+      </Suspense>
+    </div>
+  )
+}

--- a/src/components/dashboard/side-nav.tsx
+++ b/src/components/dashboard/side-nav.tsx
@@ -3,7 +3,7 @@
 import { useSyncExternalStore } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
-import { LayoutDashboard, Package, DollarSign, Layers, Boxes, ShoppingCart, ClipboardList, ClipboardCheck, Scissors, LogOut, UserCircle, Users, Truck } from 'lucide-react'
+import { LayoutDashboard, Package, DollarSign, Layers, Boxes, ShoppingCart, ClipboardList, ClipboardCheck, Scissors, LogOut, UserCircle, Users, Truck, Trash2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Separator } from '@/components/ui/separator'
 import { Button } from '@/components/ui/button'
@@ -20,6 +20,7 @@ const MANAGEMENT_NAV = [
   { href: '/cutting-dispatch', label: 'Điều phối cắt', icon: Scissors, resource: 'cutting_dispatch' },
   { href: '/remnants', label: 'Kho tấm lẻ', icon: Package, resource: 'remnants' },
   { href: '/costing', label: 'Giá thành', icon: DollarSign, resource: 'costing' },
+  { href: '/waste-report', label: 'Báo cáo hao hụt', icon: Trash2, resource: 'waste_report' },
   { href: '/materials', label: 'Nguyên liệu', icon: Layers, resource: 'materials' },
   { href: '/purchasing', label: 'Đơn nhập VL', icon: Truck, resource: 'purchasing' },
   { href: '/skus', label: 'Sản phẩm', icon: Boxes, resource: 'skus' },

--- a/src/lib/api/costing.ts
+++ b/src/lib/api/costing.ts
@@ -1,9 +1,29 @@
-import { apiClient } from '@/lib/api/client'
-import type { CostingRecord, PageParams, PagedResult } from '@/types/api'
+import { ApiClientError, apiClient } from '@/lib/api/client'
+import { normalizeAuthToken } from '@/lib/auth/token'
+import type {
+  CostingRecord,
+  PageParams,
+  PagedResult,
+  WasteReportFilter,
+  WasteReportRow,
+} from '@/types/api'
 
 export interface CostingFilter extends PageParams {
   finalized?: boolean
   work_order_id?: string
+}
+
+function buildApiUrl(path: string) {
+  const base =
+    typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3000'
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080/api/v1'
+  return new URL(`${baseUrl}${path}`, base)
+}
+
+function applyWasteReportParams(url: URL, filter: WasteReportFilter) {
+  if (filter.from) url.searchParams.set('from', filter.from)
+  if (filter.to) url.searchParams.set('to', filter.to)
+  if (filter.material_id) url.searchParams.set('material_id', filter.material_id)
 }
 
 export const costingApi = {
@@ -26,4 +46,47 @@ export const costingApi = {
 
   finalize: (workOrderId: string) =>
     apiClient.post<{ status: string }>(`/costing/${workOrderId}/finalize`),
+
+  /** GET /api/v1/costing/waste-report — JSON list of WasteReportRow */
+  wasteReport: (filter: WasteReportFilter = {}) =>
+    apiClient.get<WasteReportRow[]>('/costing/waste-report', {
+      params: {
+        from: filter.from,
+        to: filter.to,
+        material_id: filter.material_id,
+      },
+    }),
+
+  /**
+   * GET /api/v1/costing/waste-report?format=csv — returns the CSV blob.
+   * Bypasses the JSON apiClient because the response body is text/csv with
+   * a Content-Disposition attachment header.
+   */
+  wasteReportCsvBlob: async (filter: WasteReportFilter = {}): Promise<Blob> => {
+    const url = buildApiUrl('/costing/waste-report')
+    applyWasteReportParams(url, filter)
+    url.searchParams.set('format', 'csv')
+
+    const token =
+      typeof window !== 'undefined'
+        ? normalizeAuthToken(localStorage.getItem('auth_token'))
+        : null
+
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        Accept: 'text/csv',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    })
+
+    if (!response.ok) {
+      const body = await response.json().catch(() => null)
+      const code: string = body?.code ?? 'UNKNOWN'
+      const message: string = body?.message ?? body?.error ?? `HTTP ${response.status}`
+      throw new ApiClientError(response.status, code, message, body?.details)
+    }
+
+    return response.blob()
+  },
 }

--- a/src/lib/auth/authorization.ts
+++ b/src/lib/auth/authorization.ts
@@ -25,6 +25,7 @@ export type AppResource =
   | 'users'
   | 'profile'
   | 'purchasing'
+  | 'waste_report'
 
 export type AppAction =
   | 'read'
@@ -54,6 +55,7 @@ const DASHBOARD_PATHS = [
   '/users',
   '/profile',
   '/purchasing',
+  '/waste-report',
 ]
 
 const KIOSK_PATHS = ['/scan', '/cutting-orders', '/report-cut', '/remnant-list', '/remnant-store', '/account']
@@ -72,6 +74,7 @@ const RESOURCE_BY_PATH: Array<{ path: string; resource: AppResource }> = [
   { path: '/users', resource: 'users' },
   { path: '/profile', resource: 'profile' },
   { path: '/purchasing', resource: 'purchasing' },
+  { path: '/waste-report', resource: 'waste_report' },
   { path: '/scan', resource: 'scan' },
   { path: '/cutting-orders', resource: 'cutting_orders' },
   { path: '/report-cut', resource: 'report_cut' },
@@ -113,11 +116,13 @@ const POLICY: Record<AppRole, Partial<Record<AppResource, readonly AppAction[]>>
     cutting_dispatch: ['read', 'assign'],
     costing: ['read', 'compute', 'finalize', 'adjust'],
     purchasing: ['read', 'create', 'cancel'],
+    waste_report: ['read', 'generate'],
   },
   accountant: {
     ...readOnly(DASHBOARD_RESOURCES),
     pos: ['read', 'create'],
     costing: ['read', 'compute', 'finalize', 'adjust'],
+    waste_report: ['read', 'generate'],
   },
   planner: {
     ...readOnly(DASHBOARD_RESOURCES),

--- a/src/lib/hooks/use-waste-report.ts
+++ b/src/lib/hooks/use-waste-report.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query'
+import { costingApi } from '@/lib/api/costing'
+import type { WasteReportFilter } from '@/types/api'
+
+export const WASTE_REPORT_KEY = 'costing-waste-report'
+
+export function useWasteReport(filter: WasteReportFilter = {}) {
+  return useQuery({
+    queryKey: [WASTE_REPORT_KEY, filter],
+    queryFn: () => costingApi.wasteReport(filter),
+    placeholderData: (prev) => prev,
+    staleTime: 60_000,
+  })
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -279,6 +279,29 @@ export interface CostingRecord {
   created_at: string
 }
 
+/**
+ * GET /api/v1/costing/waste-report — one row per material aggregated over the
+ * filter range. Mirrors backend `costing.WasteReportRow` (BR-C03 ledger).
+ */
+export interface WasteReportRow {
+  material_id: string
+  material_name: string
+  sheets_consumed: number
+  /** Total waste area in mm² across the range. Display in m² (÷ 1_000_000). */
+  waste_area_mm2: number
+  /** Mean board-sheet cost across the consumed sheets — used by BE to allocate. */
+  avg_sheet_cost: Money
+  total_waste_cost: Money
+}
+
+export interface WasteReportFilter {
+  /** Inclusive day in Asia/Ho_Chi_Minh; format YYYY-MM-DD. */
+  from?: string
+  /** Inclusive day; BE adds +1 day server-side to make it half-open. */
+  to?: string
+  material_id?: string
+}
+
 // ── Cutting ──────────────────────────────────────────────────────────────────
 
 export interface CuttingRecord {


### PR DESCRIPTION
## Summary
- Thêm trang `/waste-report` cho kế toán xem chi phí hao hụt tổng hợp theo vật liệu (BR-C03), tiêu thụ endpoint `GET /api/v1/costing/waste-report` đã merge từ BE PR #233.
- Bộ lọc khoảng ngày (mặc định 30 ngày gần nhất) + dropdown vật liệu, 3 thẻ tổng hợp, biểu đồ cột (recharts), bảng chi tiết, và nút **Tải CSV** gọi `?format=csv` rồi trigger blob download.
- Phân quyền: thêm resource `waste_report` riêng, chỉ `admin` + `accountant` có quyền `read`/`generate`. Side-nav chỉ hiển thị mục "Báo cáo hao hụt" cho hai role này; các role khác navigate trực tiếp vào URL sẽ thấy banner "không có quyền".

## Files
- `src/types/api.ts` — `WasteReportRow` và `WasteReportFilter` mirror `costing.WasteReportRow`/`WasteReportFilter` của BE.
- `src/lib/api/costing.ts` — thêm `wasteReport(filter)` (JSON) và `wasteReportCsvBlob(filter)` (Blob, đính `Authorization: Bearer`, mẫu giống `barcode.getLabelPdfBlob`).
- `src/lib/hooks/use-waste-report.ts` — TanStack Query hook (staleTime 60s).
- `src/lib/auth/authorization.ts` — thêm resource `waste_report` (không nằm trong `DASHBOARD_RESOURCES` để tránh các role khác lấy `read` ngầm qua `readOnly()`).
- `src/components/dashboard/side-nav.tsx` — mục "Báo cáo hao hụt" với icon `Trash2`, gate qua `can(role, 'read', 'waste_report')`.
- `src/app/(dashboard)/waste-report/page.tsx` — trang chính.

## Deviations from DoD
- **URL**: dùng `/waste-report` (top-level) thay vì `/accounting/waste-report` để tránh xung đột active-state với `pathname.startsWith('/costing')` của side-nav.
- **Biểu đồ "per material per week"**: BE chỉ aggregate tổng theo material cho cả khoảng thời gian, không bucket theo tuần. Biểu đồ hiện tại hiển thị tổng chi phí theo vật liệu cho khoảng thời gian đã chọn — kế toán có thể thu hẹp range để xem theo tuần. Granularity tuần cần BE follow-up (issue mới).

## Test plan
- [x] `npx tsc --noEmit` — pass
- [x] `npm run lint` — chỉ còn các lỗi storybook pre-existing
- [x] `npm run build` — pass; route `/waste-report` được prerender
- [x] `npx vitest run` — 102/106 pass; 4 fail là pre-existing trên `side-nav.stories.tsx` (đã verify trên `dev`)
- [ ] QA flow:
  - Login dưới role `accountant` / `admin` → side-nav có mục "Báo cáo hao hụt", trang hiển thị đầy đủ
  - Login dưới role khác (planner/warehouse/foreman/cnc_manager/cnc) → không thấy mục trong side-nav; navigate `/waste-report` trực tiếp → thấy banner "không có quyền"
  - Chỉnh date range / chọn vật liệu → bảng + biểu đồ refetch
  - Bấm "Tải CSV" → file `waste-report_<from>_<to>.csv` tải về với header BE đã set
- [ ] Responsive 375 / 768 / 1280 px

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)