### PR TITLE
[realtime] wire SSE stream + invalidate React Query on event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vmarble-warehouse-client",
       "version": "0.1.0",
       "dependencies": {
+        "@microsoft/fetch-event-source": "^2.0.1",
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-select": "^2.1.4",
@@ -1832,6 +1833,12 @@
         "@types/react": ">=16",
         "react": ">=16"
       }
+    },
+    "node_modules/@microsoft/fetch-event-source": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+      "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:unit:watch": "vitest --project unit"
   },
   "dependencies": {
+    "@microsoft/fetch-event-source": "^2.0.1",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-select": "^2.1.4",

--- a/src/lib/hooks/use-cutting-orders.ts
+++ b/src/lib/hooks/use-cutting-orders.ts
@@ -12,16 +12,17 @@ export function useCuttingOrders(filter: WorkOrdersFilter = {}) {
 }
 
 /**
- * Kiosk-specific hook: fetches only IN_CUTTING work orders and
- * auto-refreshes every 30 seconds without causing UI flicker
- * (placeholderData keeps the old list visible during background refetch).
+ * Kiosk-specific hook: fetches only IN_CUTTING work orders. SSE is the
+ * primary push channel (#194) — the 120 s `refetchInterval` is a safety net
+ * for the case where the EventSource drops (sleeping laptop, proxy timeout).
+ * `placeholderData` keeps the old list visible during background refetch.
  * Returns the items array directly so the page can call .map() safely.
  */
 export function useCuttingOrdersForKiosk() {
   const query = useQuery({
     queryKey: [WORK_ORDERS_KEY, { status: 'IN_CUTTING' }],
     queryFn: () => cuttingOrdersApi.list({ status: 'IN_CUTTING' }),
-    refetchInterval: 30_000,
+    refetchInterval: 120_000,
     placeholderData: (prev) => prev,
   })
   return {

--- a/src/lib/hooks/use-dashboard.ts
+++ b/src/lib/hooks/use-dashboard.ts
@@ -4,12 +4,18 @@ import { dashboardApi } from '@/lib/api/dashboard'
 export const DASHBOARD_KEY = 'dashboard-overview'
 export const WIP_PIPELINE_KEY = 'dashboard-wip-pipeline'
 
+// SSE (#194) is the primary push channel. The 120 s polling interval is a
+// fallback for the case where the EventSource drops between background tab
+// awake / proxy timeout — the dashboard reflects reality within ~2 minutes
+// even if the realtime channel is broken.
+const FALLBACK_REFETCH_MS = 120_000
+
 export function useDashboardOverview() {
   return useQuery({
     queryKey: [DASHBOARD_KEY],
     queryFn: dashboardApi.getOverview,
     staleTime: 30_000,
-    refetchInterval: 60_000,
+    refetchInterval: FALLBACK_REFETCH_MS,
   })
 }
 
@@ -18,6 +24,6 @@ export function useWIPPipeline() {
     queryKey: [WIP_PIPELINE_KEY],
     queryFn: dashboardApi.getWIPPipeline,
     staleTime: 30_000,
-    refetchInterval: 60_000,
+    refetchInterval: FALLBACK_REFETCH_MS,
   })
 }

--- a/src/lib/hooks/use-inventory.ts
+++ b/src/lib/hooks/use-inventory.ts
@@ -6,15 +6,16 @@ export const OVERFLOW_KEY = 'inventory-overflow-status'
 export const AUDIT_LOG_KEY = 'inventory-audit-log'
 
 /**
- * Polls `GET /inventory/overflow-status` every 30s. The hook is used both by
- * the global red banner and by every "Issue new sheet" button to gate UI.
+ * Polls `GET /inventory/overflow-status` as a fallback. SSE (#194) refreshes
+ * the gauge whenever a CUTTING_RECORDED event arrives — the 120 s interval
+ * here is the safety net for when the EventSource is offline.
  */
 export function useOverflowStatus() {
   return useQuery({
     queryKey: [OVERFLOW_KEY],
     queryFn: inventoryApi.getOverflowStatus,
     staleTime: 15_000,
-    refetchInterval: 30_000,
+    refetchInterval: 120_000,
     refetchOnWindowFocus: true,
   })
 }

--- a/src/lib/providers.tsx
+++ b/src/lib/providers.tsx
@@ -2,6 +2,7 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useState } from 'react'
+import { RealtimeProvider } from '@/lib/realtime/provider'
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -19,6 +20,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
   )
 
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      <RealtimeProvider>{children}</RealtimeProvider>
+    </QueryClientProvider>
   )
 }
+

