### PR TITLE
[dispatch] show WO id, dims, qty in assign dialog

### DIFF
--- a/src/app/(dashboard)/cutting-dispatch/page.tsx
+++ b/src/app/(dashboard)/cutting-dispatch/page.tsx
@@ -173,14 +173,30 @@ function AssignDialog({ wo, onClose }: AssignDialogProps) {
     <Dialog open onOpenChange={(v) => !v && handleClose()}>
       <DialogContent className="max-w-sm">
         <DialogHeader>
-          <DialogTitle>{isReassign ? 'Phân công lại lệnh cắt' : 'Phân công lệnh cắt'}</DialogTitle>
+          <DialogTitle>
+            {isReassign ? 'Phân công lại lệnh cắt' : 'Phân công lệnh cắt'}
+            <span className="ml-2 font-mono text-sm text-muted-foreground">{shortId(wo.id)}</span>
+          </DialogTitle>
         </DialogHeader>
 
         <div className="space-y-4 py-1">
-          {/* WO summary */}
+          {/* WO summary — highlights the target so bulk-dispatch can't mis-assign */}
           <div className="rounded-lg border bg-muted/30 px-4 py-3 text-sm space-y-1">
             <p><span className="text-muted-foreground">Mã lệnh:</span> <span className="font-mono font-medium">{shortId(wo.id)}</span></p>
-            <p><span className="text-muted-foreground">SKU:</span> <span className="font-medium">{wo.sku_code ?? '—'}</span></p>
+            <p><span className="text-muted-foreground">SKU:</span> <span className="font-medium">{wo.sku_code ?? '—'}</span>{wo.sku_name ? <span className="text-muted-foreground"> · {wo.sku_name}</span> : null}</p>
+            <p>
+              <span className="text-muted-foreground">Số lượng:</span>{' '}
+              <span className="font-medium">{wo.quantity.toLocaleString('vi-VN')}</span>
+              {wo.sku_dimensions && (
+                <>
+                  <span className="mx-1 text-muted-foreground">·</span>
+                  <span className="text-muted-foreground">KT:</span>{' '}
+                  <span className="font-medium">
+                    {wo.sku_dimensions.length_mm} × {wo.sku_dimensions.width_mm} mm
+                  </span>
+                </>
+              )}
+            </p>
             {isReassign && currentWorker && (
               <p>
                 <span className="text-muted-foreground">Đang phân công:</span>{' '}
@@ -234,7 +250,11 @@ function AssignDialog({ wo, onClose }: AssignDialogProps) {
             Hủy
           </Button>
           <Button onClick={handleAssign} disabled={assigning || !userId}>
-            {assigning ? 'Đang phân công…' : isReassign ? 'Phân công lại' : 'Phân công'}
+            {assigning
+              ? 'Đang phân công…'
+              : isReassign
+                ? `Phân công lại ${shortId(wo.id)}`
+                : `Phân công ${shortId(wo.id)}`}
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## Summary
- Embed short WO id directly in the assign dialog title and primary CTA label so the operator always sees which lệnh cắt they are dispatching.
- Expand the summary panel with `Số lượng` and cut dimensions (`KT: L × W mm`) from `sku_dimensions`.
- Show SKU name next to the SKU code when the backend supplies it.

Closes #186

## Technical notes
- FE-only change in `src/app/(dashboard)/cutting-dispatch/page.tsx`.
- `wo.quantity`, `wo.sku_dimensions`, and `wo.sku_name` are already part of the `WorkOrder` DTO (`src/types/api.ts`).
- No new query keys, no new endpoints, no mutation semantics changed.

## Test plan
- [ ] `npx tsc --noEmit` — 0 errors
- [ ] `npm run build` — succeeds
- [ ] Open `/cutting-dispatch`, click `Phân công` on an unassigned PLANNED WO → header shows `Phân công lệnh cắt <SHORTID>`, summary shows Số lượng + KT, CTA reads `Phân công <SHORTID>`.
- [ ] On an already-assigned WO → header and CTA switch to `Phân công lại <SHORTID>`; current worker line still rendered.
- [ ] Tested at 1280 px — layout holds within the `max-w-sm` dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)