### PR TITLE
[reports] Excel export buttons on list pages

### DIFF
--- a/src/app/(dashboard)/costing/page.tsx
+++ b/src/app/(dashboard)/costing/page.tsx
@@ -38,6 +38,7 @@ import { useDebounce } from '@/lib/hooks/use-debounce'
 import { usePageParams } from '@/lib/hooks/use-page-params'
 import { useSKUs } from '@/lib/hooks/use-skus'
 import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
+import { ExportExcelButton } from '@/components/dashboard/export-excel-button'
 import { formatVND } from '@/lib/format'
 import type { CostingRecord } from '@/types/api'
 
@@ -464,6 +465,11 @@ function CostingContent() {
             Xoá bộ lọc
           </Button>
         )}
+
+        <ExportExcelButton
+          report="costings"
+          filter={{ from: dateFrom, to: dateTo }}
+        />
       </div>
 
       {isError ? (

--- a/src/app/(dashboard)/pos/page.tsx
+++ b/src/app/(dashboard)/pos/page.tsx
@@ -31,6 +31,7 @@ import { usePOs, useCreatePO } from '@/lib/hooks/use-pos'
 import { useSKUs } from '@/lib/hooks/use-skus'
 import { usePageParams } from '@/lib/hooks/use-page-params'
 import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
+import { ExportExcelButton } from '@/components/dashboard/export-excel-button'
 import type { CreatePOInput, CreateLineItemInput, SKU } from '@/types/api'
 
 // ── Helpers
@@ -373,14 +374,15 @@ function POsContent() {
 
   return (
     <>
-      <div className="flex items-center">
+      <div className="flex items-center gap-2">
+        <ExportExcelButton report="purchase-orders" className="ml-auto" />
         {canCreatePO ? (
-          <Button className="ml-auto" onClick={() => setCreateOpen(true)}>
+          <Button onClick={() => setCreateOpen(true)}>
             <Plus className="size-4" />
             Tạo đơn hàng
           </Button>
         ) : (
-          <p className="ml-auto text-xs text-muted-foreground">Bạn chỉ có quyền xem danh sách đơn hàng.</p>
+          <p className="text-xs text-muted-foreground">Bạn chỉ có quyền xem danh sách đơn hàng.</p>
         )}
       </div>
 

--- a/src/app/(dashboard)/skus/page.tsx
+++ b/src/app/(dashboard)/skus/page.tsx
@@ -45,6 +45,7 @@ import {
 import { useMaterials } from '@/lib/hooks/use-materials'
 import { useDebounce } from '@/lib/hooks/use-debounce'
 import { usePageParams } from '@/lib/hooks/use-page-params'
+import { ExportExcelButton } from '@/components/dashboard/export-excel-button'
 import { cn } from '@/lib/utils'
 import type { SKU, CreateSKUInput, BOMItem, BOMVariant } from '@/types/api'
 
@@ -788,10 +789,13 @@ function SKUsContent() {
           placeholder="Tìm theo mã hoặc tên sản phẩm…"
           containerClassName="w-full sm:max-w-sm"
         />
-        <Button className="sm:ml-auto" onClick={() => setCreateOpen(true)}>
-          <Plus className="size-4" />
-          Tạo sản phẩm
-        </Button>
+        <div className="flex items-center gap-2 sm:ml-auto">
+          <ExportExcelButton report="skus" />
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="size-4" />
+            Tạo sản phẩm
+          </Button>
+        </div>
       </div>
 
       {isError ? (

--- a/src/app/(dashboard)/waste-report/page.tsx
+++ b/src/app/(dashboard)/waste-report/page.tsx
@@ -34,6 +34,7 @@ import {
 import { mapApiErrorVi } from '@/lib/api/client'
 import { costingApi } from '@/lib/api/costing'
 import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
+import { ExportExcelButton } from '@/components/dashboard/export-excel-button'
 import { formatVND } from '@/lib/format'
 import { useMaterials } from '@/lib/hooks/use-materials'
 import { useWasteReport } from '@/lib/hooks/use-waste-report'
@@ -242,14 +243,21 @@ function WasteReportContent() {
         </div>
 
         {canExport && (
-          <Button onClick={handleDownloadCsv} disabled={downloading || isLoading}>
-            {downloading ? (
-              <Loader2 className="size-4 animate-spin" />
-            ) : (
-              <Download className="size-4" />
-            )}
-            Tải CSV
-          </Button>
+          <div className="flex items-center gap-2">
+            <ExportExcelButton
+              report="waste"
+              filter={{ from, to }}
+              disabled={isLoading}
+            />
+            <Button onClick={handleDownloadCsv} disabled={downloading || isLoading}>
+              {downloading ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Download className="size-4" />
+              )}
+              Tải CSV
+            </Button>
+          </div>
         )}
       </div>
 

--- a/src/app/(dashboard)/work-orders/page.tsx
+++ b/src/app/(dashboard)/work-orders/page.tsx
@@ -64,6 +64,7 @@ import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
 import { evaluateStartCutGate, startCutTooltip } from '@/lib/auth/work-order-gate'
 import { useMe } from '@/lib/hooks/use-auth'
 import { useRemnantBypassedWorkOrders } from '@/lib/hooks/use-inventory'
+import { ExportExcelButton } from '@/components/dashboard/export-excel-button'
 import type {
   WorkOrderStatus,
   WorkOrder,
@@ -1135,12 +1136,24 @@ function WorkOrdersContent() {
         </div>
 
         {canCreateWorkOrder ? (
-          <Button onClick={() => setCreateOpen(true)}>
-            <Plus className="size-4" />
-            Tạo lệnh
-          </Button>
+          <div className="flex items-center gap-2">
+            <ExportExcelButton
+              report="work-orders"
+              filter={{ from: dateFrom, to: dateTo }}
+            />
+            <Button onClick={() => setCreateOpen(true)}>
+              <Plus className="size-4" />
+              Tạo lệnh
+            </Button>
+          </div>
         ) : (
-          <p className="text-xs text-muted-foreground">Bạn chỉ có quyền xem danh sách lệnh cắt.</p>
+          <div className="flex items-center gap-2">
+            <ExportExcelButton
+              report="work-orders"
+              filter={{ from: dateFrom, to: dateTo }}
+            />
+            <p className="text-xs text-muted-foreground">Bạn chỉ có quyền xem danh sách lệnh cắt.</p>
+          </div>
         )}
       </div>
 

--- a/src/components/dashboard/export-excel-button.tsx
+++ b/src/components/dashboard/export-excel-button.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useState, useSyncExternalStore } from 'react'
+import { Download, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { mapApiErrorVi } from '@/lib/api/client'
+import { reportsApi, type ExportFilter, type ExportReport } from '@/lib/api/reports'
+import { can, getCurrentRoleFromCookie } from '@/lib/auth/authorization'
+
+interface ExportExcelButtonProps {
+  report: ExportReport
+  filter?: ExportFilter
+  /** Override the default "Xuất Excel" label — useful when sitting next to other buttons. */
+  label?: string
+  /** Pass-through className to align with surrounding toolbars. */
+  className?: string
+  /** Disable beyond the role check (e.g. while the parent list is still loading). */
+  disabled?: boolean
+}
+
+function useCurrentRole() {
+  return useSyncExternalStore(
+    () => () => {},
+    () => getCurrentRoleFromCookie(),
+    () => null,
+  )
+}
+
+function triggerDownload(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  URL.revokeObjectURL(url)
+}
+
+/**
+ * Shared Excel export button. Hidden entirely for roles that cannot generate
+ * reports so /skus, /pos, /work-orders don't show a useless action to planner
+ * or warehouse users.
+ */
+export function ExportExcelButton({
+  report,
+  filter,
+  label = 'Xuất Excel',
+  className,
+  disabled,
+}: ExportExcelButtonProps) {
+  const role = useCurrentRole()
+  const [downloading, setDownloading] = useState(false)
+
+  if (!can(role, 'generate', 'reports')) return null
+
+  async function handleClick() {
+    setDownloading(true)
+    const toastId = toast.loading('Đang chuẩn bị file...')
+    try {
+      const { blob, filename } = await reportsApi.exportXlsx(report, filter)
+      triggerDownload(blob, filename)
+      toast.success('Đã tải file Excel', { id: toastId })
+    } catch (err) {
+      toast.error(mapApiErrorVi(err, 'Tải Excel thất bại'), { id: toastId })
+    } finally {
+      setDownloading(false)
+    }
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={handleClick}
+      disabled={disabled || downloading}
+      className={className}
+    >
+      {downloading ? (
+        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+      ) : (
+        <Download className="size-4" aria-hidden="true" />
+      )}
+      {label}
+    </Button>
+  )
+}

--- a/src/lib/api/reports.ts
+++ b/src/lib/api/reports.ts
@@ -1,0 +1,96 @@
+import { ApiClientError } from '@/lib/api/client'
+import { normalizeAuthToken } from '@/lib/auth/token'
+
+export type ExportReport =
+  | 'costings'
+  | 'purchase-orders'
+  | 'skus'
+  | 'work-orders'
+  | 'waste'
+
+export interface ExportFilter {
+  /** Inclusive ISO date YYYY-MM-DD lower bound on `created_at`. */
+  from?: string
+  /** Inclusive ISO date YYYY-MM-DD upper bound (BE treats as exclusive end-of-day). */
+  to?: string
+}
+
+export interface ExportResult {
+  blob: Blob
+  filename: string
+}
+
+const XLSX_MIME =
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+
+function buildApiUrl(path: string) {
+  const base =
+    typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3000'
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080/api/v1'
+  return new URL(`${baseUrl}${path}`, base)
+}
+
+/**
+ * Pulls the filename out of a Content-Disposition header. Handles both the
+ * RFC 5987 `filename*=UTF-8''<encoded>` form and the legacy quoted `filename=`
+ * form. Returns null if neither is present so the caller can fall back to a
+ * sensible default.
+ */
+export function parseContentDispositionFilename(header: string | null): string | null {
+  if (!header) return null
+  const star = header.match(/filename\*=(?:UTF-8'')?([^;]+)/i)
+  if (star?.[1]) {
+    try {
+      return decodeURIComponent(star[1].trim().replace(/^"|"$/g, ''))
+    } catch {
+      // fall through to non-encoded variant
+    }
+  }
+  const plain = header.match(/filename="?([^";]+)"?/i)
+  return plain?.[1]?.trim() ?? null
+}
+
+function defaultFilename(report: ExportReport, filter: ExportFilter): string {
+  const from = filter.from ?? 'all'
+  const to = filter.to ?? 'all'
+  return `${report}_${from}_${to}.xlsx`
+}
+
+export const reportsApi = {
+  /**
+   * GET /api/v1/reports/export/{report}.xlsx?from=YYYY-MM-DD&to=YYYY-MM-DD
+   * Restricted to admin + accountant on the BE; the FE also gates the button
+   * via `can(role, 'generate', 'reports')`.
+   */
+  async exportXlsx(report: ExportReport, filter: ExportFilter = {}): Promise<ExportResult> {
+    const url = buildApiUrl(`/reports/export/${report}.xlsx`)
+    if (filter.from) url.searchParams.set('from', filter.from)
+    if (filter.to) url.searchParams.set('to', filter.to)
+
+    const token =
+      typeof window !== 'undefined'
+        ? normalizeAuthToken(localStorage.getItem('auth_token'))
+        : null
+
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        Accept: XLSX_MIME,
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    })
+
+    if (!response.ok) {
+      const body = await response.json().catch(() => null)
+      const code: string = body?.code ?? 'UNKNOWN'
+      const message: string = body?.message ?? body?.error ?? `HTTP ${response.status}`
+      throw new ApiClientError(response.status, code, message, body?.details)
+    }
+
+    const filename =
+      parseContentDispositionFilename(response.headers.get('Content-Disposition')) ??
+      defaultFilename(report, filter)
+
+    return { blob: await response.blob(), filename }
+  },
+}

--- a/src/lib/auth/authorization.ts
+++ b/src/lib/auth/authorization.ts
@@ -27,6 +27,7 @@ export type AppResource =
   | 'profile'
   | 'purchasing'
   | 'waste_report'
+  | 'reports'
 
 export type AppAction =
   | 'read'
@@ -123,12 +124,14 @@ const POLICY: Record<AppRole, Partial<Record<AppResource, readonly AppAction[]>>
     purchasing: ['read', 'create', 'cancel'],
     waste_report: ['read', 'generate'],
     barcodes: ['read', 'generate'],
+    reports: ['read', 'generate'],
   },
   accountant: {
     ...readOnly(DASHBOARD_RESOURCES),
     pos: ['read', 'create'],
     costing: ['read', 'compute', 'finalize', 'adjust'],
     waste_report: ['read', 'generate'],
+    reports: ['read', 'generate'],
   },
   planner: {
     ...readOnly(DASHBOARD_RESOURCES),


### PR DESCRIPTION
## Summary
Implements #193 — give admin + accountant a one-click Excel export on the 5 list screens, hitting the new BE endpoints under `/api/v1/reports/export/`.

- New `src/lib/api/reports.ts` wraps `GET /reports/export/{report}.xlsx?from=&to=` with the `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` Accept header, Bearer token, and a small `parseContentDispositionFilename` helper that handles both RFC 5987 (`filename*=UTF-8''…`) and the legacy quoted form, falling back to `${report}_${from}_${to}.xlsx`.
- Shared `ExportExcelButton` (`src/components/dashboard/export-excel-button.tsx`) renders nothing for roles without `reports.generate`, shows a `Đang chuẩn bị file...` loading toast, swaps to a `Loader2` while in flight, and triggers a blob download via the standard `URL.createObjectURL` pattern.
- Wired into `/costing`, `/purchase-orders`, `/skus`, `/work-orders`, `/waste-report`. Pages with a date range pass `{ from, to }`; SKUs has no time scope so the call goes without the period.
- `reports` resource added to `AppResource`, with `{read, generate}` granted to `admin` and `accountant` only — mirrors the BE `auth.RequireRole` gate so non-permitted roles never see the button.

## Technical notes
- No changes to `src/types/api.ts` — the API only returns a binary blob, no DTOs to mirror.
- `parseContentDispositionFilename` is exported so it remains unit-testable (covered the encoded + plain branches when picking it).
- `/waste-report` keeps its existing CSV button untouched; the new Excel button sits next to it for parity.
- Disabled state on `ExportExcelButton` is wired through to the parent `disabled` flag (used by `/waste-report` while the table is loading) so we don't trigger empty exports.

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — succeeds (27/27 prerendered)
- [ ] Sign in as `admin` / `accountant` → button visible on all 5 pages, click downloads `.xlsx` with filename from `Content-Disposition`
- [ ] Sign in as `planner` / `warehouse` / `foreman` / `cnc_manager` → button hidden everywhere
- [ ] On `/costing` and `/work-orders` change the date range → exported file reflects the new `from`/`to`
- [ ] Force a 5xx via DevTools → toast shows "Tải Excel thất bại" with the BE error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)