### PR TITLE
[infra] proxy via route handlers for runtime BACKEND_URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,34 +11,12 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# WHY build ARGs instead of runtime ENV:
-#
-# 1. BACKEND_URL — used by next.config.ts rewrites()
-#    next.config.ts is evaluated once during `next build` and the result is
-#    frozen into .next/routes-manifest.json. `next start` reads that static
-#    manifest and never re-evaluates next.config.ts, so any runtime env var
-#    arrives too late and is silently ignored.
-#
-# 2. NEXT_PUBLIC_API_URL — used by src/lib/api/client.ts (browser-side)
-#    Any variable with the NEXT_PUBLIC_ prefix is inlined into the JS bundle
-#    at build time so the browser can access it. Runtime env vars have no
-#    effect because the bundle is already compiled.
-#
-# Both variables default to localhost:8080 when absent. On the CI runner the
-# .env file does not exist (gitignored), so without build ARGs:
-#   - BACKEND_URL   → rewrites proxy to localhost:8080 → ECONNREFUSED → 500
-#   - NEXT_PUBLIC_API_URL → browser calls localhost:8080 directly → CORS block
-#
-# TODO: Replace next.config.ts rewrites() with catch-all Route Handlers
-#       (src/app/api/proxy/[...path]/route.ts + src/app/api/auth/[...path]/route.ts).
-#       Route Handlers run per-request on the Node.js server so they read
-#       process.env.BACKEND_URL at runtime. NEXT_PUBLIC_API_URL can then be
-#       set to the relative path '/api/proxy' — environment-agnostic, no
-#       build ARG needed, one image works across all environments.
-ARG BACKEND_URL=http://vwms-be-app-1:8080
-ENV BACKEND_URL=$BACKEND_URL
-ARG NEXT_PUBLIC_API_URL=/api/proxy
-ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+# NEXT_PUBLIC_API_URL is the only build-time variable. Anything with the
+# NEXT_PUBLIC_ prefix is inlined into the JS bundle, so it must be known at
+# build time. We hardcode the relative path '/api/proxy' — the browser hits
+# the Next.js server, which then forwards via Route Handlers (see
+# src/app/api/proxy/[...path]/route.ts) to BACKEND_URL at runtime.
+ENV NEXT_PUBLIC_API_URL=/api/proxy
 RUN npm run build
 
 # ── Stage 3: runner ──────────────────────────────────────────────────────────
@@ -46,6 +24,10 @@ FROM node:20-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
+
+# BACKEND_URL is read by the catch-all Route Handlers at request time, so a
+# single image works across dev/staging/prod — just override this at deploy.
+ENV BACKEND_URL=http://vwms-be-app-1:8080
 
 # Create non-root user for security
 RUN addgroup --system --gid 1001 nodejs && \

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,6 @@
 import type { NextConfig } from 'next'
 import path from 'node:path'
 
-const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8080'
-
 const nextConfig: NextConfig = {
   // Enable standalone output for Docker optimization
   output: 'standalone',
@@ -47,26 +45,6 @@ const nextConfig: NextConfig = {
             value: 'same-origin',
           },
         ],
-      },
-    ]
-  },
-
-  /**
-   * Proxy /api/proxy/* → backend to avoid browser CORS restrictions.
-   * The browser only talks to localhost:3000; Next.js server forwards the
-   * request server-side where CORS does not apply.
-   */
-  async rewrites() {
-    return [
-      // Auth endpoints live at /api/auth/* on the backend.
-      {
-        source: '/api/auth/:path*',
-        destination: `${BACKEND_URL}/api/auth/:path*`,
-      },
-      // All other API calls go through /api/v1.
-      {
-        source: '/api/proxy/:path*',
-        destination: `${BACKEND_URL}/api/v1/:path*`,
       },
     ]
   },

--- a/src/app/api/auth/[...path]/route.ts
+++ b/src/app/api/auth/[...path]/route.ts
@@ -1,0 +1,17 @@
+import type { NextRequest } from 'next/server'
+import { proxyToBackend } from '@/lib/api/proxy'
+
+// Auth lives at /api/auth/* on the backend (no /api/v1 prefix).
+const PREFIX = '/api/auth'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+type Ctx = { params: Promise<{ path: string[] }> }
+
+async function handle(request: NextRequest, ctx: Ctx) {
+  const { path } = await ctx.params
+  return proxyToBackend(request, path, PREFIX)
+}
+
+export { handle as GET, handle as POST }

