### PR TITLE
feat(costing): explain disabled action buttons on cost table rows

### DIFF
--- a/src/app/(dashboard)/costing/page.tsx
+++ b/src/app/(dashboard)/costing/page.tsx
@@ -58,6 +58,38 @@ const FINALIZED_LABELS: Record<FinalizedFilter, string> = {
   DRAFT: 'Nháp',
 }
 
+function computeDisabledReason(
+  canCompute: boolean,
+  locked: boolean,
+  computing: boolean,
+  finalizing: boolean,
+): string | null {
+  if (!canCompute) return 'Không đủ quyền tính giá thành.'
+  if (locked) return 'Giá thành đã chốt, không thể tính lại.'
+  if (computing) return 'Đang tính giá thành cho lệnh khác.'
+  if (finalizing) return 'Đang chốt giá thành cho lệnh khác.'
+  return null
+}
+
+function finalizeDisabledReason(
+  canFinalize: boolean,
+  locked: boolean,
+  computing: boolean,
+  finalizing: boolean,
+): string | null {
+  if (!canFinalize) return 'Không đủ quyền chốt giá thành.'
+  if (locked) return 'Giá thành đã chốt trước đó.'
+  if (computing) return 'Đang tính lại — chờ xong rồi chốt.'
+  if (finalizing) return 'Đang chốt giá thành cho lệnh khác.'
+  return null
+}
+
+function adjustDisabledReason(canAdjust: boolean, finalized: boolean): string | null {
+  if (!canAdjust) return 'Không đủ quyền điều chỉnh giá thành (chỉ kế toán / admin).'
+  if (!finalized) return 'Chỉ điều chỉnh được sau khi đã chốt giá thành.'
+  return null
+}
+
 function useCurrentRole() {
   return useSyncExternalStore(
     () => () => {},
@@ -350,6 +382,7 @@ function CostingContent() {
                                 type="button"
                                 size="sm"
                                 variant="outline"
+                                title={computeDisabledReason(canComputeCosting, lockByFinalized, rowComputing, rowFinalizing) ?? undefined}
                                 disabled={
                                   !canComputeCosting
                                   || lockByFinalized
@@ -358,11 +391,12 @@ function CostingContent() {
                                 }
                                 onClick={() => handleCompute(r.work_order_id)}
                               >
-                                {rowComputing ? 'Đang tính...' : 'Compute'}
+                                {rowComputing ? 'Đang tính...' : 'Tính lại giá'}
                               </Button>
                               <Button
                                 type="button"
                                 size="sm"
+                                title={finalizeDisabledReason(canFinalizeCosting, lockByFinalized, rowComputing, rowFinalizing) ?? undefined}
                                 disabled={
                                   !canFinalizeCosting
                                   || lockByFinalized
@@ -371,12 +405,13 @@ function CostingContent() {
                                 }
                                 onClick={() => handleFinalize(r.work_order_id)}
                               >
-                                {rowFinalizing ? 'Đang chốt...' : 'Finalize'}
+                                {rowFinalizing ? 'Đang chốt...' : 'Chốt giá thành'}
                               </Button>
                               <Button
                                 type="button"
                                 size="sm"
                                 variant="secondary"
+                                title={adjustDisabledReason(canAdjustCosting, r.finalized) ?? 'Tạo bản điều chỉnh giá thành cho WO này'}
                                 disabled={!canAdjustCosting || !r.finalized}
                                 onClick={() => openAdjustment(r)}
                               >


### PR DESCRIPTION
## Summary
Closes #192. Accountants reported that the action buttons on `/costing` (*Tính lại giá* / *Chốt giá thành* / *Điều chỉnh*) silently flipped to disabled, so they couldn't tell a permission problem apart from \"backend not ready yet.\"

### Changes
- Added three small helpers (`computeDisabledReason`, `finalizeDisabledReason`, `adjustDisabledReason`) that return a short Vietnamese reason whenever the respective button would be disabled.
- Wired them to each button via the native `title` attribute — hovering the disabled button now explains exactly why.
- Matching labels in Vietnamese: `Compute` → *Tính lại giá*, `Finalize` → *Chốt giá thành* (Điều chỉnh already translated).

### Reason matrix
| Button | Disabled when… | Tooltip |
|---|---|---|
| Tính lại giá | `!canCompute` | Không đủ quyền tính giá thành. |
|  | record already finalized | Giá thành đã chốt, không thể tính lại. |
|  | compute/finalize running | Đang tính/ chốt giá thành cho lệnh khác. |
| Chốt giá thành | `!canFinalize` | Không đủ quyền chốt giá thành. |
|  | record already finalized | Giá thành đã chốt trước đó. |
|  | compute/finalize running | Đang tính/ chốt giá thành cho lệnh khác. |
| Điều chỉnh | `!canAdjust` | Không đủ quyền điều chỉnh giá thành (chỉ kế toán / admin). |
|  | `!r.finalized` | Chỉ điều chỉnh được sau khi đã chốt giá thành. |

## Not in scope
The actual API wiring for adjustments still waits on backend #250 (`POST /costing/:id/adjustments`). This PR covers the first DoD bullet from #192 (rule enable + tooltip); the *Điều chỉnh* dialog still shows the placeholder explaining the BE dependency.

## Test plan
- [ ] `/costing` row where user isn't accountant → all three buttons show role tooltips.
- [ ] `/costing` row where `r.finalized === false` → *Điều chỉnh* shows \"Chỉ điều chỉnh được sau khi đã chốt giá thành.\"
- [ ] `/costing` row where `r.finalized === true` → *Điều chỉnh* enabled with hint \"Tạo bản điều chỉnh giá thành cho WO này\".
- [ ] While a compute mutation runs, the sibling finalize button shows the running tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)