--- a/src/lib/realtime/events.ts
+++ b/src/lib/realtime/events.ts
@@ -1,0 +1,34 @@
+/**
+ * Realtime SSE event types — mirror BE `internal/platform/events`.
+ *
+ * Source of truth: `events.go` constants (BE PR #266 / issue #258).
+ * The FE never writes events, only consumes them; routing fields (`user_id`,
+ * `roles`) are informational — the BE has already filtered by them before the
+ * frame reaches us.
+ */
+
+export type RealtimeEventType =
+  | 'NEW_ASSIGNMENT'
+  | 'WO_STATUS_CHANGED'
+  | 'CUTTING_RECORDED'
+  | 'SCAN_CHECKPOINT'
+  | 'COSTING_COMPUTED'
+
+export interface RealtimeEvent {
+  /** Personal target — present on NEW_ASSIGNMENT, blank otherwise. */
+  user_id?: string
+  /** Role audience the BE fanned the event out to. */
+  roles?: string[]
+  type: RealtimeEventType | string
+  /** Anchored work order — present on most events, blank for global broadcasts. */
+  wo_id?: string
+  /** SKU code shipped on NEW_ASSIGNMENT so toast can show it without a fetch. */
+  sku?: string
+  payload?: Record<string, unknown>
+}
+
+export function isRealtimeEvent(value: unknown): value is RealtimeEvent {
+  if (!value || typeof value !== 'object') return false
+  const t = (value as Record<string, unknown>).type
+  return typeof t === 'string'
+}

--- a/src/lib/realtime/mapping.test.ts
+++ b/src/lib/realtime/mapping.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { eventToQueryKeys } from './mapping'
+import type { RealtimeEvent } from './events'
+
+function ev(type: RealtimeEvent['type'], extra: Partial<RealtimeEvent> = {}): RealtimeEvent {
+  return { type, ...extra }
+}
+
+describe('eventToQueryKeys', () => {
+  it('maps NEW_ASSIGNMENT to work-orders + cutting-orders prefixes', () => {
+    const keys = eventToQueryKeys(ev('NEW_ASSIGNMENT'))
+    expect(keys).toEqual([['work-orders'], ['cutting-orders']])
+  })
+
+  it('maps WO_STATUS_CHANGED to lists + WIP pipeline + dashboard', () => {
+    const keys = eventToQueryKeys(ev('WO_STATUS_CHANGED', { wo_id: 'abc' }))
+    expect(keys).toEqual([
+      ['work-orders'],
+      ['cutting-orders'],
+      ['dashboard-overview'],
+      ['dashboard-wip-pipeline'],
+    ])
+  })
+
+  it('maps CUTTING_RECORDED to inventory + remnants + dashboard', () => {
+    const keys = eventToQueryKeys(ev('CUTTING_RECORDED'))
+    expect(keys).toEqual([
+      ['work-orders'],
+      ['inventory-overflow-status'],
+      ['inventory-sheets'],
+      ['remnants'],
+      ['dashboard-overview'],
+    ])
+  })
+
+  it('maps SCAN_CHECKPOINT to barcodes + scan-events + WO + dashboard', () => {
+    const keys = eventToQueryKeys(ev('SCAN_CHECKPOINT'))
+    expect(keys).toEqual([
+      ['barcodes'],
+      ['scan-events'],
+      ['work-orders'],
+      ['dashboard-overview'],
+    ])
+  })
+
+  it('maps COSTING_COMPUTED to the costing prefix only', () => {
+    const keys = eventToQueryKeys(ev('COSTING_COMPUTED'))
+    expect(keys).toEqual([['costing']])
+  })
+
+  it('returns [] for an unknown type — tolerated for forward compatibility', () => {
+    const keys = eventToQueryKeys(ev('SOMETHING_NEW' as RealtimeEvent['type']))
+    expect(keys).toEqual([])
+  })
+
+  it('every returned key is a non-empty array prefix', () => {
+    const types: RealtimeEvent['type'][] = [
+      'NEW_ASSIGNMENT',
+      'WO_STATUS_CHANGED',
+      'CUTTING_RECORDED',
+      'SCAN_CHECKPOINT',
+      'COSTING_COMPUTED',
+    ]
+    for (const t of types) {
+      for (const key of eventToQueryKeys(ev(t))) {
+        expect(Array.isArray(key)).toBe(true)
+        expect(key.length).toBeGreaterThan(0)
+      }
+    }
+  })
+})

