### PR TITLE
feat(format): add shared formatVND / formatMoney helper

### DIFF
--- a/src/app/(dashboard)/costing/page.tsx
+++ b/src/app/(dashboard)/costing/page.tsx
@@ -36,10 +36,10 @@ import { useComputeCosting, useCosting, useFinalizeCosting } from '@/lib/hooks/u
 import { useDebounce } from '@/lib/hooks/use-debounce'
 import { usePageParams } from '@/lib/hooks/use-page-params'
 import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
+import { formatVND } from '@/lib/format'
 import type { CostingRecord } from '@/types/api'
 
-const fmt = (n: number) =>
-  n.toLocaleString('vi-VN', { style: 'currency', currency: 'VND' })
+const fmt = formatVND
 
 const formatDate = (iso: string) =>
   new Date(iso).toLocaleString('vi-VN', {

--- a/src/app/(dashboard)/overview/page.tsx
+++ b/src/app/(dashboard)/overview/page.tsx
@@ -23,6 +23,7 @@ import { AlertBanner } from '@/components/dashboard/alert-banner'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useDashboardOverview, useWIPPipeline } from '@/lib/hooks/use-dashboard'
 import { getCurrentRoleFromCookie } from '@/lib/auth/authorization'
+import { formatVND } from '@/lib/format'
 import type { RecentCutItem, RecentWorkOrderItem, RecentCostingFinalizationItem, WholeSheetsByMaterialItem, WorkOrderStatus, WIPPipelineEntry } from '@/types/api'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -39,10 +40,6 @@ function formatDateTime(iso: string) {
   return new Date(iso).toLocaleString('vi-VN', {
     day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit',
   })
-}
-
-function formatVND(amount: number) {
-  return new Intl.NumberFormat('vi-VN', { style: 'currency', currency: 'VND' }).format(amount)
 }
 
 function formatAge(iso: string | null): string {

--- a/src/app/(dashboard)/pos/[id]/page.tsx
+++ b/src/app/(dashboard)/pos/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
 import { usePOLineItems } from '@/lib/hooks/use-pos'
 import { useSKUs } from '@/lib/hooks/use-skus'
 import { usePOs } from '@/lib/hooks/use-pos'
+import { formatMoney } from '@/lib/format'
 import type { LineItem } from '@/types/api'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -28,10 +29,6 @@ function formatDate(iso: string) {
     month: '2-digit',
     year: 'numeric',
   })
-}
-
-function formatMoney(amount: number, currency: string) {
-  return new Intl.NumberFormat('vi-VN', { style: 'currency', currency }).format(amount)
 }
 
 // ── Line items table ──────────────────────────────────────────────────────────

--- a/src/app/(dashboard)/pos/page.tsx
+++ b/src/app/(dashboard)/pos/page.tsx
@@ -68,10 +68,6 @@ function formatDate(iso: string) {
   })
 }
 
-function formatMoney(amount: number, currency: string) {
-  return new Intl.NumberFormat('vi-VN', { style: 'currency', currency }).format(amount)
-}
-
 // ── Helpers — price formatting ────────────────────────────────────────────────
 
 /** Format a number with thousand-separators: 1500000 → "1,500,000" */

--- a/src/app/(dashboard)/purchasing/[id]/page.tsx
+++ b/src/app/(dashboard)/purchasing/[id]/page.tsx
@@ -41,6 +41,7 @@ import {
 } from '@/lib/hooks/use-purchasing'
 import { useMaterials } from '@/lib/hooks/use-materials'
 import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
