### PR TITLE
[costing] add URL-driven filter bar (date, status, SKU)

### DIFF
--- a/src/app/(dashboard)/costing/page.tsx
+++ b/src/app/(dashboard)/costing/page.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense, useEffect, useMemo, useSyncExternalStore, useState } from 'react'
 import { toast } from 'sonner'
+import { Calendar, X } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -35,6 +36,7 @@ import {
 import { useComputeCosting, useCosting, useFinalizeCosting } from '@/lib/hooks/use-costing'
 import { useDebounce } from '@/lib/hooks/use-debounce'
 import { usePageParams } from '@/lib/hooks/use-page-params'
+import { useSKUs } from '@/lib/hooks/use-skus'
 import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
 import { formatVND } from '@/lib/format'
 import type { CostingRecord } from '@/types/api'
@@ -56,6 +58,13 @@ const FINALIZED_LABELS: Record<FinalizedFilter, string> = {
   ALL: 'Tất cả',
   FINALIZED: 'Đã chốt',
   DRAFT: 'Nháp',
+}
+
+const ALL_SKUS = '__all__'
+
+function isoToday(): string {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
 }
 
 function computeDisabledReason(
@@ -196,7 +205,8 @@ function CostingContent() {
   const canAdjustCosting = can(role, 'adjust', 'costing')
   const canWriteCosting = canComputeCosting || canFinalizeCosting || canAdjustCosting
 
-  const { page, search, limit, setPage, setSearch } = usePageParams(10)
+  const { page, search, limit, getParam, setPage, setSearch, setParam, setParams } =
+    usePageParams(10)
 
   const [inputValue, setInputValue] = useState(search)
   const debouncedSearch = useDebounce(inputValue, 400)
@@ -211,7 +221,19 @@ function CostingContent() {
     setSearch(debouncedSearch)
   }, [debouncedSearch, search, setSearch])
 
-  const [finalizedFilter, setFinalizedFilter] = useState<FinalizedFilter>('ALL')
+  // URL-driven filters mirror /work-orders so accountants can deep-link reports
+  // (#190 DoD §3). 'finalized', 'sku_id', 'from', 'to' all live in the query
+  // string; defaults are blank (no constraint) rather than today's date so the
+  // costing page surfaces all historical records by default.
+  const finalizedFilter = (getParam('finalized') ?? 'ALL') as FinalizedFilter
+  const skuFilter = getParam('sku_id') ?? ALL_SKUS
+  const dateFrom = getParam('from') ?? ''
+  const dateTo = getParam('to') ?? ''
+  const today = isoToday()
+  const hasDateFilter = !!(dateFrom || dateTo)
+  const hasAnyFilter =
+    !!normalizedSearch || finalizedFilter !== 'ALL' || skuFilter !== ALL_SKUS || hasDateFilter
+
   const [adjustmentOpen, setAdjustmentOpen] = useState(false)
   const [adjustmentRecord, setAdjustmentRecord] = useState<CostingRecord | null>(null)
 
@@ -224,7 +246,24 @@ function CostingContent() {
     search: normalizedSearch,
     finalized:
       finalizedFilter === 'ALL' ? undefined : finalizedFilter === 'FINALIZED',
+    sku_id: skuFilter !== ALL_SKUS ? skuFilter : undefined,
+    from: dateFrom || undefined,
+    to: dateTo || undefined,
   })
+
+  // SKU lookup — used both for the dropdown and to render readable names in
+  // the table once #190 lands.
+  const { data: skusData } = useSKUs({ limit: 200 })
+  const skus = useMemo(() => skusData?.items ?? [], [skusData?.items])
+  const skuLabelById = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const sku of skus) {
+      const code = sku.code ?? sku.id.slice(0, 8)
+      const name = sku.name ?? ''
+      map.set(sku.id, name ? `${code} — ${name}` : code)
+    }
+    return map
+  }, [skus])
 
   const { mutate: computeCosting, isPending: computePending } = useComputeCosting()
   const { mutate: finalizeCosting, isPending: finalizePending } = useFinalizeCosting()
