### PR TITLE
[kiosk] show WO picker on /report-cut when no wo_id

### DIFF
--- a/src/components/kiosk/cutting-order-card.tsx
+++ b/src/components/kiosk/cutting-order-card.tsx
@@ -8,8 +8,10 @@ import type { WorkOrder } from '@/types/api'
 interface CuttingOrderCardProps {
   order: WorkOrder
   className?: string
-  /** Called when the worker taps the action button — opens the remnant suggestion modal. */
+  /** Called when the worker taps the action button. */
   onStartCutting: (order: WorkOrder) => void
+  /** Override the default "Bắt đầu cắt →" label. */
+  actionLabel?: string
 }
 
 /**
@@ -18,7 +20,7 @@ interface CuttingOrderCardProps {
  * Touch-target height is guaranteed ≥ 48px by the card layout; the
  * "Báo cáo kết quả" button enforces its own min-h-[48px].
  */
-export function CuttingOrderCard({ order, className, onStartCutting }: CuttingOrderCardProps) {
+export function CuttingOrderCard({ order, className, onStartCutting, actionLabel }: CuttingOrderCardProps) {
   const skuDisplay = order.sku_code ?? `${order.sku_id.slice(0, 8)}\u2026`
   const skuName = order.sku_name ?? 'Chưa có tên SKU'
   const hasDim = !!order.sku_dimensions
@@ -70,7 +72,7 @@ export function CuttingOrderCard({ order, className, onStartCutting }: CuttingOr
           'transition-colors active:bg-primary/10',
         )}
       >
-        Bắt đầu cắt →
+        {actionLabel ?? 'Bắt đầu cắt →'}
       </button>
     </article>
   )

--- a/src/components/kiosk/report-cut-form.tsx
+++ b/src/components/kiosk/report-cut-form.tsx
@@ -17,12 +17,15 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { BigButton } from '@/components/kiosk/big-button'
-import { useCuttingOrder, useRecordCut } from '@/lib/hooks/use-cutting-orders'
+import { CuttingOrderCard } from '@/components/kiosk/cutting-order-card'
+import { useCuttingOrder, useCuttingOrders, useRecordCut } from '@/lib/hooks/use-cutting-orders'
 import { useGenerateBarcode, useOpenBarcodeLabelPdf } from '@/lib/hooks/use-barcode'
+import { useMe } from '@/lib/hooks/use-auth'
 import { usePlan } from '@/lib/hooks/use-plans'
 import { useAvailableSheets, useRemnant } from '@/lib/hooks/use-remnants'
 import { ApiClientError } from '@/lib/api/client'
 import { cn } from '@/lib/utils'
+import type { WorkOrder } from '@/types/api'
 
 // ── Error message map ─────────────────────────────────────────────────────────
 // Maps API error codes (from the Go backend BizError) to Vietnamese strings
@@ -530,15 +533,12 @@ export function ReportCutForm() {
     )
   }
 
-  // ── Missing wo_id guard ───────────────────────────────────────────────────
+  // ── Missing wo_id: show a picker of the worker's IN_CUTTING WOs ──────────
+  // Worker reaches /report-cut directly via the bottom-nav tab — no wo_id in
+  // the URL. Instead of bouncing back to /cutting-orders, render the same
+  // list scoped to `assigned_to = me` so they can pick which WO to report on.
   if (!woId) {
-    return (
-      <div className="p-4">
-        <div className="rounded-2xl border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
-          Thiếu mã lệnh cắt (wo_id). Quay lại danh sách lệnh cắt.
-        </div>
-      </div>
-    )
+    return <ReportCutWorkOrderPicker />
   }
 
   const missingMaterialSelection = needsBoardSheetInput && !selectedMaterialId