+import { formatMoney } from '@/lib/format'
 import type { MPOStatus, AddMPOItemInput } from '@/types/api'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -369,10 +370,10 @@ function PurchasingDetail({ id }: { id: string }) {
                     </TableCell>
                     <TableCell className="text-right text-sm">{item.quantity}</TableCell>
                     <TableCell className="text-right text-sm">
-                      {item.unit_cost.amount.toLocaleString('vi-VN')} {item.unit_cost.currency}
+                      {formatMoney(item.unit_cost.amount, item.unit_cost.currency)}
                     </TableCell>
                     <TableCell className="text-right text-sm font-medium">
-                      {item.total_cost.amount.toLocaleString('vi-VN')} {item.total_cost.currency}
+                      {formatMoney(item.total_cost.amount, item.total_cost.currency)}
                     </TableCell>
                     {isDraft && canManage && (
                       <TableCell className="text-right">

--- a/src/app/(dashboard)/waste-report/page.tsx
+++ b/src/app/(dashboard)/waste-report/page.tsx
@@ -34,6 +34,7 @@ import {
 import { mapApiErrorVi } from '@/lib/api/client'
 import { costingApi } from '@/lib/api/costing'
 import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
+import { formatVND } from '@/lib/format'
 import { useMaterials } from '@/lib/hooks/use-materials'
 import { useWasteReport } from '@/lib/hooks/use-waste-report'
 import type { WasteReportFilter, WasteReportRow } from '@/types/api'
@@ -63,10 +64,6 @@ function formatM2(mm2: number): string {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   })
-}
-
-function formatVND(amount: number): string {
-  return amount.toLocaleString('vi-VN', { style: 'currency', currency: 'VND' })
 }
 
 function formatCostPerM2(row: WasteReportRow): string {

--- a/src/app/(dashboard)/work-orders/[id]/page.tsx
+++ b/src/app/(dashboard)/work-orders/[id]/page.tsx
@@ -55,6 +55,7 @@ import { ApiClientError } from '@/lib/api/client'
 import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
 import { evaluateStartCutGate, startCutTooltip } from '@/lib/auth/work-order-gate'
 import { useMe } from '@/lib/hooks/use-auth'
+import { formatMoney, formatVND } from '@/lib/format'
 import type {
   WorkOrderStatus,
   BarcodeRecord,
@@ -568,10 +569,10 @@ function LaborSection({ wo }: { wo: WorkOrder }) {
                         </TableCell>
                         <TableCell className="text-right">{entry.minutes}</TableCell>
                         <TableCell className="text-right">
-                          {entry.rate_per_hour.toLocaleString('vi-VN')}
+                          {formatVND(entry.rate_per_hour)}
                         </TableCell>
                         <TableCell className="text-right font-medium">
-                          {costVnd.toLocaleString('vi-VN')}
+                          {formatVND(costVnd)}
                         </TableCell>
                         <TableCell className="text-sm">
                           <span className="font-medium">{workerLabel(entry.worker_id)}</span>
@@ -775,10 +776,10 @@ function WorkOrderDetail({ id }: { id: string }) {
             ) : hasCostingRecord && costingRecord ? (
               <div className="space-y-3">
                 <div className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
-                  <Field label="Nguyên vật liệu" value={`${costingRecord.material_cost.amount} ${costingRecord.material_cost.currency}`} />
-                  <Field label="Vật tư phụ" value={`${costingRecord.auxiliary_cost.amount} ${costingRecord.auxiliary_cost.currency}`} />
-                  <Field label="Nhân công" value={`${costingRecord.labor_cost.amount} ${costingRecord.labor_cost.currency}`} />
-                  <Field label="Tổng chi phí" value={<span className="font-bold">{costingRecord.total_cost.amount} {costingRecord.total_cost.currency}</span>} />
+                  <Field label="Nguyên vật liệu" value={formatMoney(costingRecord.material_cost.amount, costingRecord.material_cost.currency)} />
+                  <Field label="Vật tư phụ" value={formatMoney(costingRecord.auxiliary_cost.amount, costingRecord.auxiliary_cost.currency)} />
+                  <Field label="Nhân công" value={formatMoney(costingRecord.labor_cost.amount, costingRecord.labor_cost.currency)} />
+                  <Field label="Tổng chi phí" value={<span className="font-bold">{formatMoney(costingRecord.total_cost.amount, costingRecord.total_cost.currency)}</span>} />
                 </div>
                 {(() => {
                   const gate = evaluateStartCutGate({ wo, currentUserId: me?.id ?? null, role })

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { formatVND, formatMoney, formatIntVN } from './format'
+
+describe('formatVND', () => {
+  it('adds vi-VN thousand separators and the đồng symbol', () => {
+    // Non-breaking space (U+00A0) sits between number and symbol on some runtimes.
+    const out = formatVND(1_500_000)
+    expect(out.replace(/\s+/g, ' ')).toBe('1.500.000 ₫')
+  })
+
+  it('rounds fractional đồng to the nearest whole', () => {
+    expect(formatVND(1_500.4)).toMatch(/^1\.500/)
+    expect(formatVND(1_500.6)).toMatch(/^1\.501/)
+  })
+
+  it('handles zero and negative amounts', () => {
+    expect(formatVND(0)).toMatch(/^0\s*₫$/)
+    expect(formatVND(-50_000)).toMatch(/^-50\.000/)
+  })
+
+  it('returns em-dash for NaN / Infinity instead of throwing', () => {
+    expect(formatVND(Number.NaN)).toBe('—')
+    expect(formatVND(Number.POSITIVE_INFINITY)).toBe('—')
+  })
+})
+
+describe('formatMoney', () => {
+  it('delegates to formatVND when currency is VND', () => {
+    expect(formatMoney(1_000_000, 'VND')).toBe(formatVND(1_000_000))
+  })
+
+  it('formats non-VND currencies using vi-VN locale', () => {
+    const out = formatMoney(1234.56, 'USD')
+    expect(out).toMatch(/1\.234/)
+    expect(out).toMatch(/US/)
+  })
+
+  it('falls back to raw-number + currency on unknown codes', () => {
+    const out = formatMoney(10, 'ZZZ')
+    expect(out).toMatch(/10/)
+    expect(out).toMatch(/ZZZ/)
+  })
+})
+
+describe('formatIntVN', () => {
+  it('separates thousands with periods', () => {
+    expect(formatIntVN(1_000)).toBe('1.000')
+    expect(formatIntVN(1_234_567)).toBe('1.234.567')
+  })
+})

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,40 @@
+// Shared number / money / date formatters. Keep presentational-only — no API or state here.
+
+/**
+ * Format a raw VND amount (smallest-unit integer from the backend) as a
+ * locale-aware Vietnamese currency string, e.g. `1.500.000 ₫`.
+ *
+ * Always rounds to whole đồng (we never display sub-đồng precision) and uses
+ * `vi-VN` thousand separators.
+ */
+export function formatVND(amount: number): string {
+  if (!Number.isFinite(amount)) return '—'
+  return Math.round(amount).toLocaleString('vi-VN', {
+    style: 'currency',
+    currency: 'VND',
+    maximumFractionDigits: 0,
+  })
+}
+
+/**
+ * Format a `{ amount, currency }` Money DTO. Falls back to `amount + currency`
+ * when the currency is non-VND so display stays predictable.
+ */
+export function formatMoney(amount: number, currency: string): string {
+  if (!Number.isFinite(amount)) return '—'
+  if (currency === 'VND') return formatVND(amount)
+  try {
+    return amount.toLocaleString('vi-VN', { style: 'currency', currency })
+  } catch {
+    return `${amount.toLocaleString('vi-VN')} ${currency}`
+  }
+}
+
+/**
+ * Format a plain integer quantity with vi-VN thousand separators
+ * (e.g. 1500 → `1.500`). For counts of sheets, pieces, etc.
+ */
+export function formatIntVN(value: number): string {
+  if (!Number.isFinite(value)) return '—'
+  return value.toLocaleString('vi-VN')
+}


### PR DESCRIPTION
## Summary
Closes #189. Money used to render three different ways across the dashboard:

- Raw `amount + currency` concatenation on `/work-orders/:id` costing card (e.g. `1500000 VND`).
- Per-file `formatVND` copies in `/overview`, `/waste-report`, `/costing`, `/pos/*`.
- `toLocaleString('vi-VN')` **without** the currency symbol on the `/purchasing` detail table and the WO labor table.

Centralised formatting in `src/lib/format.ts`:
- `formatVND(amount)` → `"1.500.000 ₫"` (rounded, `vi-VN`).
- `formatMoney(amount, ccy)` → delegates to `formatVND` for VND; keeps `vi-VN` locale for other currencies; falls back to raw number + code for unknown ISO codes.
- `formatIntVN(value)` for non-money integers (sheets, units).
- `NaN` / `Infinity` → `—` instead of throwing.

### Call sites swept
| File | Change |
|---|---|
| `costing/page.tsx` | Local `fmt` now aliases the shared helper. |
| `waste-report/page.tsx` | Deletes local `formatVND`; reuses shared. |
| `overview/page.tsx` | Deletes local `formatVND`; reuses shared. |
| `pos/[id]/page.tsx` | Deletes local `formatMoney`; reuses shared. |
| `pos/page.tsx` | Drops unused local `formatMoney` (list view renders quantity only). |
| `purchasing/[id]/page.tsx` | Unit / total cost columns now show the currency symbol. |
| `work-orders/[id]/page.tsx` | Costing breakdown (material / aux / labor / total) + labor table rewritten to use helpers. |

### Tests
`src/lib/format.test.ts` — 8 cases: `vi-VN` separators, rounding, zero, negative, non-VND delegation, unknown code fallback, NaN / Infinity guard, `formatIntVN` shape.

## Test plan
- [ ] `/costing` — table columns and dialog totals show `₫` suffix with dot-separated groups.
- [ ] `/work-orders/:id` costing section shows `1.500.000 ₫` instead of `1500000 VND`.
- [ ] `/work-orders/:id` labor table — *Lương/giờ* and *Chi phí* columns show `₫`.
- [ ] `/waste-report` stats, chart tooltip, and table cost columns unchanged visually.
- [ ] `/overview` cost-allocation pie tooltip unchanged visually.
- [ ] `/purchasing/:id` item table now includes currency symbol.
- [ ] `/pos` list and detail render prices with thousand separators.
- [ ] `npm run test:unit -- src/lib/format.test.ts` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)