### PR TITLE
[layout] allow admin sidebar to scroll so logout stays reachable

### DIFF
--- a/src/components/dashboard/side-nav.tsx
+++ b/src/components/dashboard/side-nav.tsx
@@ -77,8 +77,9 @@ export function SideNav() {
 
       <Separator />
 
-      {/* Nav links */}
-      <nav className="flex flex-col gap-1 p-3">
+      {/* Nav links — flex-1 + overflow-y-auto + min-h-0 so the list scrolls
+          and the footer below stays anchored even on short viewports. */}
+      <nav className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto p-3">
         {navItemsForRole(role).map(({ href, label, icon: Icon }) => {
           const active = pathname.startsWith(href)
           return (
@@ -99,7 +100,7 @@ export function SideNav() {
         })}
       </nav>
 
-      <div className="mt-auto space-y-1 p-3 border-t">
+      <div className="space-y-1 border-t p-3">
         {/* Identity chip */}
         {role && (
           <Link


### PR DESCRIPTION
## Summary
Fixes #222 — on short viewports (laptop screens, DevTools docked right) the admin sidebar's logout button was pushed below the fold with no way to scroll, leaving users stuck logged in.

The fixed `<aside>` is 100vh, but the inner `<nav>` had no `flex-1` and no `overflow-y-auto`, so when the 14-item nav list + footer exceeded the viewport, the footer simply rendered outside the frame.

Single-class fix per the issue's proposed root cause:

```diff
- <nav className="flex flex-col gap-1 p-3">
+ <nav className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto p-3">
```

`min-h-0` is the non-obvious bit — without it the flex item refuses to shrink below content size and `overflow-y-auto` becomes a no-op. The footer's `mt-auto` is now redundant (flex-1 on nav anchors it) so it was dropped to keep the rule set tight.

## Technical notes
- No behavior change for tall viewports — `flex-1` consumes remaining space, no scrollbar appears when not needed.
- Storybook stories untouched — they don't constrain height so they render the same.
- No type / API surface changes.

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — succeeds
- [ ] Sign in as `admin` (full 14-item nav). Test at 3 viewport heights:
  - 1080p → no scrollbar, footer flush at bottom
  - ~700px → sidebar scrolls, logout button reachable
  - ~500px → worst case, scroll still works, logout reachable
- [ ] Sign in as `cnc_manager` (fewer nav items) → no spurious scrollbar
- [ ] Resize the window with sidebar open → scrollbar appears/disappears smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)