### PR TITLE
[fe-filter] add date-range filter to /remnants /cutting-dispatch /assembly

### DIFF
--- a/src/app/(dashboard)/assembly/page.tsx
+++ b/src/app/(dashboard)/assembly/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { Suspense, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { ArrowRight, Boxes, CheckCircle2, ClipboardList, HardHat, Loader2, Plus } from 'lucide-react'
 import { toast } from 'sonner'
@@ -26,6 +26,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
+import {
+  DateRangeFilter,
+  defaultFromIso,
+  isoToday,
+} from '@/components/dashboard/date-range-filter'
 import { useMaterials } from '@/lib/hooks/use-materials'
 import { useSKU } from '@/lib/hooks/use-skus'
 import {
@@ -37,6 +42,7 @@ import {
   useWorkOrders,
 } from '@/lib/hooks/use-work-orders'
 import { useMe } from '@/lib/hooks/use-auth'
+import { usePageParams } from '@/lib/hooks/use-page-params'
 import type { LaborStage, MaterialType, WorkOrder } from '@/types/api'
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -354,12 +360,22 @@ function AssemblyCard({ wo }: AssemblyCardProps) {
 
 // ── Page ─────────────────────────────────────────────────────────────────────
 
-export default function AssemblyPage() {
+function AssemblyContent() {
   const { data: me } = useMe()
+  const { getParam, setParams } = usePageParams(100)
+
+  const dateFrom = getParam('from') ?? defaultFromIso()
+  const dateTo = getParam('to') ?? isoToday()
+
   // BE has no team / assignee filter on /work-orders for foreman yet — pull all
   // IN_PROCESSING work orders for now. When BE adds ?foreman_id, switch to a
   // server-side filter so foremen don't see other shops' lists.
-  const { data, isLoading, isError } = useWorkOrders({ status: 'IN_PROCESSING', limit: 100 })
+  const { data, isLoading, isError } = useWorkOrders({
+    status: 'IN_PROCESSING',
+    from: dateFrom,
+    to: dateTo,
+    limit: 100,
+  })
   const workOrders = useMemo(() => data?.items ?? [], [data?.items])
 
   return (
@@ -375,9 +391,16 @@ export default function AssemblyPage() {
             quản lý các lệnh đang gia công — ghi nhận vật tư, công lao động và đánh dấu hoàn thành.
           </p>
         </div>
-        <Link href="/work-orders" className="inline-flex items-center gap-1 text-sm text-primary hover:underline">
-          Tất cả lệnh sản xuất <ArrowRight className="size-4" />
-        </Link>
+        <div className="flex items-center gap-3">
+          <DateRangeFilter
+            from={dateFrom}
+            to={dateTo}
+            onChange={({ from, to }) => setParams({ from, to })}
+          />
+          <Link href="/work-orders" className="inline-flex items-center gap-1 text-sm text-primary hover:underline">
+            Tất cả lệnh sản xuất <ArrowRight className="size-4" />
+          </Link>
+        </div>
       </header>
 
       {isLoading ? (
@@ -417,5 +440,13 @@ export default function AssemblyPage() {
         </div>
       )}
     </div>
+  )
+}
+
+export default function AssemblyPage() {
+  return (
+    <Suspense fallback={<Skeleton className="h-64 w-full rounded-xl" />}>
+      <AssemblyContent />
+    </Suspense>
   )
 }

--- a/src/app/(dashboard)/cutting-dispatch/page.tsx
+++ b/src/app/(dashboard)/cutting-dispatch/page.tsx
@@ -30,6 +30,11 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { DataPagination } from '@/components/ui/data-pagination'
+import {
+  DateRangeFilter,
+  defaultFromIso,
+  isoToday,
+} from '@/components/dashboard/date-range-filter'
 import { usePageParams } from '@/lib/hooks/use-page-params'
 import { useWorkOrders,
   useAssignWorkOrder,
@@ -289,11 +294,16 @@ function CuttingDispatchContent() {
   const [pulseIds, setPulseIds] = useState<Set<string>>(() => new Set())
   const [recentIds, setRecentIds] = useState<Set<string>>(() => new Set())
 
-  const { page, limit, setPage } = usePageParams(15)
+  const { page, limit, setPage, getParam, setParams } = usePageParams(15)
+
+  const dateFrom = getParam('from') ?? defaultFromIso()
+  const dateTo = getParam('to') ?? isoToday()
 
   const filter = {
     ...(statusFilter !== 'ALL' ? { status: statusFilter } : {}),
     ...(assignmentFilter === 'unassigned' ? { assigned: 'null' as const } : {}),
+    from: dateFrom,
+    to: dateTo,
     page,
     limit,
   }
@@ -393,6 +403,13 @@ function CuttingDispatchContent() {
             <SelectItem value="all">Tất cả phân công</SelectItem>
           </SelectContent>
         </Select>
+
+        <DateRangeFilter
+          from={dateFrom}
+          to={dateTo}
+          onChange={({ from, to }) => setParams({ from, to })}
+          className="ml-auto"
+        />
       </div>
 
       {/* Table */}

--- a/src/app/(dashboard)/remnants/page.tsx
+++ b/src/app/(dashboard)/remnants/page.tsx
@@ -6,6 +6,11 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { SearchInput } from '@/components/ui/search-input'
 import { DataPagination } from '@/components/ui/data-pagination'
 import {
+  DateRangeFilter,
+  defaultFromIso,
+  isoToday,
+} from '@/components/dashboard/date-range-filter'
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -58,7 +63,7 @@ function TableSkeleton({ rows = 8 }: { rows?: number }) {
 // ── Inner component — uses useSearchParams (must be inside <Suspense>) ────────
 
 function RemnantsContent() {
-  const { page, search, limit, setPage, setSearch } = usePageParams(10)
+  const { page, search, limit, setPage, setSearch, getParam, setParams } = usePageParams(10)
 
   const [inputValue, setInputValue] = useState(search)
   const debouncedSearch = useDebounce(inputValue, 400)
@@ -71,11 +76,16 @@ function RemnantsContent() {
 
   const [statusFilter, setStatusFilter] = useState<RemnantStatus | 'ALL'>('ALL')
 
+  const dateFrom = getParam('from') ?? defaultFromIso()
+  const dateTo = getParam('to') ?? isoToday()
+
   const { data, isLoading, isFetching, isError } = useRemnants({
     page,
     limit,
     search: debouncedSearch || undefined,
     status: statusFilter === 'ALL' ? undefined : statusFilter,
+    from: dateFrom,
+    to: dateTo,
   })
 
   const isPending = isFetching && inputValue !== debouncedSearch
@@ -114,6 +124,13 @@ function RemnantsContent() {
             ))}
           </SelectContent>
         </Select>
+
+        <DateRangeFilter
+          from={dateFrom}
+          to={dateTo}
+          onChange={({ from, to }) => setParams({ from, to })}
+          className="sm:ml-auto"
+        />
       </div>
 
       {/* Table */}

--- a/src/components/dashboard/date-range-filter.tsx
+++ b/src/components/dashboard/date-range-filter.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { Calendar, RotateCcw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+const DEFAULT_RANGE_DAYS = 30
+
+export function isoDate(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+export function isoToday(): string {
+  return isoDate(new Date())
+}
+
+export function defaultFromIso(daysAgo = DEFAULT_RANGE_DAYS): string {
+  const d = new Date()
+  d.setDate(d.getDate() - daysAgo)
+  return isoDate(d)
+}
+
+interface DateRangeFilterProps {
+  from: string
+  to: string
+  onChange: (next: { from: string; to: string }) => void
+  /** Days back the "reset" button restores. Defaults to 30. */
+  defaultDaysAgo?: number
+  /** Inline label to the left of the inputs (visually optional). */
+  label?: string
+  className?: string
+}
+
+/**
+ * Two-input date range picker with cross-validated min/max and a "30 ngày
+ * gần nhất" reset button. The component is purely controlled — URL sync,
+ * defaults, and React Query refetch are the caller's responsibility.
+ *
+ * Used wherever a list page needs server-side `?from=&to=` filtering.
+ */
+export function DateRangeFilter({
+  from,
+  to,
+  onChange,
+  defaultDaysAgo = DEFAULT_RANGE_DAYS,
+  label,
+  className,
+}: DateRangeFilterProps) {
+  const today = isoToday()
+  const defaultFrom = defaultFromIso(defaultDaysAgo)
+  const isAtDefault = from === defaultFrom && to === today
+
+  return (
+    <div className={`flex flex-wrap items-center gap-1.5 ${className ?? ''}`}>
+      {label ? (
+        <span className="text-xs text-muted-foreground">{label}</span>
+      ) : (
+        <Calendar className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+      )}
+      <input
+        type="date"
+        value={from}
+        max={to}
+        aria-label="Từ ngày"
+        onChange={(e) => onChange({ from: e.target.value || defaultFrom, to })}
+        className="h-9 rounded-md border bg-transparent px-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      />
+      <span className="text-sm text-muted-foreground" aria-hidden="true">
+        –
+      </span>
+      <input
+        type="date"
+        value={to}
+        min={from}
+        max={today}
+        aria-label="Đến ngày"
+        onChange={(e) => onChange({ from, to: e.target.value || today })}
+        className="h-9 rounded-md border bg-transparent px-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      />
+      {!isAtDefault && (
+        <Button
+          variant="outline"
+          size="sm"
+          className="gap-1"
+          onClick={() => onChange({ from: defaultFrom, to: today })}
+        >
+          <RotateCcw className="size-3" />
+          {defaultDaysAgo} ngày
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/src/lib/api/remnants.ts
+++ b/src/lib/api/remnants.ts
@@ -7,6 +7,10 @@ export interface RemnantsFilter extends PageParams {
   status?: string
   min_length_mm?: number
   min_width_mm?: number
+  /** Inclusive ISO date (YYYY-MM-DD) lower bound on `created_at`. */
+  from?: string
+  /** Inclusive ISO date (YYYY-MM-DD) upper bound on `created_at`. */
+  to?: string
 }
 
 // ── Remnants API ──────────────────────────────────────────────────────────────
@@ -27,6 +31,8 @@ export const remnantsApi = {
         status: filter.status,
         min_length_mm: filter.min_length_mm,
         min_width_mm: filter.min_width_mm,
+        from: filter.from,
+        to: filter.to,
       },
     }),
 


### PR DESCRIPTION
## Summary
Closes part of #224 — wires a 30-day date-range filter into the three list pages whose backends already accept `?from=&to=`:

- `/remnants` (BE: `/inventory/remnants`)
- `/cutting-dispatch` (BE: `/work-orders` — already had it for /work-orders, just inheriting here)
- `/assembly` (BE: `/work-orders?status=IN_PROCESSING`)

`/pos` and `/purchasing` are intentionally **carved out** of this PR — the orders module BE handler doesn't parse `from`/`to` yet (tracked under BE companion issue #271). They'll be wired in a follow-up PR once that lands so we don't ship a filter that silently does nothing.

## Implementation
- New shared component `src/components/dashboard/date-range-filter.tsx` exports `DateRangeFilter`, `defaultFromIso`, `isoToday`. Cross-validates `from <= to` via the inputs' `min`/`max`, exposes a "30 ngày" reset that's hidden when already at the default, and is purely controlled.
- URL sync via the existing `usePageParams().getParam/setParams` so the params are shareable and survive Back/Forward.
- `RemnantsFilter` (`src/lib/api/remnants.ts`) gains `from?: string; to?: string` passthrough — already on `WorkOrdersFilter`.
- `/assembly` wrapped in `<Suspense>` so `usePageParams()` can use `useSearchParams()` without breaking the build (App Router requirement).

## Technical notes
- No backend contract changes. All three BE endpoints already support the params (verified via swagger / handler grep).
- 30-day default chosen to match `/costing` and `/work-orders` so users see consistent behavior across the app.
- Defensive: empty input falls back to default rather than passing an empty string to the API.
- No new query keys; the from/to values flow through the existing TanStack Query keys so refetch is automatic.

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — succeeds (27/27 prerendered)
- [ ] On each of the 3 pages, change the date range → table refetches, URL updates with `?from=&to=`
- [ ] Refresh the page → filter state restored from the URL
- [ ] "30 ngày" button hidden at default, appears after change, restores defaults on click
- [ ] `from` input blocked from going past `to`; `to` input blocked from going before `from`

🤖 Generated with [Claude Code](https://claude.com/claude-code)