@@ -854,5 +854,88 @@ export function ReportCutForm() {
         {isPending ? 'Đang gửi…' : 'Báo cáo kết quả'}
       </BigButton>
     </form>
+  )
+}
+
+// ── ReportCutWorkOrderPicker ─────────────────────────────────────────────────
+// Rendered when the worker lands on /report-cut without a wo_id (i.e. tapped
+// the bottom-nav "Báo cáo" tab directly). Shows the same IN_CUTTING WOs from
+// /cutting-orders, but scoped to `assigned_to = current user` so the worker
+// can only pick from their own active cuts. Tapping a card forwards to
+// /report-cut?wo_id=<id> which re-enters this component on the happy path.
+
+function ReportCutWorkOrderPicker() {
+  const router = useRouter()
+  const { data: me, isLoading: isLoadingMe } = useMe()
+
+  // BE filter `assigned=<id>` is honored by /work-orders. We also apply a
+  // defensive client-side filter in case BE doesn't (e.g. older deploys),
+  // and so the empty state never accidentally shows another worker's WOs.
+  const {
+    data: woData,
+    isLoading: isLoadingWOs,
+    isError,
+  } = useCuttingOrders(
+    me?.id ? { status: 'IN_CUTTING', assigned: me.id } : { status: 'IN_CUTTING' },
+  )
+
+  const myWOs = useMemo<WorkOrder[]>(() => {
+    const items = woData?.items ?? []
+    if (!me?.id) return []
+    return items.filter((wo) => wo.assigned_to === me.id)
+  }, [woData?.items, me?.id])
+
+  const isLoading = isLoadingMe || isLoadingWOs
+
+  return (
+    <div className="space-y-4 p-4 pb-6">
+      <div>
+        <h1 className="text-xl font-bold leading-tight">Báo cáo kết quả cắt</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Chọn lệnh cắt bạn muốn báo cáo.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-[120px] animate-pulse rounded-2xl border bg-muted/40"
+            />
+          ))}
+        </div>
+      ) : isError ? (
+        <div
+          role="alert"
+          className="rounded-2xl border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive"
+        >
+          Không thể tải lệnh cắt. Kiểm tra kết nối mạng và thử lại.
+        </div>
+      ) : myWOs.length === 0 ? (
+        <div className="rounded-2xl border bg-muted/30 p-6 text-center">
+          <p className="text-base font-semibold">Bạn chưa có lệnh nào đang cắt</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Vào tab Lệnh cắt để bắt đầu một lệnh trước khi báo cáo.
+          </p>
+          <button
+            type="button"
+            onClick={() => router.push('/cutting-orders')}
+            className="mt-4 inline-flex min-h-[48px] items-center justify-center rounded-xl border bg-white px-4 text-base font-semibold shadow-sm active:bg-muted"
+          >
+            Mở danh sách lệnh cắt
+          </button>
+        </div>
+      ) : (
+        myWOs.map((wo) => (
+          <CuttingOrderCard
+            key={wo.id}
+            order={wo}
+            actionLabel="Báo cáo kết quả →"
+            onStartCutting={() => router.push(`/report-cut?wo_id=${wo.id}`)}
+          />
+        ))
+      )}
+    </div>
   )
 }

--- a/src/lib/api/cutting-orders.ts
+++ b/src/lib/api/cutting-orders.ts
@@ -7,6 +7,12 @@ export interface WorkOrdersFilter {
   date?: string
   from?: string
   to?: string
+  /**
+   * Assignee filter. Pass a user id to scope to that worker; pass `'null'` to
+   * fetch only WOs with `assigned_to IS NULL`. Callers should still apply a
+   * client-side fallback because some BE deploys may ignore the param.
+   */
+  assigned?: 'null' | string
   page?: number
   pageSize?: number
 }


### PR DESCRIPTION
## Summary
Fixes the kiosk bottom-nav "Báo cáo" tab — previously it dumped the worker on `/report-cut` with no `wo_id` and only the missing-wo_id error banner. The form was designed to be entered from the `RemnantSuggestionModal` on `/cutting-orders`, so the tab itself was effectively dead.

The fix replaces the error banner with a small picker that re-uses the same `IN_CUTTING` list, scoped to `assigned_to = me`. Tapping a card forwards to `/report-cut?wo_id=<id>` and re-enters the happy path. Empty state offers a shortcut back to `/cutting-orders`.

## Root cause
- `src/components/kiosk/bottom-nav.tsx:21` — static `Link` to `/report-cut` with no query.
- `src/components/kiosk/report-cut-form.tsx:534-542` — guard `if (!woId) return <error>` was the only fallback.
- Real entry points (`remnant-suggestion-modal.tsx:187,202`) always supply `wo_id`.

Not a BE/data issue — overflow-status, /me, and SSE were all 200 in the user's screenshot.

## Technical notes
- `WorkOrdersFilter` in `src/lib/api/cutting-orders.ts` gains an optional `assigned?: 'null' | string`. Already supported by BE per `/cutting-dispatch`.
- Defensive client-side filter (`wo.assigned_to === me.id`) so the picker never shows another worker's WOs even if BE ignores the param.
- `CuttingOrderCard` accepts an `actionLabel` override so the picker reads "Báo cáo kết quả →".
- Empty state, error state, and loading state all covered.
- No new query keys (reuses `[work-orders, { status, assigned }]`).

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — succeeds
- [ ] Sign in as `cnc` worker → tap "Báo cáo" tab → see only own IN_CUTTING WOs.
- [ ] Tap a card → lands on `/report-cut?wo_id=<id>` → form renders normally.
- [ ] Worker with no IN_CUTTING WOs → sees empty state + "Mở danh sách lệnh cắt" shortcut.
- [ ] Direct hit to `/report-cut?wo_id=<id>` still works (regression check on the happy path).