--- a/src/app/api/proxy/[...path]/route.ts
+++ b/src/app/api/proxy/[...path]/route.ts
@@ -1,0 +1,19 @@
+import type { NextRequest } from 'next/server'
+import { proxyToBackend } from '@/lib/api/proxy'
+
+// Forward to /api/v1 — keeps client.ts paths unchanged (e.g. /work-orders).
+const PREFIX = '/api/v1'
+
+// Disable caching: every request is forwarded live to the backend.
+export const dynamic = 'force-dynamic'
+// Node.js runtime — Edge cannot stream a request body to fetch().
+export const runtime = 'nodejs'
+
+type Ctx = { params: Promise<{ path: string[] }> }
+
+async function handle(request: NextRequest, ctx: Ctx) {
+  const { path } = await ctx.params
+  return proxyToBackend(request, path, PREFIX)
+}
+
+export { handle as GET, handle as POST, handle as PUT, handle as PATCH, handle as DELETE }

--- a/src/lib/api/proxy.ts
+++ b/src/lib/api/proxy.ts
@@ -1,0 +1,63 @@
+import type { NextRequest } from 'next/server'
+
+const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:8080'
+
+// Hop-by-hop headers must not be forwarded (RFC 7230 §6.1) plus host/content-length
+// which must be recomputed by the runtime that emits the request.
+const HOP_BY_HOP = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'host',
+  'content-length',
+])
+
+function copyHeaders(source: Headers): Headers {
+  const out = new Headers()
+  source.forEach((value, key) => {
+    if (!HOP_BY_HOP.has(key.toLowerCase())) out.set(key, value)
+  })
+  return out
+}
+
+/**
+ * Forward an incoming Next.js request to the Go backend.
+ * Reads BACKEND_URL at call-time so the same image can target any environment.
+ *
+ * @param request   Incoming request from a route handler.
+ * @param segments  Captured `[...path]` slug.
+ * @param prefix    Backend path prefix — e.g. `/api/v1` or `/api/auth`.
+ */
+export async function proxyToBackend(
+  request: NextRequest,
+  segments: string[],
+  prefix: string,
+): Promise<Response> {
+  const path = segments.join('/')
+  const url = new URL(request.url)
+  const target = `${BACKEND_URL}${prefix}/${path}${url.search}`
+
+  const init: RequestInit & { duplex?: 'half' } = {
+    method: request.method,
+    headers: copyHeaders(request.headers),
+    redirect: 'manual',
+  }
+
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    init.body = request.body
+    init.duplex = 'half'
+  }
+
+  const upstream = await fetch(target, init)
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: copyHeaders(upstream.headers),
+  })
+}


### PR DESCRIPTION
## Summary
- Replace `next.config.ts` `rewrites()` with catch-all Route Handlers at `src/app/api/{auth,proxy}/[...path]/route.ts` so `BACKEND_URL` is read **at request time**, not baked into `routes-manifest.json` at build time.
- One Docker image now works across dev/staging/prod — just override `BACKEND_URL` at deploy. `NEXT_PUBLIC_API_URL` stays inlined as the relative path `/api/proxy`.
- Drop the `ARG BACKEND_URL` from `Dockerfile` (and the long TODO note explaining why we needed it).

## Technical notes
- New shared helper `src/lib/api/proxy.ts` strips hop-by-hop headers (RFC 7230 §6.1) plus `host` / `content-length`, streams request bodies via `duplex: 'half'`, and forwards the upstream response body untouched. SSE / streaming responses pass through unchanged.
- Both handlers run on the Node.js runtime (`export const runtime = 'nodejs'`) — Edge cannot stream a request body to `fetch`. Both use `dynamic = 'force-dynamic'` to bypass Next.js fetch caching.
- `/api/auth/[...path]` forwards to `${BACKEND_URL}/api/auth/${path}` (login / refresh).
- `/api/proxy/[...path]` forwards to `${BACKEND_URL}/api/v1/${path}` — keeps every existing call site unchanged.
- No frontend code changes — `apiClient` already targets the relative `/api/proxy` base.

Closes #213

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — succeeds, both handlers appear as `ƒ` (dynamic)
- [ ] Smoke: `BACKEND_URL=http://localhost:8080 npm run dev`, login + load `/overview` + load `/plans`
- [ ] Re-run prod image with `-e BACKEND_URL=http://staging:8080` and verify same image hits staging without rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)