### PR TITLE
[work-orders] per-stage labor entry form on detail page

### DIFF
--- a/src/app/(dashboard)/work-orders/[id]/page.tsx
+++ b/src/app/(dashboard)/work-orders/[id]/page.tsx
@@ -33,13 +33,22 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/components/ui/tabs'
+import {
+  useAddLaborEntry,
   useAddWorkOrderConsumption,
   useAdvanceStatus,
   useWorkOrder,
   useWorkOrderConsumptions,
+  useWorkOrderLaborEntries,
 } from '@/lib/hooks/use-work-orders'
 import { usePlan } from '@/lib/hooks/use-plans'
 import { useMaterials } from '@/lib/hooks/use-materials'
+import { useUsers } from '@/lib/hooks/use-users'
 import { useGenerateBarcode, useBarcodesForWorkOrder, useBarcodeScanEvents } from '@/lib/hooks/use-barcode'
 import { useWorkOrderCosting, useComputeCosting } from '@/lib/hooks/use-costing'
 import { ApiClientError } from '@/lib/api/client'
@@ -54,6 +63,8 @@ import type {
   ScanCheckpoint,
   MaterialType,
   AdvanceStatusInput,
+  LaborStage,
+  User,
 } from '@/types/api'
 
 // ── Helpers
@@ -66,6 +77,15 @@ function useCurrentRole() {
   )
 }
 
