### PR TITLE
fix(waste-report): wrap stat skeletons in div, not p

### DIFF
--- a/src/app/(dashboard)/waste-report/page.tsx
+++ b/src/app/(dashboard)/waste-report/page.tsx
@@ -245,9 +245,9 @@ function WasteReportContent() {
             <CardTitle className="text-xs font-medium text-muted-foreground">Số tấm tiêu thụ</CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-2xl font-semibold">
+            <div className="text-2xl font-semibold">
               {isLoading ? <Skeleton className="h-7 w-20" /> : totals.sheets.toLocaleString('vi-VN')}
-            </p>
+            </div>
           </CardContent>
         </Card>
         <Card>
@@ -255,9 +255,9 @@ function WasteReportContent() {
             <CardTitle className="text-xs font-medium text-muted-foreground">Tổng diện tích hao hụt</CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-2xl font-semibold">
+            <div className="text-2xl font-semibold">
               {isLoading ? <Skeleton className="h-7 w-24" /> : `${formatM2(totals.areaMm2)} m²`}
-            </p>
+            </div>
           </CardContent>
         </Card>
         <Card>
@@ -265,9 +265,9 @@ function WasteReportContent() {
             <CardTitle className="text-xs font-medium text-muted-foreground">Tổng chi phí hao hụt</CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-2xl font-semibold text-red-700">
+            <div className="text-2xl font-semibold text-red-700">
               {isLoading ? <Skeleton className="h-7 w-32" /> : formatVND(totals.cost)}
-            </p>
+            </div>
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
## Summary
Closes #182. Removes the React hydration warning on `/waste-report`.

`<Skeleton>` (`src/components/ui/skeleton.tsx`) renders a `<div data-slot=\"skeleton\">`. HTML forbids a block-level `<div>` as a descendant of an inline `<p>`, so the three summary cards in `WasteReportContent` (`waste-report/page.tsx:248-271`) triggered:

> In HTML, `<div>` cannot be a descendant of `<p>`. This will cause a hydration error.

Switched the three `<p className=\"text-2xl font-semibold\">` wrappers to `<div>` while keeping the same typography classes — visual output is unchanged for the loading and loaded states.

Grepped `src/**/*.tsx` for the same `<p>` + `<Skeleton>` pattern; no other occurrences remain.

## Test plan
- [ ] Open `/waste-report` with the React dev console — no hydration warning logged.
- [ ] Confirm three summary cards (*Số tấm tiêu thụ*, *Tổng diện tích hao hụt*, *Tổng chi phí hao hụt*) render the skeleton during loading and the formatted number after data arrives.
- [ ] Compare typography against `dev` — text size, weight, red color on the cost card all preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)