--- a/src/lib/realtime/mapping.ts
+++ b/src/lib/realtime/mapping.ts
@@ -1,0 +1,64 @@
+/**
+ * Pure mapping from a realtime event to the TanStack Query keys that should
+ * be invalidated. Kept side-effect-free so it's trivially unit-testable.
+ *
+ * Each key is a non-empty array — passed to `queryClient.invalidateQueries`
+ * which then matches every query whose key starts with that prefix. Returning
+ * the bare prefix (e.g. `['work-orders']`) is intentional: a single event
+ * should refresh every filter combination of that domain that the user has
+ * open in any tab.
+ */
+
+import type { RealtimeEvent } from './events'
+
+export type QueryKey = readonly unknown[]
+
+export function eventToQueryKeys(event: RealtimeEvent): QueryKey[] {
+  switch (event.type) {
+    case 'NEW_ASSIGNMENT':
+      // Assignee + cnc_manager dashboards both surface unassigned WO lists.
+      return [['work-orders'], ['cutting-orders']]
+
+    case 'WO_STATUS_CHANGED':
+      // Status change touches lists, the WO detail card, and the WIP pipeline
+      // counts on /overview.
+      return [
+        ['work-orders'],
+        ['cutting-orders'],
+        ['dashboard-overview'],
+        ['dashboard-wip-pipeline'],
+      ]
+
+    case 'CUTTING_RECORDED':
+      // RecordCut writes a sheet/remnant + cutting record; refresh inventory
+      // overflow gauge and the dashboard counters.
+      return [
+        ['work-orders'],
+        ['inventory-overflow-status'],
+        ['inventory-sheets'],
+        ['remnants'],
+        ['dashboard-overview'],
+      ]
+
+    case 'SCAN_CHECKPOINT':
+      // A scan advances the WO checkpoint; barcode list latest-scan column +
+      // dashboard counters need to reflect it.
+      return [
+        ['barcodes'],
+        ['scan-events'],
+        ['work-orders'],
+        ['dashboard-overview'],
+      ]
+
+    case 'COSTING_COMPUTED':
+      // ComputeCost persists a record; costing list + by-WO detail need the
+      // new totals. The detail panel keys off `[COSTING_KEY, 'detail', woId]`
+      // — invalidating the prefix sweeps both shapes.
+      return [['costing']]
+
+    default:
+      // Unknown event types are tolerated — the BE may add new types ahead of
+      // FE handling. Returning `[]` no-ops the invalidation step.
+      return []
+  }
+}

--- a/src/lib/realtime/provider.tsx
+++ b/src/lib/realtime/provider.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { fetchEventSource, type EventSourceMessage } from '@microsoft/fetch-event-source'
+import { toast } from 'sonner'
+import { normalizeAuthToken } from '@/lib/auth/token'
+import { isRealtimeEvent, type RealtimeEvent } from './events'
+import { eventToQueryKeys } from './mapping'
+
+const SSE_PATH = '/notifications/stream'
+// Backoff schedule (ms) for reconnect attempts. After the last entry we cap
+// at the same value rather than escalate further — staying aggressive enough
+// that a sleeping laptop reconnects within a minute of waking.
+const BACKOFF_MS = [1_000, 2_000, 4_000, 8_000, 15_000, 30_000]
+
+class RetriableError extends Error {}
+class FatalError extends Error {}
+
+function buildSseUrl(): string {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080/api/v1'
+  const base = typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3000'
+  return new URL(`${baseUrl}${SSE_PATH}`, base).toString()
+}
+
+/**
+ * RealtimeProvider opens a single SSE stream while the user is authenticated
+ * and dispatches each event to the TanStack Query cache via the pure
+ * `eventToQueryKeys` mapping.
+ *
+ * Why fetch-event-source instead of native EventSource:
+ *   - native EventSource cannot send Authorization headers, so it would force
+ *     us to put the JWT in the URL (visible in proxy logs and browser
+ *     history). fetch-event-source forwards arbitrary headers.
+ *   - we control reconnect on auth failure so a logout breaks the loop.
+ *
+ * Why a provider rather than a one-off hook:
+ *   - exactly one stream per browser tab, regardless of how many components
+ *     subscribe.
+ *   - co-located with `Providers` so it sits inside the QueryClientProvider
+ *     tree and uses the same client.
+ */
+export function RealtimeProvider({ children }: { children: React.ReactNode }) {
+  const queryClient = useQueryClient()
+  // Persist the abort controller so logout / unmount tears down the stream.
+  const ctrlRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const token = normalizeAuthToken(localStorage.getItem('auth_token'))
+    if (!token) return
+
+    let attempt = 0
+    let cancelled = false
+    const ctrl = new AbortController()
+    ctrlRef.current = ctrl
+
+    const handleEvent = (msg: EventSourceMessage) => {
+      // The BE emits unnamed `message` events; ignore the keep-alive ping.
+      if (!msg.data) return
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(msg.data)
+      } catch {
+        return
+      }
+      if (!isRealtimeEvent(parsed)) return
+
+      const event = parsed as RealtimeEvent
+      for (const key of eventToQueryKeys(event)) {
+        queryClient.invalidateQueries({ queryKey: key })
+      }
+
+      // Personal toast for the assignee. Other event types are quiet.
+      if (event.type === 'NEW_ASSIGNMENT') {
+        const sku = event.sku ? ` · ${event.sku}` : ''
+        toast.success(`Bạn có lệnh sản xuất mới${sku}`)
+      }
+    }
+
+    const connect = async () => {
+      while (!cancelled) {
+        try {
+          await fetchEventSource(buildSseUrl(), {
+            method: 'GET',
+            headers: { Authorization: `Bearer ${token}` },
+            signal: ctrl.signal,
+            // Disable the library's own retry so we own the backoff.
+            openWhenHidden: true,
+            async onopen(response) {
+              if (response.ok && response.headers.get('content-type')?.includes('text/event-stream')) {
+                attempt = 0
+                return
+              }
+              if (response.status === 401 || response.status === 403) {
+                throw new FatalError(`auth failed: ${response.status}`)
+              }
+              throw new RetriableError(`bad status: ${response.status}`)
+            },
+            onmessage: handleEvent,
+            onerror(err) {
+              // Throw → exits fetchEventSource so we can apply our own backoff.
+              if (err instanceof FatalError) throw err
+              throw new RetriableError(err instanceof Error ? err.message : 'stream error')
+            },
+            onclose() {
+              throw new RetriableError('stream closed by server')
+            },
+          })
+          // Reached only when fetchEventSource resolves cleanly (e.g. abort) —
+          // exit the loop.
+          return
+        } catch (err) {
+          if (cancelled || err instanceof FatalError) return
+
+          const delay = BACKOFF_MS[Math.min(attempt, BACKOFF_MS.length - 1)]
+          attempt += 1
+          await sleep(delay, ctrl.signal)
+        }
+      }
+    }
+
+    connect()
+
+    return () => {
+      cancelled = true
+      ctrl.abort()
+      ctrlRef.current = null
+    }
+  }, [queryClient])
+
+  return <>{children}</>
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) return resolve()
+    const id = setTimeout(resolve, ms)
+    signal.addEventListener('abort', () => {
+      clearTimeout(id)
+      resolve()
+    }, { once: true })
+  })
+}


