### PR TITLE
fix: update BACKEND_URL to use Docker container name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 #       process.env.BACKEND_URL at runtime. NEXT_PUBLIC_API_URL can then be
 #       set to the relative path '/api/proxy' — environment-agnostic, no
 #       build ARG needed, one image works across all environments.
-ARG BACKEND_URL=http://10.8.0.1:8080
+ARG BACKEND_URL=http://vwms-be-app-1:8080
 ENV BACKEND_URL=$BACKEND_URL
 ARG NEXT_PUBLIC_API_URL=/api/proxy
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL


### PR DESCRIPTION
## Problem

Frontend API calls timeout (10s) khi gọi qua Next.js rewrite:
- Browser → `https://vwms.529studio.site/api/auth/login`
- Next.js rewrite → `http://10.8.0.1:8080/api/auth/login` (WireGuard IP)
- **Timeout** vì frontend container không có WireGuard, không thể access `10.8.0.1`

## Root Cause

Dockerfile build với `BACKEND_URL=http://10.8.0.1:8080`:
- Next.js rewrite được "đóng băng" vào `.next/routes-manifest.json` lúc build time
- Runtime `.env` không có tác dụng vì rewrite đã hard-coded
- Frontend container không thể route tới WireGuard interface

## Solution

Đổi Dockerfile build ARG:
```diff
- ARG BACKEND_URL=http://10.8.0.1:8080
+ ARG BACKEND_URL=http://vwms-be-app-1:8080
```

**Why this works:**
- Frontend và backend cùng Docker network `vwms_net`
- Docker DNS resolution: `vwms-be-app-1` → `172.21.0.4`
- Container-to-container communication hoạt động bình thường

## Testing

**Before (timeout):**
```bash
curl https://vwms.529studio.site/api/auth/login -X POST \
  -H 'Content-Type: application/json' \
  -d '{"username":"admin","password":"admin123"}' \
  --max-time 10
# → curl: (28) Operation timed out after 10006 milliseconds
```

**After (expected - sau khi merge PR này):**
```bash
curl https://vwms.529studio.site/api/auth/login -X POST \
  -H 'Content-Type: application/json' \
  -d '{"username":"admin","password":"admin123"}'
# → {"token":"Bearer ...","role":"admin","expires_at":"..."}
```

## Impact

- ✅ Fix API timeout issue
- ✅ Không cần sửa source code TypeScript/React
- ✅ Tất cả Next.js rewrites (`/api/auth/*`, `/api/proxy/*`) hoạt động
- ✅ Frontend accessible qua domain mới `vwms.529studio.site`

## Checklist

- [x] Dockerfile updated
- [x] Commit message descriptive
- [ ] CI/CD build pass
- [ ] Deploy to staging
- [ ] Verify API calls work

🤖 Generated with [Claude Code](https://claude.com/claude-code)