+
+const LABOR_STAGE_LABEL: Record<LaborStage, string> = {
+  CNC: 'CNC',
+  GRINDING: 'Mài',
+  ASSEMBLY: 'Dán',
+  POLISHING: 'Đánh bóng',
+}
+
+const LABOR_STAGES: LaborStage[] = ['CNC', 'GRINDING', 'ASSEMBLY', 'POLISHING']
 
 const STATUS_LABEL: Record<WorkOrderStatus, string> = {
   PLANNED: 'Kế hoạch',
@@ -337,6 +357,246 @@ function GenerateBarcodeDialog({ wo, open, onClose }: {
   )
 }
 
+// ── Labor section ─────────────────────────────────────────────────────────────
+
+function LaborSection({ wo }: { wo: WorkOrder }) {
+  const role = useCurrentRole()
+  const canRecordLabor = can(role, 'record_labor', 'work_orders')
+  const locked = wo.status === 'COSTED'
+
+  const [stage, setStage] = useState<LaborStage | ''>('')
+  const [minutes, setMinutes] = useState('')
+  const [workerId, setWorkerId] = useState('')
+  const [ratePerHour, setRatePerHour] = useState('')
+
+  const {
+    data: entries,
+    isLoading: entriesLoading,
+    isError: entriesError,
+  } = useWorkOrderLaborEntries(wo.id)
+  // Workers eligible to have their time recorded: kiosk operators and the
+  // production roles that can also perform labor themselves.
+  const { data: usersData, isLoading: usersLoading } = useUsers({
+    role: 'cnc,foreman,cnc_manager',
+    is_active: true,
+    limit: 200,
+  })
+  const workers = useMemo<User[]>(() => usersData?.items ?? [], [usersData?.items])
+  const workersById = useMemo(() => new Map(workers.map((u) => [u.id, u])), [workers])
+
+  const { mutate: addEntry, isPending: adding } = useAddLaborEntry()
+
+  function workerLabel(id: string): string {
+    const u = workersById.get(id)
+    if (!u) return shortId(id)
+    return u.full_name?.trim() || u.username
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!canRecordLabor || locked || adding) return
+    if (!stage) return
+
+    const parsedMinutes = Number(minutes)
+    if (!Number.isFinite(parsedMinutes) || parsedMinutes <= 0) return
+
+    const parsedRate = Number(ratePerHour)
+    if (!Number.isFinite(parsedRate) || parsedRate <= 0) return
+
+    addEntry(
+      {
+        workOrderId: wo.id,
+        input: {
+          stage,
+          minutes: parsedMinutes,
+          rate_per_hour: parsedRate,
+          worker_id: workerId || undefined,
+        },
+      },
+      {
+        onSuccess: () => {
+          setStage('')
+          setMinutes('')
+          setWorkerId('')
+          setRatePerHour('')
+        },
+      },
+    )
+  }
+
+  return (
+    <div>
+      <h2 className="mb-3 text-base font-semibold">Ghi nhận công lao động</h2>
+
+      <div className="mb-3 rounded-lg border p-4">
+        {!canRecordLabor ? (
+          <p className="text-sm text-muted-foreground">Bạn chỉ có quyền xem công lao động.</p>
+        ) : locked ? (
+          <p className="text-sm text-muted-foreground">
+            Giá thành đã được chốt — không thể bổ sung công lao động (BR-C04).
+          </p>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">
+              <div className="space-y-1.5">
+                <Label htmlFor="labor-stage">Công đoạn *</Label>
+                <Select value={stage} onValueChange={(v) => setStage(v as LaborStage)} disabled={adding}>
+                  <SelectTrigger id="labor-stage" className="h-12">
+                    <SelectValue placeholder="Chọn công đoạn" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {LABOR_STAGES.map((s) => (
+                      <SelectItem key={s} value={s}>
+                        {LABOR_STAGE_LABEL[s]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="labor-minutes">Số phút *</Label>
+                <Input
+                  id="labor-minutes"
+                  type="number"
+                  min={5}
+                  step={5}
+                  inputMode="numeric"
+                  className="h-12"
+                  value={minutes}
+                  onChange={(e) => setMinutes(e.target.value)}
+                  disabled={adding}
+                  placeholder="vd: 60"
+                  required
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="labor-rate">Đơn giá / giờ (VND) *</Label>
+                <Input
+                  id="labor-rate"
+                  type="number"
+                  min={1}
+                  step="any"
+                  inputMode="numeric"
+                  className="h-12"
+                  value={ratePerHour}
+                  onChange={(e) => setRatePerHour(e.target.value)}
+                  disabled={adding}
+                  placeholder="vd: 50000"
+                  required
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="labor-worker">Công nhân</Label>
+                <Select value={workerId} onValueChange={setWorkerId} disabled={usersLoading || adding}>
+                  <SelectTrigger id="labor-worker" className="h-12">
+                    <SelectValue placeholder={usersLoading ? 'Đang tải…' : 'Chính tôi'} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {workers.map((u) => (
+                      <SelectItem key={u.id} value={u.id}>
+                        {u.full_name?.trim() || u.username}
+                        <span className="ml-1 text-xs text-muted-foreground">({u.role})</span>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <Button
+              type="submit"
+              className="h-12"
+              disabled={
+                adding ||
+                !stage ||
+                !minutes.trim() ||
+                Number(minutes) <= 0 ||
+                !ratePerHour.trim() ||
+                Number(ratePerHour) <= 0
+              }
+            >
+              {adding ? 'Đang lưu…' : 'Ghi nhận công'}
+            </Button>
+          </form>
+        )}
+      </div>
+
+      <div className="rounded-lg border">
+        {entriesLoading ? (
+          <div className="divide-y">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex gap-4 px-4 py-3">
+                {Array.from({ length: 5 }).map((_, j) => (
+                  <Skeleton key={j} className="h-5 flex-1" />
+                ))}
+              </div>
+            ))}
+          </div>
+        ) : entriesError ? (
+          <p className="p-4 text-sm text-destructive">Không thể tải dữ liệu công lao động.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Công đoạn</TableHead>
+                  <TableHead className="text-right">Số phút</TableHead>
+                  <TableHead className="text-right">Đơn giá / giờ</TableHead>
+                  <TableHead className="text-right">Chi phí</TableHead>
+                  <TableHead>Công nhân / Ghi nhận bởi</TableHead>
+                  <TableHead>Thời gian</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {!entries || entries.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={6} className="py-8 text-center text-muted-foreground">
+                      Chưa có ghi nhận công nào.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  entries.map((entry) => {
+                    const costVnd = Math.round((entry.minutes * entry.rate_per_hour) / 60)
+                    const sameActor = entry.worker_id === entry.actor_id
+                    return (
+                      <TableRow key={entry.id}>
+                        <TableCell className="font-medium">
+                          {LABOR_STAGE_LABEL[entry.stage] ?? entry.stage}
+                        </TableCell>
+                        <TableCell className="text-right">{entry.minutes}</TableCell>
+                        <TableCell className="text-right">
+                          {entry.rate_per_hour.toLocaleString('vi-VN')}
+                        </TableCell>
+                        <TableCell className="text-right font-medium">
+                          {costVnd.toLocaleString('vi-VN')}
+                        </TableCell>
+                        <TableCell className="text-sm">
+                          <span className="font-medium">{workerLabel(entry.worker_id)}</span>
+                          {!sameActor && (
+                            <span className="text-muted-foreground">
+                              {' '}· ghi nhận bởi {workerLabel(entry.actor_id)}
+                            </span>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {formatDate(entry.created_at)}
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
 // ── Detail content ────────────────────────────────────────────────────────────
 
 function WorkOrderDetail({ id }: { id: string }) {
@@ -495,6 +755,13 @@ function WorkOrderDetail({ id }: { id: string }) {
         </div>
       </div>
 
+      <Tabs defaultValue="overview" className="w-full">
+        <TabsList>
+          <TabsTrigger value="overview">Tổng quan</TabsTrigger>
+          <TabsTrigger value="labor">Nhân công</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview" className="space-y-8 pt-4">
       {/* Costing gate — only shown for PLANNED */}
       {wo.status === 'PLANNED' && (
         <div>
@@ -729,6 +996,12 @@ function WorkOrderDetail({ id }: { id: string }) {
           )}
         </div>
       </div>
+        </TabsContent>
+
+        <TabsContent value="labor" className="pt-4">
+          <LaborSection wo={wo} />
+        </TabsContent>
+      </Tabs>
     </div>
   )
 }

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,91 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Tabs as TabsPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> &
+  VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
+        "data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }

--- a/src/lib/api/work-orders.ts
+++ b/src/lib/api/work-orders.ts
@@ -6,6 +6,8 @@ import type {
   SuggestAssignmentResult,
   ConsumptionRecord,
   AddConsumptionInput,
+  LaborEntry,
+  AddLaborEntryInput,
   PagedResult,
 } from '@/types/api'
 import { apiClient } from './client'
@@ -52,6 +54,14 @@ export const workOrdersApi = {
   /** POST /api/v1/work-orders/:id/consumptions */
   addConsumption: (id: string, input: AddConsumptionInput) =>
     apiClient.post<ConsumptionRecord>(`/work-orders/${id}/consumptions`, input),
+
+  /** GET /api/v1/work-orders/:id/labor-entries */
+  listLaborEntries: (id: string) =>
+    apiClient.get<LaborEntry[]>(`/work-orders/${id}/labor-entries`),
+
+  /** POST /api/v1/work-orders/:id/labor-entries */
+  addLaborEntry: (id: string, input: AddLaborEntryInput) =>
+    apiClient.post<LaborEntry>(`/work-orders/${id}/labor-entries`, input),
 
   /** POST /api/v1/work-orders/:id/assign */
   assign: (id: string, input: AssignWorkOrderInput) =>

--- a/src/lib/auth/authorization.ts
+++ b/src/lib/auth/authorization.ts
@@ -40,6 +40,7 @@ export type AppAction =
   | 'generate'
   | 'assign'
   | 'toggle_active'
+  | 'record_labor'
 
 const DASHBOARD_PATHS = [
   '/overview',
@@ -112,7 +113,7 @@ const POLICY: Record<AppRole, Partial<Record<AppResource, readonly AppAction[]>>
     users: ['read', 'create', 'toggle_active'],
     pos: ['read', 'create'],
     plans: ['read', 'create', 'approve', 'cancel'],
-    work_orders: ['read', 'create', 'advance', 'assign', 'consume', 'generate'],
+    work_orders: ['read', 'create', 'advance', 'assign', 'consume', 'generate', 'record_labor'],
     cutting_dispatch: ['read', 'assign'],
     costing: ['read', 'compute', 'finalize', 'adjust'],
     purchasing: ['read', 'create', 'cancel'],
@@ -135,12 +136,12 @@ const POLICY: Record<AppRole, Partial<Record<AppResource, readonly AppAction[]>>
   },
   foreman: {
     ...readOnly(['profile']),
-    work_orders: ['read', 'advance', 'consume', 'generate'],
+    work_orders: ['read', 'advance', 'consume', 'generate', 'record_labor'],
     barcodes: ['read'],
   },
   cnc_manager: {
     ...readOnly(['profile']),
-    work_orders: ['read'],
+    work_orders: ['read', 'record_labor'],
     cutting_dispatch: ['read', 'assign'],
   },
   cnc: {

--- a/src/lib/hooks/use-work-orders.ts
+++ b/src/lib/hooks/use-work-orders.ts
@@ -6,11 +6,13 @@ import type {
   AdvanceStatusInput,
   AssignWorkOrderInput,
   AddConsumptionInput,
+  AddLaborEntryInput,
 } from '@/types/api'
 import { mapApiErrorVi } from '@/lib/api/client'
 
 export const WORK_ORDERS_KEY = 'work-orders'
 export const CONSUMPTIONS_KEY = 'consumptions'
+export const LABOR_ENTRIES_KEY = 'labor-entries'
 
 export function useWorkOrders(filter: WorkOrdersFilter = {}) {
   return useQuery({
@@ -109,5 +111,36 @@ export function useAssignWorkOrder() {
 export function useSuggestAssignment() {
   return useMutation({
     mutationFn: (woId: string) => workOrdersApi.suggestAssignment(woId),
+  })
+}
+
+export function useWorkOrderLaborEntries(workOrderId: string) {
+  return useQuery({
+    queryKey: [LABOR_ENTRIES_KEY, workOrderId],
+    queryFn: () => workOrdersApi.listLaborEntries(workOrderId),
+    enabled: !!workOrderId,
+  })
+}
+
+export function useAddLaborEntry() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      workOrderId,
+      input,
+    }: {
+      workOrderId: string
+      input: AddLaborEntryInput
+    }) => workOrdersApi.addLaborEntry(workOrderId, input),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: [LABOR_ENTRIES_KEY, variables.workOrderId] })
+      // Labor cost is part of the costing record — refresh so the WO detail
+      // page reflects the new total once costing is recomputed.
+      queryClient.invalidateQueries({ queryKey: ['costing'] })
+      toast.success('Đã ghi nhận công lao động')
+    },
+    onError: (err) => {
+      toast.error(mapApiErrorVi(err, 'Ghi nhận công lao động thất bại'))
+    },
   })
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -262,6 +262,34 @@ export interface ConsumptionRecord {
   created_at: string
 }
 
+// ── Labor entries (Pillar C — Actual Costing) ───────────────────────────────
+
+export type LaborStage = 'CNC' | 'GRINDING' | 'ASSEMBLY' | 'POLISHING'
+
+/** GET /api/v1/work-orders/:id/labor-entries */
+export interface LaborEntry {
+  id: string
+  work_order_id: string
+  stage: LaborStage
+  minutes: number
+  /** Hourly rate in smallest currency unit (VND/hour). Cost = minutes * rate_per_hour / 60. */
+  rate_per_hour: number
+  /** Person whose time is recorded (may differ from actor when foreman logs for crew). */
+  worker_id: string
+  /** Recorder — the user who submitted the entry, from JWT. */
+  actor_id: string
+  created_at: string
+}
+
+/** POST /api/v1/work-orders/:id/labor-entries */
+export interface AddLaborEntryInput {
+  stage: LaborStage
+  minutes: number
+  rate_per_hour: number
+  /** Optional; when omitted backend attributes the entry to the caller. */
+  worker_id?: string
+}
+
 // ── Costing ──────────────────────────────────────────────────────────────────
 
 /** GET /api/v1/costing  or  GET /api/v1/costing/{workOrderID} */


### PR DESCRIPTION
## Summary
- New "Nhân công" tab on the Work Order detail page lets foreman / cnc_manager / admin record per-stage labor entries (CNC, Mài, Dán, Đánh bóng) against `POST /work-orders/:id/labor-entries`.
- Form is disabled once the WO reaches `COSTED` (BR-C04 — costing record immutable after finalize).
- Entries table shows minutes, hourly rate, derived cost (minutes × rate / 60), and "X · ghi nhận bởi Y" when the recorder differs from the worker.
- Adds `record_labor` RBAC action for foreman / cnc_manager / admin.

## Implementation
- Types: `LaborStage`, `LaborEntry`, `AddLaborEntryInput` mirror BE `production.LaborEntry` (incl. optional `worker_id` from BE #238).
- API: `workOrdersApi.listLaborEntries` / `addLaborEntry`.
- Hooks: `useWorkOrderLaborEntries`, `useAddLaborEntry` (invalidates `labor-entries` + `costing` keys; success toast).
- UI: `Tabs` (newly installed shadcn component) — existing detail content moved into "Tổng quan" tab; new `LaborSection` mounts in "Nhân công".
- Worker dropdown populated via `useUsers({ role: 'cnc,foreman,cnc_manager', is_active: true })` — same pattern as cutting-dispatch.

## Known limitation
`GET /admin/users` currently requires admin role. For foreman / cnc_manager the dropdown will be empty, but the form still works — submitting without `worker_id` defaults the worker to the JWT actor on the BE. Closing this gap fully requires a follow-up BE issue to expose a non-admin user-list endpoint (or relax the role check on the existing one).

## Test plan
- [ ] Admin user: open `/work-orders/<id>`, "Nhân công" tab — dropdown lists active cnc/foreman/cnc_manager users.
- [ ] Submit one entry per stage; verify it appears in the table with correct derived cost.
- [ ] Submit with `worker_id` blank — entry shows "<actor name>" only (no "ghi nhận bởi").
- [ ] Submit with a different `worker_id` — entry shows "Worker · ghi nhận bởi Actor".
- [ ] Advance the WO to COSTED — form becomes a "đã chốt" notice; existing entries still render read-only.
- [ ] cnc/planner/warehouse: tab visible (read-only) but form hidden behind "chỉ có quyền xem" copy.
- [ ] `npm run lint` (only pre-existing storybook errors), `npx tsc --noEmit`, `npm run test:unit`, `npm run build` — all green.

Closes #160