### PR DESCRIPTION
## Summary
- Add `RealtimeProvider` that opens `GET /api/v1/notifications/stream` via `@microsoft/fetch-event-source`, dispatches events through a pure mapping into TanStack Query cache invalidations, and toasts `NEW_ASSIGNMENT` to the assignee.
- Downgrade polling fallbacks from 30–60 s to 120 s on `/cutting-orders`, `/inventory/overflow-status`, `/dashboard/overview`, `/dashboard/wip-pipeline` now that SSE is the primary channel.

Closes #194 — backed by BE PR #266 / issue #258.

## Technical notes
- **Why `@microsoft/fetch-event-source` over native `EventSource`** — native EventSource cannot send `Authorization` headers, which would force the JWT into the URL (visible in proxy logs and browser history). The library forwards arbitrary headers, lets us own reconnect on auth failure, and supports `signal` for clean teardown on logout.
- **Pure mapping in `src/lib/realtime/mapping.ts`** — `eventToQueryKeys(event)` returns the list of query-key prefixes to invalidate. Side-effect-free → unit-testable. Each prefix is a non-empty array so `queryClient.invalidateQueries` matches every filter combination of that domain that any open tab is subscribed to.
- **Reconnect policy** — exponential backoff 1 → 2 → 4 → 8 → 15 → 30 s, capped at 30 s. 401/403 are treated as `FatalError` so a logout breaks the loop instead of spinning. The library's built-in retry is disabled so we own the schedule.
- **Toast scope** — only `NEW_ASSIGNMENT` toasts (the assignee should be notified when handed work). Other event types are silent — they only invalidate caches.
- **Provider placement** — sits inside `QueryClientProvider` so the same client is used. One stream per browser tab regardless of how many components subscribe.
- **Forward compatibility** — unknown event types from BE are tolerated: the mapping returns `[]` and the toast only fires for known types, so a BE rolling out a new event type ahead of FE doesn't break anything.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [x] `npm run test:unit -- src/lib/realtime/mapping.test.ts` — 7/7 passed (covers all 5 event types + unknown + every key shape)
- [ ] Manual: log in 2 tabs as planner + cnc → assign WO from planner tab, assignee toast + WO list updates within ~1 s on the worker tab
- [ ] Manual: throttle network to "Offline" then back online → reconnect within ~30 s without page reload
- [ ] Manual: log out → SSE stream tears down (no re-connect spam in network tab)
- [ ] Manual: trigger ComputeCost → /costing list reflects new total without manual refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)