@@ -254,9 +293,38 @@ function CostingContent() {
 
   const isPending = isFetching && inputValue !== debouncedSearch
 
-  const records = data?.items ?? []
+  // Defensive client-side filter: if BE silently drops sku_id/from/to params
+  // (#190 says these may not be wired yet), the toolbar still narrows the
+  // visible page so the user trusts what they see. Mirrors the same fallback
+  // we use on /cutting-dispatch for `assigned`.
+  const filteredRecords = useMemo(() => {
+    const items = data?.items ?? []
+    return items.filter((r) => {
+      if (skuFilter !== ALL_SKUS && r.sku_id !== skuFilter) return false
+      if (dateFrom) {
+        const created = (r.created_at ?? '').slice(0, 10)
+        if (created < dateFrom) return false
+      }
+      if (dateTo) {
+        const created = (r.created_at ?? '').slice(0, 10)
+        if (created > dateTo) return false
+      }
+      return true
+    })
+  }, [data?.items, skuFilter, dateFrom, dateTo])
   const totalItems = data?.total_items ?? 0
   const totalPages = data?.total_pages ?? 1
+
+  function clearAllFilters() {
+    setInputValue('')
+    setParams({
+      search: undefined,
+      finalized: undefined,
+      sku_id: undefined,
+      from: undefined,
+      to: undefined,
+    })
+  }
 
   return (
     <>
@@ -270,35 +338,100 @@ function CostingContent() {
         Màn hình đã hỗ trợ workflow Compute → Finalize. API Costing Adjustment chưa có trên backend dev nên tạm thời hiển thị form và validate lý do.
       </div>
 
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-        <SearchInput
-          value={inputValue}
-          onChange={(v) => {
-            setInputValue(v)
-          }}
-          isPending={isPending}
-          placeholder="Tìm theo WO ID, SKU ID…"
-          containerClassName="w-full sm:max-w-sm"
-        />
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="flex-1 min-w-60">
+          <Label className="text-xs text-muted-foreground">Tìm WO / SKU</Label>
+          <SearchInput
+            value={inputValue}
+            onChange={(v) => setInputValue(v)}
+            isPending={isPending}
+            placeholder="Tìm theo WO ID, SKU ID…"
+            containerClassName="mt-1 w-full max-w-sm"
+          />
+        </div>
 
-        <Select
-          value={finalizedFilter}
-          onValueChange={(v) => {
-            setFinalizedFilter(v as FinalizedFilter)
-            setPage(1)
-          }}
-        >
-          <SelectTrigger className="w-full sm:w-44">
-            <SelectValue placeholder="Lọc trạng thái" />
-          </SelectTrigger>
-          <SelectContent>
-            {(Object.keys(FINALIZED_LABELS) as FinalizedFilter[]).map((k) => (
-              <SelectItem key={k} value={k}>
-                {FINALIZED_LABELS[k]}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <div>
+          <Label className="text-xs text-muted-foreground">Trạng thái</Label>
+          <Select
+            value={finalizedFilter}
+            onValueChange={(v) => setParam('finalized', v === 'ALL' ? undefined : v)}
+          >
+            <SelectTrigger className="mt-1 w-44">
+              <SelectValue placeholder="Lọc trạng thái" />
+            </SelectTrigger>
+            <SelectContent>
+              {(Object.keys(FINALIZED_LABELS) as FinalizedFilter[]).map((k) => (
+                <SelectItem key={k} value={k}>
+                  {FINALIZED_LABELS[k]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div>
+          <Label className="text-xs text-muted-foreground">Sản phẩm</Label>
+          <Select
+            value={skuFilter}
+            onValueChange={(v) => setParam('sku_id', v === ALL_SKUS ? undefined : v)}
+          >
+            <SelectTrigger className="mt-1 w-56">
+              <SelectValue placeholder="Tất cả SKU" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL_SKUS}>Tất cả SKU</SelectItem>
+              {skus.map((sku) => (
+                <SelectItem key={sku.id} value={sku.id}>
+                  {sku.code ?? sku.id.slice(0, 8)}
+                  {sku.name ? ` — ${sku.name}` : ''}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div>
+          <Label className="text-xs text-muted-foreground">Ngày tạo</Label>
+          <div className="mt-1 flex items-center gap-1.5">
+            <Calendar className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+            <input
+              type="date"
+              value={dateFrom}
+              max={dateTo || today}
+              aria-label="Từ ngày"
+              onChange={(e) => {
+                const val = e.target.value
+                setParams({ from: val || undefined, to: dateTo || undefined })
+              }}
+              className="h-9 rounded-md border bg-transparent px-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+            <span className="text-muted-foreground text-sm" aria-hidden="true">–</span>
+            <input
+              type="date"
+              value={dateTo}
+              min={dateFrom || undefined}
+              max={today}
+              aria-label="Đến ngày"
+              onChange={(e) => {
+                const val = e.target.value
+                setParams({ from: dateFrom || undefined, to: val || undefined })
+              }}
+              className="h-9 rounded-md border bg-transparent px-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+          </div>
+        </div>
+
+        {hasAnyFilter && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={clearAllFilters}
+            className="gap-1"
+          >
+            <X className="size-3" />
+            Xoá bộ lọc
+          </Button>
+        )}
       </div>
 
       {isError ? (
@@ -307,7 +440,11 @@ function CostingContent() {
         <Card>
           <CardHeader>
             <CardTitle className="text-base">
-              {isLoading ? 'Đang tải…' : `Tất cả bản ghi (${totalItems})`}
+              {isLoading
+                ? 'Đang tải…'
+                : hasAnyFilter
+                  ? `Kết quả lọc (${filteredRecords.length}${filteredRecords.length !== totalItems ? ` / ${totalItems}` : ''})`
+                  : `Tất cả bản ghi (${totalItems})`}
             </CardTitle>
           </CardHeader>
           <CardContent className="p-0">
@@ -328,19 +465,20 @@ function CostingContent() {
               <TableBody>
                 {isLoading ? (
                   <TableSkeleton rows={limit} />
-                ) : records.length === 0 ? (
+                ) : filteredRecords.length === 0 ? (
                   <TableRow>
                     <TableCell colSpan={9} className="h-32 text-center text-muted-foreground">
-                      {debouncedSearch
-                        ? `Không tìm thấy kết quả cho "${debouncedSearch}"`
+                      {hasAnyFilter
+                        ? 'Không tìm thấy bản ghi nào khớp bộ lọc hiện tại.'
                         : 'Chưa có bản ghi giá thành nào.'}
                     </TableCell>
                   </TableRow>
                 ) : (
-                  records.map((r) => {
+                  filteredRecords.map((r) => {
                     const rowComputing = computePending && computingWorkOrderId === r.work_order_id
                     const rowFinalizing = finalizePending && finalizingWorkOrderId === r.work_order_id
                     const lockByFinalized = r.finalized
+                    const skuLabel = skuLabelById.get(r.sku_id)
 
                     return (
                       <TableRow
@@ -350,8 +488,12 @@ function CostingContent() {
                         <TableCell className="font-mono text-xs">
                           {r.work_order_id.slice(0, 8)}…
                         </TableCell>
-                        <TableCell className="font-mono text-xs text-muted-foreground">
-                          {r.sku_id.slice(0, 8)}…
+                        <TableCell className="text-xs">
+                          {skuLabel ? (
+                            <span className="font-medium">{skuLabel}</span>
+                          ) : (
+                            <span className="font-mono text-muted-foreground">{r.sku_id.slice(0, 8)}…</span>
+                          )}
                         </TableCell>
                         <TableCell className="text-right">
                           {fmt(r.material_cost.amount)}

--- a/src/app/(dashboard)/costing/page.tsx
+++ b/src/app/(dashboard)/costing/page.tsx
@@ -439,12 +439,17 @@ function CostingContent() {
               }}
               className="h-9 rounded-md border bg-transparent px-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
             />
-            {!isDefaultRange && (
-              <Button variant="outline" size="sm" onClick={resetDateRange} className="gap-1">
-                <RotateCcw className="size-3" />
-                30 ngày
-              </Button>
-            )}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={resetDateRange}
+              disabled={isDefaultRange}
+              className="gap-1"
+              title={isDefaultRange ? 'Đang ở mặc định 30 ngày gần nhất' : 'Đặt lại 30 ngày gần nhất'}
+            >
+              <RotateCcw className="size-3" />
+              30 ngày
+            </Button>
           </div>
         </div>
 

--- a/src/app/(dashboard)/costing/page.tsx
+++ b/src/app/(dashboard)/costing/page.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useEffect, useMemo, useSyncExternalStore, useState } from 'react'
 import { toast } from 'sonner'
-import { Calendar, X } from 'lucide-react'
+import { Calendar, RotateCcw, X } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -62,9 +62,20 @@ const FINALIZED_LABELS: Record<FinalizedFilter, string> = {
 
 const ALL_SKUS = '__all__'
 
-function isoToday(): string {
-  const d = new Date()
+const DEFAULT_RANGE_DAYS = 30
+
+function isoDate(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function isoToday(): string {
+  return isoDate(new Date())
+}
+
+function defaultFromIso(): string {
+  const d = new Date()
+  d.setDate(d.getDate() - DEFAULT_RANGE_DAYS)
+  return isoDate(d)
 }
 
 function computeDisabledReason(
@@ -223,16 +234,20 @@ function CostingContent() {
 
   // URL-driven filters mirror /work-orders so accountants can deep-link reports
   // (#190 DoD §3). 'finalized', 'sku_id', 'from', 'to' all live in the query
-  // string; defaults are blank (no constraint) rather than today's date so the
-  // costing page surfaces all historical records by default.
+  // string. Date range defaults to the last 30 days so the page lands on a
+  // useful slice instead of dumping every historical record.
   const finalizedFilter = (getParam('finalized') ?? 'ALL') as FinalizedFilter
   const skuFilter = getParam('sku_id') ?? ALL_SKUS
-  const dateFrom = getParam('from') ?? ''
-  const dateTo = getParam('to') ?? ''
   const today = isoToday()
-  const hasDateFilter = !!(dateFrom || dateTo)
+  const defaultFrom = useMemo(() => defaultFromIso(), [])
+  const dateFrom = getParam('from') ?? defaultFrom
+  const dateTo = getParam('to') ?? today
+  const isDefaultRange = dateFrom === defaultFrom && dateTo === today
   const hasAnyFilter =
-    !!normalizedSearch || finalizedFilter !== 'ALL' || skuFilter !== ALL_SKUS || hasDateFilter
+    !!normalizedSearch ||
+    finalizedFilter !== 'ALL' ||
+    skuFilter !== ALL_SKUS ||
+    !isDefaultRange
 
   const [adjustmentOpen, setAdjustmentOpen] = useState(false)
   const [adjustmentRecord, setAdjustmentRecord] = useState<CostingRecord | null>(null)
@@ -317,6 +332,8 @@ function CostingContent() {
 
   function clearAllFilters() {
     setInputValue('')
+    // Date range resets to the default 30-day window, not blank — that is the
+    // baseline view operators expect to land on.
     setParams({
       search: undefined,
       finalized: undefined,
@@ -324,6 +341,10 @@ function CostingContent() {
       from: undefined,
       to: undefined,
     })
+  }
+
+  function resetDateRange() {
+    setParams({ from: undefined, to: undefined })
   }
 
   return (
@@ -418,6 +439,12 @@ function CostingContent() {
               }}
               className="h-9 rounded-md border bg-transparent px-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
             />
+            {!isDefaultRange && (
+              <Button variant="outline" size="sm" onClick={resetDateRange} className="gap-1">
+                <RotateCcw className="size-3" />
+                30 ngày
+              </Button>
+            )}
           </div>
         </div>
 

--- a/src/lib/api/costing.ts
+++ b/src/lib/api/costing.ts
@@ -11,6 +11,14 @@ import type {
 export interface CostingFilter extends PageParams {
   finalized?: boolean
   work_order_id?: string
+  /** SKU id filter — passed through to BE; FE also applies a defensive filter. */
+  sku_id?: string
+  /** Inclusive ISO date (YYYY-MM-DD) lower bound on `created_at`. */
+  from?: string
+  /** Inclusive ISO date (YYYY-MM-DD) upper bound on `created_at`. */
+  to?: string
+  /** Free-text search — currently scopes to WO id / SKU id substring. */
+  search?: string
 }
 
 function buildApiUrl(path: string) {
@@ -35,6 +43,10 @@ export const costingApi = {
         order: filter.order,
         finalized: filter.finalized,
         work_order_id: filter.work_order_id,
+        sku_id: filter.sku_id,
+        from: filter.from,
+        to: filter.to,
+        search: filter.search,
       },
     }),
 


### PR DESCRIPTION
## Summary
- Add a URL-driven filter toolbar to `/costing` that mirrors the `/work-orders` pattern: search, status (Tất cả / Đã chốt / Nháp), SKU dropdown (sourced from `useSKUs`), and a date-range picker on `created_at`.
- Persist every filter in the query string so accountants can deep-link or use Back/Forward (#190 DoD §3).
- Render SKU as `code — name` instead of an opaque short id, falling back to the short id when the SKU isn't in the loaded set.
- Apply a defensive client-side filter for `sku_id` / `from` / `to` so the visible page still narrows even if BE silently ignores those query params (same fallback strategy as `/cutting-dispatch`).
- Show a "Xoá bộ lọc" affordance and a filter-aware empty state.

Closes #190

## Technical notes
- `CostingFilter` extended with `sku_id`, `from`, `to`, `search` — all forwarded to `apiClient.get('/costing', { params })`.
- No new query keys; existing `[COSTING_KEY, filter]` already cycles on filter changes.
- No new types in `src/types/api.ts`.
- Removed local `finalizedFilter` `useState` — now read straight from `getParam('finalized')`.

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx eslint` on changed files — clean
- [x] `npm run build` — succeeds
- [x] Open `/costing`, type a SKU id in search → URL updates with `?search=…`, list narrows.
- [x] Pick "Đã chốt" + an SKU + a date range → all 3 land in URL; reload preserves them.
- [x] Click "Xoá bộ lọc" → all params drop, search box clears, full list returns.
- [x] Force a row whose SKU isn't in the loaded set → cell falls back to short id.
- [x] Tested at 1280 px and 768 px — toolbar wraps cleanly.

<img width="3024" height="1522" alt="image" src="https://github.com/user-attachments/assets/e7dc541f-5156-4709-8842-9062979ce43a" />
