### PR TITLE
[costing] wire adjustment dialog to live API

### DIFF
--- a/src/app/(dashboard)/costing/page.tsx
+++ b/src/app/(dashboard)/costing/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { Suspense, useEffect, useMemo, useSyncExternalStore, useState } from 'react'
-import { toast } from 'sonner'
 import { Calendar, RotateCcw, X } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -33,13 +32,13 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { useComputeCosting, useCosting, useFinalizeCosting } from '@/lib/hooks/use-costing'
+import { useComputeCosting, useCosting, useCostingDetail, useCreateCostingAdjustment, useFinalizeCosting } from '@/lib/hooks/use-costing'
 import { useDebounce } from '@/lib/hooks/use-debounce'
 import { usePageParams } from '@/lib/hooks/use-page-params'
 import { useSKUs } from '@/lib/hooks/use-skus'
 import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
 import { formatVND } from '@/lib/format'
-import type { CostingRecord } from '@/types/api'
+import type { CostingAdjustment, CostingRecord, Money } from '@/types/api'
 
 const fmt = formatVND
 
@@ -144,68 +143,209 @@ function AdjustmentDialog({
   record: CostingRecord | null
   onClose: () => void
 }) {
+  const workOrderId = record?.work_order_id ?? null
+  const { data: detail, isLoading: detailLoading } = useCostingDetail(open ? workOrderId : null)
+  const { mutate: createAdjustment, isPending: submitting } = useCreateCostingAdjustment()
+
+  // The 3 delta inputs are signed strings so the user can type "-50000" to
+  // reverse a charge. Empty string => 0 delta.
   const [reason, setReason] = useState('')
+  const [deltaMaterial, setDeltaMaterial] = useState('')
+  const [deltaAuxiliary, setDeltaAuxiliary] = useState('')
+  const [deltaLabor, setDeltaLabor] = useState('')
 
   useEffect(() => {
     if (!open) {
-      queueMicrotask(() => setReason(''))
+      // queueMicrotask so the dialog close animation reads the old values.
+      queueMicrotask(() => {
+        setReason('')
+        setDeltaMaterial('')
+        setDeltaAuxiliary('')
+        setDeltaLabor('')
+      })
     }
   }, [open])
 
+  const parsedMaterial = Number(deltaMaterial) || 0
+  const parsedAuxiliary = Number(deltaAuxiliary) || 0
+  const parsedLabor = Number(deltaLabor) || 0
+  const previewDeltaTotal = parsedMaterial + parsedAuxiliary + parsedLabor
+  const allZero = parsedMaterial === 0 && parsedAuxiliary === 0 && parsedLabor === 0
+
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
-    if (!reason.trim()) return
+    if (!record || !reason.trim() || allZero || submitting) return
 
-    toast.error('Backend chưa hỗ trợ API Costing Adjustment trên môi trường hiện tại.')
+    const currency = record.total_cost.currency
+    const money = (amount: number): Money => ({ amount, currency })
+
+    createAdjustment(
+      {
+        workOrderId: record.work_order_id,
+        input: {
+          reason: reason.trim(),
+          delta_material: money(parsedMaterial),
+          delta_auxiliary: money(parsedAuxiliary),
+          delta_labor: money(parsedLabor),
+        },
+      },
+      { onSuccess: () => onClose() },
+    )
   }
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-lg">
         <DialogHeader>
           <DialogTitle>Tạo điều chỉnh giá thành</DialogTitle>
         </DialogHeader>
 
         {!record ? null : (
           <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-1 rounded-lg border bg-muted/30 p-3 text-sm">
-              <p>
-                <span className="text-muted-foreground">WO:</span>{' '}
+            {/* Effective totals panel — read from /detail so FE never does
+                money arithmetic. Falls back to record.total_cost while loading. */}
+            <div className="space-y-1.5 rounded-lg border bg-muted/30 p-3 text-sm">
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">WO</span>
                 <span className="font-mono">{record.work_order_id.slice(0, 8).toUpperCase()}</span>
-              </p>
-              <p>
-                <span className="text-muted-foreground">Tổng hiện tại:</span>{' '}
-                <span className="font-semibold">{fmt(record.total_cost.amount)}</span>
-              </p>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Tổng gốc</span>
+                <span>{fmt(record.total_cost.amount)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Tổng hiệu lực hiện tại</span>
+                <span className="font-semibold">
+                  {detailLoading ? <Skeleton className="inline-block h-4 w-24" /> :
+                    detail ? fmt(detail.effective_total.amount) : fmt(record.total_cost.amount)}
+                </span>
+              </div>
+              {!allZero && (
+                <div className="flex items-center justify-between border-t pt-1.5">
+                  <span className="text-muted-foreground">Tổng sau điều chỉnh (xem trước)</span>
+                  <span className={`font-semibold ${previewDeltaTotal < 0 ? 'text-destructive' : 'text-emerald-600'}`}>
+                    {fmt((detail?.effective_total.amount ?? record.total_cost.amount) + previewDeltaTotal)}
+                  </span>
+                </div>
+              )}
             </div>
 
+            <div className="grid grid-cols-3 gap-3">
+              <div className="space-y-1">
+                <Label htmlFor="adj-mat" className="text-xs">Δ Vật liệu</Label>
+                <Input
+                  id="adj-mat"
+                  type="number"
+                  step="any"
+                  inputMode="numeric"
+                  value={deltaMaterial}
+                  onChange={(e) => setDeltaMaterial(e.target.value)}
+                  placeholder="0"
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="adj-aux" className="text-xs">Δ Phụ liệu</Label>
+                <Input
+                  id="adj-aux"
+                  type="number"
+                  step="any"
+                  inputMode="numeric"
+                  value={deltaAuxiliary}
+                  onChange={(e) => setDeltaAuxiliary(e.target.value)}
+                  placeholder="0"
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="adj-lab" className="text-xs">Δ Nhân công</Label>
+                <Input
+                  id="adj-lab"
+                  type="number"
+                  step="any"
+                  inputMode="numeric"
+                  value={deltaLabor}
+                  onChange={(e) => setDeltaLabor(e.target.value)}
+                  placeholder="0"
+                />
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Nhập số dương để cộng thêm, số âm (vd <span className="font-mono">-50000</span>) để giảm trừ.
+            </p>
+
             <div className="space-y-1.5">
-              <Label htmlFor="adjustment-reason">Lý do điều chỉnh</Label>
+              <Label htmlFor="adjustment-reason">Lý do điều chỉnh *</Label>
               <Input
                 id="adjustment-reason"
                 value={reason}
                 onChange={(e) => setReason(e.target.value)}
-                placeholder="Nhập lý do bắt buộc"
+                placeholder="VD: bù vật tư bị tính thiếu, miễn giảm cho khách…"
                 required
+                maxLength={500}
               />
             </div>
 
-            <p className="rounded border border-dashed px-3 py-2 text-xs text-muted-foreground">
-              Lịch sử điều chỉnh sẽ hiển thị tại đây sau khi backend cung cấp API adjustments.
-            </p>
+            <AdjustmentHistory adjustments={detail?.adjustments} loading={detailLoading} />
 
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={onClose}>
+              <Button type="button" variant="outline" onClick={onClose} disabled={submitting}>
                 Huỷ
               </Button>
-              <Button type="submit" disabled={!reason.trim()}>
-                Lưu điều chỉnh
+              <Button
+                type="submit"
+                disabled={submitting || !reason.trim() || allZero}
+                title={allZero ? 'Cần nhập ít nhất một delta khác 0' : undefined}
+              >
+                {submitting ? 'Đang lưu…' : 'Lưu điều chỉnh'}
               </Button>
             </DialogFooter>
           </form>
         )}
       </DialogContent>
     </Dialog>
+  )
+}
+
+function AdjustmentHistory({
+  adjustments,
+  loading,
+}: {
+  adjustments: CostingAdjustment[] | undefined
+  loading: boolean
+}) {
+  if (loading) {
+    return (
+      <div className="rounded border p-3">
+        <Skeleton className="mb-2 h-4 w-32" />
+        <Skeleton className="h-12 w-full" />
+      </div>
+    )
+  }
+  if (!adjustments || adjustments.length === 0) {
+    return (
+      <p className="rounded border border-dashed px-3 py-2 text-xs text-muted-foreground">
+        Chưa có điều chỉnh nào cho WO này.
+      </p>
+    )
+  }
+  return (
+    <div className="rounded border">
+      <div className="border-b bg-muted/30 px-3 py-1.5 text-xs font-medium text-muted-foreground">
+        Lịch sử điều chỉnh ({adjustments.length})
+      </div>
+      <ul className="max-h-40 divide-y overflow-auto text-sm">
+        {adjustments.map((a) => (
+          <li key={a.id} className="flex items-center justify-between gap-3 px-3 py-2">
+            <div className="min-w-0">
+              <p className="truncate">{a.reason || <span className="italic text-muted-foreground">không có lý do</span>}</p>
+              <p className="text-xs text-muted-foreground">{formatDate(a.created_at)}</p>
+            </div>
+            <span className={`shrink-0 font-mono text-sm ${a.delta_total.amount < 0 ? 'text-destructive' : 'text-emerald-600'}`}>
+              {a.delta_total.amount > 0 ? '+' : ''}{fmt(a.delta_total.amount)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
   )
 }
 
@@ -354,10 +494,6 @@ function CostingContent() {
         record={adjustmentRecord}
         onClose={() => setAdjustmentOpen(false)}
       />
-
-      <div className="rounded-lg border border-dashed px-4 py-3 text-sm text-muted-foreground">
-        Màn hình đã hỗ trợ workflow Compute → Finalize. API Costing Adjustment chưa có trên backend dev nên tạm thời hiển thị form và validate lý do.
-      </div>
 
       <div className="flex flex-wrap items-end gap-3">
         <div className="flex-1 min-w-60">

--- a/src/lib/api/costing.ts
+++ b/src/lib/api/costing.ts
@@ -1,7 +1,10 @@
 import { ApiClientError, apiClient } from '@/lib/api/client'
 import { normalizeAuthToken } from '@/lib/auth/token'
 import type {
+  CostingAdjustment,
   CostingRecord,
+  CostingRecordDetail,
+  CreateAdjustmentInput,
   PageParams,
   PagedResult,
   WasteReportFilter,
@@ -52,6 +55,22 @@ export const costingApi = {
 
   getByWorkOrder: (workOrderId: string) =>
     apiClient.get<CostingRecord>(`/costing/${workOrderId}`),
+
+  /**
+   * GET /api/v1/costing/:workOrderID/detail — record + adjustments[] +
+   * running effective totals. Used by the adjustment dialog so the FE never
+   * does money arithmetic itself.
+   */
+  getDetail: (workOrderId: string) =>
+    apiClient.get<CostingRecordDetail>(`/costing/${workOrderId}/detail`),
+
+  /** POST /api/v1/costing/:workOrderID/adjustments — BR-C04 (#178). */
+  createAdjustment: (workOrderId: string, input: CreateAdjustmentInput) =>
+    apiClient.post<CostingAdjustment>(`/costing/${workOrderId}/adjustments`, input),
+
+  /** GET /api/v1/costing/:workOrderID/adjustments — full audit list. */
+  listAdjustments: (workOrderId: string) =>
+    apiClient.get<CostingAdjustment[]>(`/costing/${workOrderId}/adjustments`),
 
   compute: (workOrderId: string) =>
     apiClient.post<CostingRecord>(`/costing/${workOrderId}/compute`),

--- a/src/lib/hooks/use-costing.ts
+++ b/src/lib/hooks/use-costing.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { costingApi, type CostingFilter } from '@/lib/api/costing'
 import { ApiClientError, mapApiErrorVi } from '@/lib/api/client'
+import type { CreateAdjustmentInput } from '@/types/api'
 
 export const COSTING_KEY = 'costing'
 
@@ -53,6 +54,41 @@ export function useFinalizeCosting() {
     },
     onError: (err) => {
       toast.error(mapApiErrorVi(err, 'Chốt giá thành thất bại'))
+    },
+  })
+}
+
+/**
+ * Bundles record + adjustments[] + running effective totals (#178). Lazy
+ * — only enabled when the dialog opens, so list rows pay no cost.
+ */
+export function useCostingDetail(workOrderId: string | null) {
+  return useQuery({
+    queryKey: [COSTING_KEY, 'detail', workOrderId],
+    queryFn: () => costingApi.getDetail(workOrderId!),
+    enabled: !!workOrderId,
+    staleTime: 15_000,
+    retry: (failureCount, err) => {
+      if (err instanceof ApiClientError && err.status === 404) return false
+      return failureCount < 2
+    },
+  })
+}
+
+export function useCreateCostingAdjustment() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ workOrderId, input }: { workOrderId: string; input: CreateAdjustmentInput }) =>
+      costingApi.createAdjustment(workOrderId, input),
+    onSuccess: (_, { workOrderId }) => {
+      // Refresh both the list (effective totals show on row) and the detail
+      // panel that the dialog reads from.
+      queryClient.invalidateQueries({ queryKey: [COSTING_KEY] })
+      queryClient.invalidateQueries({ queryKey: [COSTING_KEY, 'detail', workOrderId] })
+      toast.success('Đã ghi nhận điều chỉnh')
+    },
+    onError: (err) => {
+      toast.error(mapApiErrorVi(err, 'Tạo điều chỉnh thất bại'))
     },
   })
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -308,6 +308,48 @@ export interface CostingRecord {
 }
 
 /**
+ * One adjustment row applied to a finalized costing record (BR-C04).
+ * Mirrors backend `costing.CostingAdjustment` exactly.
+ *
+ * Adjustments never mutate the underlying record — the record numbers stay
+ * immutable; effective totals = record + Σ deltas.
+ */
+export interface CostingAdjustment {
+  id: string
+  costing_record_id: string
+  reason: string
+  delta_material: Money
+  delta_auxiliary: Money
+  delta_labor: Money
+  delta_total: Money
+  /** UUID of the user who created the adjustment (auditor field). */
+  created_by: string
+  created_at: string
+}
+
+/**
+ * GET /api/v1/costing/:workOrderID/detail — bundles the immutable record with
+ * its adjustments and the running effective totals (record + Σ deltas).
+ * Mirrors backend `costing.CostingRecordDetail`.
+ */
+export interface CostingRecordDetail {
+  record: CostingRecord
+  adjustments: CostingAdjustment[]
+  effective_material: Money
+  effective_auxiliary: Money
+  effective_labor: Money
+  effective_total: Money
+}
+
+/** POST /api/v1/costing/:workOrderID/adjustments */
+export interface CreateAdjustmentInput {
+  reason: string
+  delta_material: Money
+  delta_auxiliary: Money
+  delta_labor: Money
+}
+
+/**
  * GET /api/v1/costing/waste-report — one row per material aggregated over the
  * filter range. Mirrors backend `costing.WasteReportRow` (BR-C03 ledger).
  */


