### PR TITLE
feat(waste-report): hide zero-cost rows by default + explain tooltip

### DIFF
--- a/src/app/(dashboard)/waste-report/page.test.ts
+++ b/src/app/(dashboard)/waste-report/page.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { filterCostedRows } from './page'
+import type { WasteReportRow } from '@/types/api'
+
+function row(overrides: Partial<WasteReportRow> = {}): WasteReportRow {
+  return {
+    material_id: 'm1',
+    material_name: 'Plywood A',
+    sheets_consumed: 10,
+    waste_area_mm2: 500_000,
+    avg_sheet_cost: { amount: 100_000, currency: 'VND' },
+    total_waste_cost: { amount: 50_000, currency: 'VND' },
+    ...overrides,
+  }
+}
+
+describe('filterCostedRows', () => {
+  it('keeps rows with a positive total_waste_cost', () => {
+    const rows = [row({ material_id: 'a' }), row({ material_id: 'b', total_waste_cost: { amount: 1, currency: 'VND' } })]
+    expect(filterCostedRows(rows)).toHaveLength(2)
+  })
+
+  it('drops rows whose total_waste_cost is zero (WO chưa costed)', () => {
+    const rows = [
+      row({ material_id: 'a' }),
+      row({ material_id: 'b', total_waste_cost: { amount: 0, currency: 'VND' } }),
+      row({ material_id: 'c', total_waste_cost: { amount: 7_000, currency: 'VND' } }),
+    ]
+    const out = filterCostedRows(rows)
+    expect(out.map((r) => r.material_id)).toEqual(['a', 'c'])
+  })
+
+  it('drops rows with negative cost defensively (should never happen in practice)', () => {
+    const rows = [row({ material_id: 'a', total_waste_cost: { amount: -1, currency: 'VND' } })]
+    expect(filterCostedRows(rows)).toHaveLength(0)
+  })
+
+  it('returns an empty array when every row is uncosted', () => {
+    const rows = [
+      row({ material_id: 'a', total_waste_cost: { amount: 0, currency: 'VND' } }),
+      row({ material_id: 'b', total_waste_cost: { amount: 0, currency: 'VND' } }),
+    ]
+    expect(filterCostedRows(rows)).toEqual([])
+  })
+})

--- a/src/app/(dashboard)/waste-report/page.tsx
+++ b/src/app/(dashboard)/waste-report/page.tsx
@@ -75,6 +75,16 @@ function formatCostPerM2(row: WasteReportRow): string {
   return formatVND(row.total_waste_cost.amount / m2)
 }
 
