### PR TITLE
feat(dashboard): add WIP pipeline widget per stage

### DIFF
--- a/src/app/(dashboard)/overview/page.tsx
+++ b/src/app/(dashboard)/overview/page.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useMemo } from 'react'
+import Link from 'next/link'
 import {
   LineChart,
   Line,
@@ -15,12 +17,13 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts'
-import { Layers, TrendingUp, Scissors, DollarSign, AlertTriangle, CheckCircle2, Clock } from 'lucide-react'
+import { Layers, TrendingUp, Scissors, DollarSign, AlertTriangle, CheckCircle2, Clock, AlertCircle } from 'lucide-react'
 import { StatCard } from '@/components/dashboard/stat-card'
 import { AlertBanner } from '@/components/dashboard/alert-banner'
 import { Skeleton } from '@/components/ui/skeleton'
-import { useDashboardOverview } from '@/lib/hooks/use-dashboard'
-import type { RecentCutItem, RecentWorkOrderItem, RecentCostingFinalizationItem, WholeSheetsByMaterialItem } from '@/types/api'
+import { useDashboardOverview, useWIPPipeline } from '@/lib/hooks/use-dashboard'
+import { getCurrentRoleFromCookie } from '@/lib/auth/authorization'
+import type { RecentCutItem, RecentWorkOrderItem, RecentCostingFinalizationItem, WholeSheetsByMaterialItem, WorkOrderStatus, WIPPipelineEntry } from '@/types/api'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -42,7 +45,112 @@ function formatVND(amount: number) {
   return new Intl.NumberFormat('vi-VN', { style: 'currency', currency: 'VND' }).format(amount)
 }
 
+function formatAge(iso: string | null): string {
+  if (!iso) return '—'
+  const diffMs = Date.now() - new Date(iso).getTime()
+  const days = Math.floor(diffMs / 86_400_000)
+  if (days === 0) return 'Hôm nay'
+  return `${days} ngày`
+}
+
 const PIE_COLORS = ['#2563eb', '#16a34a', '#dc2626', '#d97706', '#7c3aed', '#0891b2']
+
+const WIP_STATUS_LABEL: Record<WorkOrderStatus, string> = {
+  PLANNED: 'Kế hoạch',
+  IN_CUTTING: 'Đang cắt',
+  IN_PROCESSING: 'Đang xử lý',
+  COMPLETED: 'Hoàn thành',
+  COSTED: 'Đã tính giá',
+}
+
+const WIP_STATUS_COLOR: Record<WorkOrderStatus, string> = {
+  PLANNED: 'bg-slate-100 text-slate-700 border-slate-200',
+  IN_CUTTING: 'bg-orange-100 text-orange-700 border-orange-200',
+  IN_PROCESSING: 'bg-blue-100 text-blue-700 border-blue-200',
+  COMPLETED: 'bg-green-100 text-green-700 border-green-200',
+  COSTED: 'bg-purple-100 text-purple-700 border-purple-200',
+}
+
+const WIP_STATUS_ORDER: WorkOrderStatus[] = ['PLANNED', 'IN_CUTTING', 'IN_PROCESSING', 'COMPLETED', 'COSTED']
+
+const WIP_VISIBLE_ROLES = new Set(['admin', 'planner', 'cnc_manager'])
+
+// ── WIP Pipeline widget ───────────────────────────────────────────────────────
+
+function WIPPipelineWidget() {
+  const { data, isLoading, isError } = useWIPPipeline()
+  const role = useMemo(() => {
+    if (typeof window === 'undefined') return null
+    return getCurrentRoleFromCookie()
+  }, [])
+
+  if (!role || !WIP_VISIBLE_ROLES.has(role)) return null
+
+  if (isLoading) {
+    return (
+      <div className="rounded-xl border bg-card p-5 shadow-sm">
+        <Skeleton className="mb-4 h-5 w-40" />
+        <div className="grid grid-cols-5 gap-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 rounded-lg" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="rounded-xl border bg-card p-5 shadow-sm">
+        <p className="text-sm text-muted-foreground">Không thể tải WIP pipeline.</p>
+      </div>
+    )
+  }
+
+  const stageMap = new Map<WorkOrderStatus, WIPPipelineEntry>(
+    data.stages.map((s) => [s.status, s])
+  )
+
+  return (
+    <div className="rounded-xl border bg-card p-5 shadow-sm">
+      <div className="mb-4 flex items-center gap-2">
+        <Scissors className="size-4 text-muted-foreground" />
+        <p className="text-sm font-semibold">WIP Pipeline</p>
+      </div>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        {WIP_STATUS_ORDER.map((status) => {
+          const entry = stageMap.get(status)
+          const count = entry?.count ?? 0
+          const atRisk = entry?.at_risk_count ?? 0
+          const age = entry?.oldest_started_at ?? null
+          const hasRisk = atRisk > 0
+
+          return (
+            <Link
+              key={status}
+              href={`/work-orders?status=${status}`}
+              className="group flex flex-col gap-2 rounded-lg border p-3 transition-colors hover:bg-muted/50"
+            >
+              <span className={`inline-flex w-fit items-center rounded-full border px-2 py-0.5 text-xs font-medium ${WIP_STATUS_COLOR[status]}`}>
+                {WIP_STATUS_LABEL[status]}
+              </span>
+              <span className="text-2xl font-bold tabular-nums">{count}</span>
+              <div className="space-y-0.5 text-xs text-muted-foreground">
+                <p>Tuổi: {formatAge(age)}</p>
+                {hasRisk && (
+                  <p className="flex items-center gap-1 font-medium text-destructive">
+                    <AlertCircle className="size-3 shrink-0" />
+                    {atRisk} rủi ro
+                  </p>
+                )}
+              </div>
+            </Link>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
 
 // ── Skeleton ──────────────────────────────────────────────────────────────────
 
@@ -240,6 +348,9 @@ export default function OverviewPage() {
           trend={kpi.pending_costing > 0 ? 'down' : 'up'}
         />
       </div>
+
+      {/* WIP Pipeline */}
+      <WIPPipelineWidget />
 
       {/* Charts */}
       <div className="grid gap-4 lg:grid-cols-3">

--- a/src/app/(dashboard)/work-orders/page.tsx
+++ b/src/app/(dashboard)/work-orders/page.tsx
@@ -843,12 +843,12 @@ function WorkOrdersContent() {
   const canCreateWorkOrder = can(role, 'create', 'work_orders')
   const canAdvanceWorkOrder = can(role, 'advance', 'work_orders')
 
-  const [statusFilter, setStatusFilter] = useState<WorkOrderStatus | 'ALL'>('ALL')
   const [planSearch, setPlanSearch] = useState('')
   const [createOpen, setCreateOpen] = useState(false)
   const [advanceTarget, setAdvanceTarget] = useState<WorkOrder | null>(null)
 
   const { page, limit, getParam, setPage, setParam, setParams } = usePageParams(15)
+  const statusFilter = (getParam('status') ?? 'ALL') as WorkOrderStatus | 'ALL'
   const planFilter = getParam('plan_id') ?? 'ALL'
   const debouncedPlanSearch = useDebounce(planSearch, 300)
 
@@ -1024,7 +1024,7 @@ function WorkOrdersContent() {
         <div className="flex flex-wrap items-center gap-2">
           <Select
             value={statusFilter}
-            onValueChange={(v) => { setStatusFilter(v as WorkOrderStatus | 'ALL'); setPage(1) }}
+            onValueChange={(v) => { setParam('status', v === 'ALL' ? undefined : v) }}
           >
             <SelectTrigger className="w-44">
               <SelectValue />

--- a/src/lib/api/dashboard.ts
+++ b/src/lib/api/dashboard.ts
@@ -1,7 +1,10 @@
-import type { OverviewOutput } from '@/types/api'
+import type { OverviewOutput, WIPPipelineOutput } from '@/types/api'
 import { apiClient } from './client'
 
 export const dashboardApi = {
   /** GET /api/v1/dashboard/overview */
   getOverview: () => apiClient.get<OverviewOutput>('/dashboard/overview'),
+
+  /** GET /api/v1/dashboard/wip-pipeline */
+  getWIPPipeline: () => apiClient.get<WIPPipelineOutput>('/dashboard/wip-pipeline'),
 }

--- a/src/lib/hooks/use-dashboard.ts
+++ b/src/lib/hooks/use-dashboard.ts
@@ -2,11 +2,21 @@ import { useQuery } from '@tanstack/react-query'
 import { dashboardApi } from '@/lib/api/dashboard'
 
 export const DASHBOARD_KEY = 'dashboard-overview'
+export const WIP_PIPELINE_KEY = 'dashboard-wip-pipeline'
 
 export function useDashboardOverview() {
   return useQuery({
     queryKey: [DASHBOARD_KEY],
     queryFn: dashboardApi.getOverview,
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  })
+}
+
+export function useWIPPipeline() {
+  return useQuery({
+    queryKey: [WIP_PIPELINE_KEY],
+    queryFn: dashboardApi.getWIPPipeline,
     staleTime: 30_000,
     refetchInterval: 60_000,
   })

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -722,3 +722,18 @@ export interface MPOFilter extends PageParams {
   status?: MPOStatus
   material_id?: string
 }
+
+// ── WIP Pipeline (dashboard) ─────────────────────────────────────────────────
+
+export interface WIPPipelineEntry {
+  status: WorkOrderStatus
+  count: number
+  /** ISO timestamp of the oldest started_at in this stage, null if none */
+  oldest_started_at: string | null
+  /** WOs whose expected_completion < now + 2 days and not yet COMPLETED */
+  at_risk_count: number
+}
+
+export interface WIPPipelineOutput {
+  stages: WIPPipelineEntry[]
+}


### PR DESCRIPTION
## Summary
- New WIP Pipeline widget on the overview page showing one column per `WorkOrderStatus` (PLANNED / IN_CUTTING / IN_PROCESSING / COMPLETED / COSTED)
- Each column shows: WO count, age of oldest job, and at-risk count (red) when `at_risk_count > 0`
- Clicking a column navigates to `/work-orders?status=<STATUS>` for drill-down
- Polls every 60s; only visible to `admin`, `planner`, `cnc_manager`
- Makes the work-orders status filter URL-driven (was local state) to support the drill-down link

## Test plan
- [ ] Visit `/overview` as `admin` — WIP Pipeline widget appears below KPI cards
- [ ] Visit `/overview` as `warehouse` — widget is hidden
- [ ] Click a column → navigates to `/work-orders` with correct `?status=` param and filter pre-selected
- [ ] At-risk count > 0 shows red `AlertCircle` label
- [ ] Widget auto-refreshes every 60s
- [ ] Responsive at 375 px (2-col grid), 768 px (3-col), 1280 px (5-col)
- [ ] Backend returns empty stages → columns show 0 count, no crash

## Cross-link
Backend: giangdq202/Vmarble-Warehouse-Management-Service#226 (closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)