### PR TITLE
fix(fonts): preload latin-ext for Vietnamese diacritics

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,12 +6,12 @@ import { Toaster } from '@/components/ui/sonner'
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
-  subsets: ['latin'],
+  subsets: ['latin', 'latin-ext'],
 })
 
 const geistMono = Geist_Mono({
   variable: '--font-geist-mono',
-  subsets: ['latin'],
+  subsets: ['latin', 'latin-ext'],
 })
 
 export const metadata: Metadata = {


### PR DESCRIPTION
## Summary
Closes #184, closes #185.

Geist + Geist_Mono were loaded in `src/app/layout.tsx` with `subsets: ['latin']` only. Vietnamese letters that carry diacritics (`ấ`, `ẻ`, `ỏ`, `ờ`, `ừ`, …) live in the **latin-ext** Unicode range, so the browser silently fell back to a system font for any glyph with a diacritic — producing the inconsistent rendering reported on labels like \"Bỏ qua tấm lẻ\" and \"Tấm nguyên\", plus a long tail of other strings across the dashboard and kiosk.

Adding `'latin-ext'` to both loaders ships the diacritic glyphs as part of the same web-font, so all Vietnamese text now renders in Geist consistently.

> Note: Geist on Google Fonts exposes only `cyrillic | latin | latin-ext` — there is no separate `'vietnamese'` subset, so the issue title's \"Vietnamese font support\" is implemented via `latin-ext`.

## Why this also covers the rest of the app
The fix is at the root font loader, so every page that uses `font-sans` or `font-mono` benefits — labels under `(dashboard)`, `(kiosk)`, and `(auth)` route groups all share the same `<body>` font stack.

## Test plan
- [ ] `/work-orders` → open the *Bỏ qua tấm lẻ phù hợp?* dialog and confirm all glyphs render in the same Geist weight.
- [ ] `/overview` → confirm \"Tấm nguyên theo vật liệu\" widget header is consistent.
- [ ] `/remnants` → table rows with \"Tấm nguyên: …\" prefix render uniformly.
- [ ] Inspect Network tab in Chrome — the woff2 requests for Geist now include a `latin-ext` subset payload.
- [ ] Spot-check Safari (which is stricter about font fallback) on the same screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)