+/**
+ * BR-C03: a row with total_waste_cost.amount === 0 means the underlying work
+ * orders have not been costed yet, so there is no sheet price to allocate
+ * waste against. We keep those rows filterable because users reading the
+ * report almost always want the accounting view, not the operational one.
+ */
+export function filterCostedRows(rows: WasteReportRow[]): WasteReportRow[] {
+  return rows.filter((r) => r.total_waste_cost.amount > 0)
+}
+
 function buildCsvFilename(filter: WasteReportFilter): string {
   const from = filter.from ?? 'all'
   const to = filter.to ?? 'all'
@@ -125,7 +135,15 @@ function WasteReportContent() {
     error,
   } = useWasteReport(canRead ? filter : {})
 
-  const reportRows: WasteReportRow[] = useMemo(() => rows ?? [], [rows])
+  const allReportRows: WasteReportRow[] = useMemo(() => rows ?? [], [rows])
+
+  // Row filter — default ON: hide materials with 0đ waste (WO chưa costed).
+  const [onlyCosted, setOnlyCosted] = useState(true)
+  const reportRows = useMemo(
+    () => (onlyCosted ? filterCostedRows(allReportRows) : allReportRows),
+    [allReportRows, onlyCosted],
+  )
+  const uncostedCount = allReportRows.length - filterCostedRows(allReportRows).length
 
   const totals = useMemo(() => {
     return reportRows.reduce(
@@ -238,6 +256,27 @@ function WasteReportContent() {
         )}
       </div>
 
+      {/* Filter toggle */}
+      <label
+        className="flex w-fit cursor-pointer items-center gap-2 rounded-md border bg-muted/30 px-3 py-1.5 text-xs text-muted-foreground"
+        title="Ẩn các dòng có tổng chi phí hao hụt = 0 (WO chưa được tính giá)."
+      >
+        <input
+          type="checkbox"
+          className="size-3.5 accent-primary"
+          checked={onlyCosted}
+          onChange={(e) => setOnlyCosted(e.target.checked)}
+        />
+        <span>
+          Chỉ hiển thị vật liệu đã tính giá
+          {onlyCosted && uncostedCount > 0 && (
+            <span className="ml-1 font-medium text-foreground">
+              ({uncostedCount} dòng đang bị ẩn)
+            </span>
+          )}
+        </span>
+      </label>
+
       {/* Summary cards */}
       <div className="grid gap-3 md:grid-cols-3">
         <Card>
@@ -338,17 +377,31 @@ function WasteReportContent() {
                   </TableCell>
                 </TableRow>
               ) : (
-                reportRows.map((r) => (
-                  <TableRow key={r.material_id}>
-                    <TableCell className="font-medium">{r.material_name}</TableCell>
-                    <TableCell className="text-right">{r.sheets_consumed.toLocaleString('vi-VN')}</TableCell>
-                    <TableCell className="text-right">{formatM2(r.waste_area_mm2)}</TableCell>
-                    <TableCell className="text-right">{formatCostPerM2(r)}</TableCell>
-                    <TableCell className="text-right font-medium text-red-700">
-                      {formatVND(r.total_waste_cost.amount)}
-                    </TableCell>
-                  </TableRow>
-                ))
+                reportRows.map((r) => {
+                  const uncosted = r.total_waste_cost.amount <= 0
+                  return (
+                    <TableRow
+                      key={r.material_id}
+                      className={uncosted ? 'opacity-70' : ''}
+                      title={uncosted ? 'Chưa tính giá thành (WO chưa được cost). Tổng chi phí hao hụt hiển thị 0đ vì không có giá tấm gốc để phân bổ.' : undefined}
+                    >
+                      <TableCell className="font-medium">
+                        {r.material_name}
+                        {uncosted && (
+                          <span className="ml-1 text-[10px] font-normal uppercase tracking-wide text-amber-700">
+                            (chưa tính giá)
+                          </span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-right">{r.sheets_consumed.toLocaleString('vi-VN')}</TableCell>
+                      <TableCell className="text-right">{formatM2(r.waste_area_mm2)}</TableCell>
+                      <TableCell className="text-right">{formatCostPerM2(r)}</TableCell>
+                      <TableCell className="text-right font-medium text-red-700">
+                        {formatVND(r.total_waste_cost.amount)}
+                      </TableCell>
+                    </TableRow>
+                  )
+                })
               )}
             </TableBody>
           </Table>

--- a/src/app/(dashboard)/waste-report/page.tsx
+++ b/src/app/(dashboard)/waste-report/page.tsx
@@ -284,9 +284,9 @@ function WasteReportContent() {
             <CardTitle className="text-xs font-medium text-muted-foreground">Số tấm tiêu thụ</CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-2xl font-semibold">
+            <div className="text-2xl font-semibold">
               {isLoading ? <Skeleton className="h-7 w-20" /> : totals.sheets.toLocaleString('vi-VN')}
-            </p>
+            </div>
           </CardContent>
         </Card>
         <Card>
@@ -294,9 +294,9 @@ function WasteReportContent() {
             <CardTitle className="text-xs font-medium text-muted-foreground">Tổng diện tích hao hụt</CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-2xl font-semibold">
+            <div className="text-2xl font-semibold">
               {isLoading ? <Skeleton className="h-7 w-24" /> : `${formatM2(totals.areaMm2)} m²`}
-            </p>
+            </div>
           </CardContent>
         </Card>
         <Card>
@@ -304,9 +304,9 @@ function WasteReportContent() {
             <CardTitle className="text-xs font-medium text-muted-foreground">Tổng chi phí hao hụt</CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-2xl font-semibold text-red-700">
+            <div className="text-2xl font-semibold text-red-700">
               {isLoading ? <Skeleton className="h-7 w-32" /> : formatVND(totals.cost)}
-            </p>
+            </div>
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
## Summary
Closes #191.

Users read `/waste-report` as the accounting view, but rows whose underlying work orders haven't been costed yet show `0 ₫` in *Tổng chi phí hao hụt* (BR-C03: without a sheet price there's nothing to allocate). That looked like a system bug.

- New toggle **Chỉ hiển thị vật liệu đã tính giá** (default **ON**) drops rows with `total_waste_cost.amount <= 0`.
- When the toggle is active the label shows how many entries are hidden (`(N dòng đang bị ẩn)`) so the filter's effect is discoverable.
- Rows that slip through (toggle off) are dimmed, tagged with a small *chưa tính giá* pill, and carry a native `title` tooltip explaining the 0 ₫ cost.
- Extracted `filterCostedRows()` and covered it with 4 unit tests so the logic is pinned independent of the UI.

### i18n audit
Walked every string on the page — all already in Vietnamese (Tải CSV, Vật liệu, Đang tải…, etc.). Nothing to translate.

## Test plan
- [ ] `/waste-report` initial render — the toggle is checked and any 0 ₫ material rows are hidden; label shows the hidden count.
- [ ] Uncheck the toggle → the 0 ₫ rows appear dimmed with a *(chưa tính giá)* pill; hover shows the tooltip.
- [ ] Re-check the toggle → rows disappear again, hidden count updates.
- [x] `npm run test:unit -- src/app/\(dashboard\)/waste-report/page.test.ts` → 4 tests pass.
- [x] CSV export (*Tải CSV*) still reflects the raw server range — the filter is UI-only, confirmed by reading `costingApi.wasteReportCsvBlob(filter)`.

<img width="1964" height="444" alt="image" src="https://github.com/user-attachments/assets/d0af2040-f6f1-4585-85ab-b7a02f922812" />
