### PR TITLE
[kiosk] send is_waste=true on full waste cuts (BR-K02)

### DIFF
--- a/src/components/kiosk/report-cut-form.tsx
+++ b/src/components/kiosk/report-cut-form.tsx
@@ -488,12 +488,17 @@ export function ReportCutForm() {
           length_mm: parseFloat(data.usedLength),
           width_mm: parseFloat(data.usedWidth),
         },
-        remnant_dimension: hasRemnant && data.remnantLength && data.remnantWidth
+        // BR-K02 (BE #247): send remnant_dimension XOR is_waste=true. Picking
+        // "Hao hụt toàn bộ" → omit remnant_dimension and flip the flag so BE
+        // can distinguish an intentional waste cut from a malformed payload.
+        ...(hasRemnant && data.remnantLength && data.remnantWidth
           ? {
-              length_mm: parseFloat(data.remnantLength),
-              width_mm: parseFloat(data.remnantWidth),
+              remnant_dimension: {
+                length_mm: parseFloat(data.remnantLength),
+                width_mm: parseFloat(data.remnantWidth),
+              },
             }
-          : undefined,
+          : { is_waste: true }),
       },
       {
         onSuccess: (res) => {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -355,6 +355,13 @@ export interface RecordCutInput {
   used_dimension: { length_mm: number; width_mm: number }
   /** Omit entirely when the cut produces no remnant (waste). */
   remnant_dimension?: { length_mm: number; width_mm: number }
+  /**
+   * BR-K02 (BE #247 / #263): exactly one of `remnant_dimension` or
+   * `is_waste: true` must be present. Send `is_waste: true` when the worker
+   * picks "Hao hụt toàn bộ" so BE knows the cut intentionally produced no
+   * remnant — without this the request is rejected with 400.
+   */
+  is_waste?: boolean
   /** Optional usable-area override (e.g. chipped corner). Both or neither. */
   bounding_box_length_mm?: number
   bounding_box_width_mm?: number


### PR DESCRIPTION
## Summary
BE issue #247 (PR #263) tightens BR-K02: \`POST /api/v1/inventory/cuts\` now requires exactly one of \`remnant_dimension\` or \`is_waste: true\`. Without the flag, the kiosk "Hao hụt toàn bộ" path fails with 400 once BE merges.

- Add \`is_waste?: boolean\` to \`RecordCutInput\` (mirrors backend Go struct).
- When \`hasRemnant === false\`, emit \`{ is_waste: true }\` and omit \`remnant_dimension\` from the payload.
- Keep the happy path (\`remnant_dimension\` set when worker enters dimensions) unchanged.

Closes #208

## Technical notes
- FE-only. No new query keys, no UI change.
- Type lives in \`src/types/api.ts\` next to existing \`RecordCutInput\`.
- Used spread + ternary so the JSON payload contains exactly one of the two fields, matching the BE XOR validator.

## Test plan
- [x] \`npx tsc --noEmit\` — 0 errors
- [x] \`npm run build\` — succeeds
- [ ] On kiosk, pick "Hao hụt toàn bộ" → submit → verify network payload contains \`is_waste: true\` and no \`remnant_dimension\`.
- [ ] Pick "Còn tấm lẻ" + enter dimensions → verify payload contains \`remnant_dimension\` and no \`is_waste\`.
- [ ] BE returns 400 if both/none present → existing error path shows the Vietnamese message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)