### PR TITLE
[overview] sync alert banner with overflow status + cap pct

### DIFF
--- a/src/app/(dashboard)/overview/page.tsx
+++ b/src/app/(dashboard)/overview/page.tsx
@@ -23,6 +23,7 @@ import { AlertBanner } from '@/components/dashboard/alert-banner'
 import { CncQueueDepthWidget } from '@/components/dashboard/cnc-queue-depth-widget'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useDashboardOverview, useWIPPipeline } from '@/lib/hooks/use-dashboard'
+import { useOverflowStatus } from '@/lib/hooks/use-inventory'
 import { useSKUs } from '@/lib/hooks/use-skus'
 import { getCurrentRoleFromCookie } from '@/lib/auth/authorization'
 import { formatVND } from '@/lib/format'
@@ -276,6 +277,7 @@ function WholeSheetsByMaterial({ items }: { items: WholeSheetsByMaterialItem[] }
 
 export default function OverviewPage() {
   const { data, isLoading, isError, refetch } = useDashboardOverview()
+  const { data: overflow } = useOverflowStatus()
   // Pulled alongside the overview so the pie chart can render the SKU name
   // next to the SKU code (the backend dashboard payload only includes the code).
   const { data: skusData } = useSKUs({ limit: 200 })
@@ -304,8 +306,18 @@ export default function OverviewPage() {
 
   const { kpi, charts, recent_activity } = data
   const utilizationPct = Math.round(kpi.utilization_pct)
-  const alertStatus: 'RED' | 'YELLOW' | 'GREEN' =
+  // Take the worst of (a) dashboard utilization buckets and (b) the live
+  // overflow-status — they query different things and used to disagree
+  // on screen (e.g. red sticky banner over a green "bình thường" pill).
+  const utilizationStatus: 'RED' | 'YELLOW' | 'GREEN' =
     utilizationPct >= 90 ? 'RED' : utilizationPct >= 70 ? 'YELLOW' : 'GREEN'
+  const overflowStatus = overflow?.status ?? 'GREEN'
+  const alertStatus: 'RED' | 'YELLOW' | 'GREEN' =
+    overflowStatus === 'RED' || utilizationStatus === 'RED'
+      ? 'RED'
+      : overflowStatus === 'YELLOW' || utilizationStatus === 'YELLOW'
+        ? 'YELLOW'
+        : 'GREEN'
 
   const trendData = (charts.remnant_trend_7d ?? []).map((p) => ({
     ...p,
@@ -332,6 +344,9 @@ export default function OverviewPage() {
       <AlertBanner
         status={alertStatus}
         utilizationPct={utilizationPct}
+        overflowPct={overflow?.overflow_pct}
+        thresholdPct={overflow?.threshold_pct}
+        drivenByOverflow={overflowStatus === 'RED'}
         message={
           alertStatus === 'RED'
             ? 'Kho tấm lẻ quá tải — tạm ngừng xuất tấm nguyên'

--- a/src/components/dashboard/alert-banner.tsx
+++ b/src/components/dashboard/alert-banner.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangle, CheckCircle, AlertCircle } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { formatOverflowPct } from '@/components/inventory/overflow-banner'
 
 type OverflowStatus = 'GREEN' | 'YELLOW' | 'RED'
 
@@ -9,6 +10,15 @@ interface AlertBannerProps {
   utilizationPct: number
   message: string
   className?: string
+  /**
+   * Live overflow ratio from /inventory/overflow-status. When provided and
+   * `drivenByOverflow` is true, we show this metric instead of the dashboard
+   * utilization so the banner agrees with the sticky red OverflowBanner.
+   */
+  overflowPct?: number
+  thresholdPct?: number
+  /** True when status was bumped to RED by the overflow query (BR-K05). */
+  drivenByOverflow?: boolean
 }
 
 const STATUS_CONFIG: Record<
@@ -41,16 +51,25 @@ export function AlertBanner({
   utilizationPct,
   message,
   className,
+  overflowPct,
+  thresholdPct,
+  drivenByOverflow,
 }: AlertBannerProps) {
   const config = STATUS_CONFIG[status]
   const Icon = config.icon
+
+  // When the red status comes from the overflow query, show the same metric
+  // as the sticky banner so the two never disagree on screen.
+  const detail = drivenByOverflow && overflowPct != null
+    ? `Tỷ lệ tràn: ${formatOverflowPct(overflowPct)}% (ngưỡng ${thresholdPct?.toFixed(0) ?? 15}%)`
+    : `${utilizationPct.toFixed(1)}% tận dụng`
 
   return (
     <Alert className={cn(config.className, className)}>
       <Icon className="size-4" />
       <AlertTitle>{config.title}</AlertTitle>
       <AlertDescription>
-        {message} ({utilizationPct.toFixed(1)}% tận dụng)
+        {message} ({detail})
       </AlertDescription>
     </Alert>
   )

--- a/src/components/inventory/overflow-banner.tsx
+++ b/src/components/inventory/overflow-banner.tsx
@@ -5,6 +5,21 @@ import { cn } from '@/lib/utils'
 import { useOverflowStatus } from '@/lib/hooks/use-inventory'
 
 /**
+ * When the BE returns nonsensical ratios (e.g. corrupted seed data inflating
+ * remnant_area beyond every sheet ever produced), the raw percentage becomes
+ * a meaningless 6-digit number that blows up the layout. Cap the displayed
+ * value at 4 digits so the banner stays readable while still flagging that
+ * the inventory is far past the threshold.
+ */
+const DISPLAY_CAP_PCT = 9999
+
+export function formatOverflowPct(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return '—'
+  if (value >= DISPLAY_CAP_PCT) return `≥ ${DISPLAY_CAP_PCT}`
+  return value.toFixed(1)
+}
+
+/**
  * Sticky red banner shown across kiosk + dashboard layouts when remnant
  * inventory exceeds the overflow threshold (BR-K05). The banner forces the
  * shop floor to consume remnants before issuing a new whole sheet.
@@ -15,7 +30,7 @@ export function OverflowBanner({ className }: { className?: string }) {
   const { data } = useOverflowStatus()
   if (!data || !data.block_new_sheet_issue) return null
 
-  const pct = Number.isFinite(data.overflow_pct) ? data.overflow_pct.toFixed(1) : '—'
+  const pct = formatOverflowPct(data.overflow_pct)
   const threshold = Number.isFinite(data.threshold_pct) ? data.threshold_pct.toFixed(0) : '15'
 
   return (


### PR DESCRIPTION
## Summary
Fixes the visual contradiction reported on `/overview`: the sticky red `OverflowBanner` was screaming \"Kho tấm lẻ vượt 15% — Tỷ lệ hiện tại: 425924.0%\" while the dashboard `AlertBanner` directly underneath cheerfully showed \"Kho tấm lẻ bình thường (3.0% tận dụng)\". Two banners, two endpoints, two metrics — and one confused user.

## Root cause (verified against the live BE)
The two banners were querying different endpoints and computing unrelated ratios:

| Banner | Endpoint | Formula | Sample |
|---|---|---|---|
| Sticky red | `GET /inventory/overflow-status` | `total_remnant_area / total_sheet_area × 100` | 425923.95% |
| Dashboard pill | `GET /dashboard/overview` | `kpi.utilization_pct` (different denom) | 3.2% |

Both BE values are technically correct given the input — staging just has corrupted seed/load-test data (1M remnants, 7 consumed, 125k active WOs) that inflates the overflow ratio past the realm of the physically possible. But the FE shouldn't render a layout that contradicts itself regardless of input.

## Changes
- `/overview` (`src/app/(dashboard)/overview/page.tsx`) now also calls `useOverflowStatus()`. The alert state is the worst of `{utilization bucket, overflow.status}`, so it can never sit at GREEN while the sticky banner is RED.
- When the RED state is driven by overflow, the dashboard banner reports the same \"Tỷ lệ tràn / ngưỡng\" pair as the sticky banner instead of the unrelated utilization number.
- `OverflowBanner` (and the new exported `formatOverflowPct`) caps the displayed value at `≥ 9999` so absurd ratios don't blow out the layout. `AlertBanner` reuses the same helper so both reads agree.

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — succeeds
- [ ] Sign in as admin against staging (which currently returns 425924% overflow): both banners now show RED with consistent \"Tỷ lệ tràn: ≥ 9999% (ngưỡng 15%)\" copy
- [ ] In a healthy env (overflow.status = GREEN, utilization = 3%): only the dashboard pill shows, GREEN, with `3.0% tận dụng`
- [ ] In a YELLOW utilization env (`70 ≤ pct < 90`) with overflow GREEN: dashboard pill is YELLOW, sticky banner hidden — no regression

## Notes
- This does not paper over the staging data corruption — that needs a separate truncate/clean from the BE side. This PR just makes sure the FE behaves rationally regardless of what the BE returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)