### PR DESCRIPTION
## Summary
- Adjustment dialog now actually calls `POST /api/v1/costing/:workOrderID/adjustments` instead of toasting an error. Closes #178 (P0 — the dialog was misleading users).
- Reads from `GET /costing/:workOrderID/detail` (BE PR #264) to show effective totals + adjustment history without doing money arithmetic on the FE.
- Three signed delta inputs (vật liệu / phụ liệu / nhân công) plus a required reason. Live preview of "tổng sau điều chỉnh" before submit.

Closes #178

## Technical notes
- New types mirror BE `costing.CostingAdjustment`, `CostingRecordDetail`, `CreateAdjustmentInput` exactly. No money arithmetic on FE — `effective_total` comes pre-folded from BE.
- `useCostingDetail(workOrderId)` is enabled only when the dialog opens, so list rows pay no detail-endpoint cost. 404 disables retry to keep the dialog usable for WOs without a costing record yet (the parent already gates the button on `record` existence).
- `useCreateCostingAdjustment` invalidates both `[COSTING_KEY]` and `[COSTING_KEY, 'detail', workOrderId]` on success — list rows + the open dialog refresh atomically.
- Reused the existing `canAdjustCosting` (from `can(role, 'adjust', 'costing')`) and `adjustDisabledReason` — only `accountant` and `admin` see the action button, so the role gate stays where it already lived (no duplication inside the dialog).
- Removed the old "Backend chưa hỗ trợ…" banner above the filter bar — it's no longer accurate.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — `/costing` ○ static
- [ ] Manual: open dialog on a finalized record → effective totals load, history list shows existing adjustments
- [ ] Manual: enter `delta_material = 50000`, reason → submit → toast success, history grows by one row, effective_total updates by 50000
- [ ] Manual: enter `delta_labor = -25000` → preview turns red, after submit the row's effective total drops by 25000
- [ ] Manual: empty reason or all-zero deltas → submit button disabled with tooltip
- [ ] Manual: log in as planner → action button disabled (existing `canAdjust` gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)