### PR TITLE
fix(api): adapt to BE cursor envelope on 3 broken consumers

### DIFF
--- a/src/app/(dashboard)/costing/page.tsx
+++ b/src/app/(dashboard)/costing/page.tsx
@@ -9,7 +9,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { SearchInput } from '@/components/ui/search-input'
-import { DataPagination } from '@/components/ui/data-pagination'
+import { LoadMoreButton } from '@/components/ui/load-more-button'
 import {
   Dialog,
   DialogContent,
@@ -357,8 +357,7 @@ function CostingContent() {
   const canAdjustCosting = can(role, 'adjust', 'costing')
   const canWriteCosting = canComputeCosting || canFinalizeCosting || canAdjustCosting
 
-  const { page, search, limit, getParam, setPage, setSearch, setParam, setParams } =
-    usePageParams(10)
+  const { search, getParam, setSearch, setParam, setParams } = usePageParams(10)
 
   const [inputValue, setInputValue] = useState(search)
   const debouncedSearch = useDebounce(inputValue, 400)
@@ -396,9 +395,8 @@ function CostingContent() {
   const [computingWorkOrderId, setComputingWorkOrderId] = useState<string | null>(null)
   const [finalizingWorkOrderId, setFinalizingWorkOrderId] = useState<string | null>(null)
 
-  const { data, isLoading, isFetching, isError } = useCosting({
-    page,
-    limit,
+  const list = useCosting({
+    limit: 20,
     search: normalizedSearch,
     finalized:
       finalizedFilter === 'ALL' ? undefined : finalizedFilter === 'FINALIZED',
@@ -406,6 +404,7 @@ function CostingContent() {
     from: dateFrom || undefined,
     to: dateTo || undefined,
   })
+  const { items, hasMore, fetchNextPage, isFetchingNextPage, isLoading, isFetching, isError } = list
 
   // SKU lookup — used both for the dropdown and to render readable names in
   // the table once #190 lands.
@@ -451,10 +450,9 @@ function CostingContent() {
 
   // Defensive client-side filter: if BE silently drops sku_id/from/to params
   // (#190 says these may not be wired yet), the toolbar still narrows the
-  // visible page so the user trusts what they see. Mirrors the same fallback
+  // visible list so the user trusts what they see. Mirrors the same fallback
   // we use on /cutting-dispatch for `assigned`.
   const filteredRecords = useMemo(() => {
-    const items = data?.items ?? []
     return items.filter((r) => {
       if (skuFilter !== ALL_SKUS && r.sku_id !== skuFilter) return false
       if (dateFrom) {
@@ -467,9 +465,7 @@ function CostingContent() {
       }
       return true
     })
-  }, [data?.items, skuFilter, dateFrom, dateTo])
-  const totalItems = data?.total_items ?? 0
-  const totalPages = data?.total_pages ?? 1
+  }, [items, skuFilter, dateFrom, dateTo])
 
   function clearAllFilters() {
     setInputValue('')
@@ -617,8 +613,8 @@ function CostingContent() {
               {isLoading
                 ? 'Đang tải…'
                 : hasAnyFilter
-                  ? `Kết quả lọc (${filteredRecords.length}${filteredRecords.length !== totalItems ? ` / ${totalItems}` : ''})`
-                  : `Tất cả bản ghi (${totalItems})`}
+                  ? `Kết quả lọc (${filteredRecords.length}${hasMore ? '+' : ''})`
+                  : `Đã tải (${items.length}${hasMore ? '+' : ''})`}
             </CardTitle>
           </CardHeader>
           <CardContent className="p-0">
@@ -638,7 +634,7 @@ function CostingContent() {
               </TableHeader>
               <TableBody>
                 {isLoading ? (
-                  <TableSkeleton rows={limit} />
+                  <TableSkeleton rows={10} />
                 ) : filteredRecords.length === 0 ? (
                   <TableRow>
                     <TableCell colSpan={9} className="h-32 text-center text-muted-foreground">
@@ -747,12 +743,11 @@ function CostingContent() {
       )}
 
       {!isLoading && !isError && (
-        <DataPagination
-          currentPage={page}
-          totalPages={totalPages}
-          totalItems={totalItems}
-          limit={limit}
-          onPageChange={setPage}
+        <LoadMoreButton
+          hasMore={hasMore}
+          isFetching={isFetchingNextPage}
+          onClick={fetchNextPage}
+          itemCount={items.length}
         />
       )}
     </>

--- a/src/lib/api/barcode.ts
+++ b/src/lib/api/barcode.ts
@@ -1,5 +1,5 @@
 import { normalizeAuthToken } from '@/lib/auth/token'
-import type { BarcodeRecord, BatchPrintInput, ScanEvent, ScanResult, ScanCheckpoint, GenerateBarcodeInput } from '@/types/api'
+import type { BarcodeRecord, BatchPrintInput, CursorResult, ScanEvent, ScanResult, ScanCheckpoint, GenerateBarcodeInput } from '@/types/api'
 import { ApiClientError, apiClient } from './client'
 
 function buildApiUrl(path: string) {
@@ -45,9 +45,20 @@ export const barcodeApi = {
   listByWorkOrder: (workOrderId: string) =>
     apiClient.get<BarcodeRecord[]>('/barcodes', { params: { work_order_id: workOrderId } }),
 
-  /** GET /api/proxy/barcodes/:id/scans */
-  listScans: (barcodeId: string) =>
-    apiClient.get<ScanEvent[]>(`/barcodes/${barcodeId}/scans`),
+  /**
+   * GET /api/proxy/barcodes/:id/scans
+   * BE returns the cursor envelope; consumers (work-order detail tab, /barcodes
+   * latest-checkpoint badge) only need a flat list of recent scans, so we
+   * fetch the first page (limit=100) and unwrap. Migrate to useCursorList if
+   * a dedicated full-history viewer page is added.
+   */
+  listScans: async (barcodeId: string): Promise<ScanEvent[]> => {
+    const res = await apiClient.get<CursorResult<ScanEvent>>(
+      `/barcodes/${barcodeId}/scans`,
+      { params: { limit: 100 } },
+    )
+    return res.items
+  },
 
   /** POST /api/proxy/barcodes/:id/scans
    * scanned_by UUID is extracted server-side from the JWT — do not send it.

--- a/src/lib/api/costing.ts
+++ b/src/lib/api/costing.ts
@@ -5,13 +5,15 @@ import type {
   CostingRecord,
   CostingRecordDetail,
   CreateAdjustmentInput,
-  PageParams,
-  PagedResult,
+  CursorResult,
   WasteReportFilter,
   WasteReportRow,
 } from '@/types/api'
 
-export interface CostingFilter extends PageParams {
+export interface CostingFilter {
+  /** Opaque cursor token from the previous page; absent for the first page. */
+  cursor?: string | null
+  limit?: number
   finalized?: boolean
   work_order_id?: string
   /** SKU id filter — passed through to BE; FE also applies a defensive filter. */
@@ -39,11 +41,10 @@ function applyWasteReportParams(url: URL, filter: WasteReportFilter) {
 
 export const costingApi = {
   list: (filter: CostingFilter = {}) =>
-    apiClient.get<PagedResult<CostingRecord>>('/costing', {
+    apiClient.get<CursorResult<CostingRecord>>('/costing', {
       params: {
-        page: filter.page,
+        cursor: filter.cursor ?? undefined,
         limit: filter.limit,
-        order: filter.order,
         finalized: filter.finalized,
         work_order_id: filter.work_order_id,
         sku_id: filter.sku_id,

--- a/src/lib/api/inventory.ts
+++ b/src/lib/api/inventory.ts
@@ -1,4 +1,4 @@
-import type { AuditLogAction, AuditLogEntry, OverflowStatus } from '@/types/api'
+import type { AuditLogAction, AuditLogEntry, CursorResult, OverflowStatus } from '@/types/api'
 import { apiClient } from './client'
 
 export interface PreAssignSheetInput {
@@ -32,11 +32,15 @@ export const inventoryApi = {
 
   /**
    * GET /api/v1/inventory/audit-log?action=REMNANT_BYPASSED
-   * Returns audit-log entries filtered by action — used by the WO list to
-   * badge work orders the planner created via remnant bypass (BR-K05).
+   * BE returns the cursor envelope; this caller only needs to badge bypassed
+   * WOs in the visible list, so we fetch the first page (limit=100) and
+   * surface a flat array. Migrate to useCursorList when the audit-log gets
+   * its own viewer page.
    */
-  listAuditLogByAction: (action: AuditLogAction) =>
-    apiClient.get<AuditLogEntry[]>('/inventory/audit-log', {
-      params: { action },
-    }),
+  listAuditLogByAction: async (action: AuditLogAction): Promise<AuditLogEntry[]> => {
+    const res = await apiClient.get<CursorResult<AuditLogEntry>>('/inventory/audit-log', {
+      params: { action, limit: 100 },
+    })
+    return res.items
+  },
 }

--- a/src/lib/hooks/use-costing.ts
+++ b/src/lib/hooks/use-costing.ts
@@ -2,16 +2,23 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { costingApi, type CostingFilter } from '@/lib/api/costing'
 import { ApiClientError, mapApiErrorVi } from '@/lib/api/client'
-import type { CreateAdjustmentInput } from '@/types/api'
+import { useCursorList } from '@/lib/hooks/use-cursor-list'
+import type { CostingRecord, CreateAdjustmentInput } from '@/types/api'
 
 export const COSTING_KEY = 'costing'
 
-export function useCosting(filter: CostingFilter = {}) {
-  return useQuery({
-    queryKey: [COSTING_KEY, filter],
-    queryFn: () => costingApi.list(filter),
+/**
+ * Cursor-paginated costing list. Filters (excluding `cursor`) form the cache
+ * key — when any filter changes the cache splits and the list naturally
+ * resets to the first page.
+ */
+export function useCosting(
+  filter: Omit<CostingFilter, 'cursor'> = {},
+) {
+  return useCursorList<CostingRecord>({
+    queryKey: [COSTING_KEY, 'cursor', filter],
+    fetchPage: (cursor) => costingApi.list({ ...filter, cursor }),
     staleTime: 60_000,
-    placeholderData: (prev) => prev,
   })
 }
 


### PR DESCRIPTION
## Demo blocker — sửa gấp 3 chỗ vỡ trên dev

BE đã merge #272 Phase 4 (#283/#284/#286/#287) đổi 4 endpoint sang envelope `{ items, next_cursor, has_more }`. FE vẫn typed như array hoặc `PagedResult` cũ → 3 chỗ vỡ runtime.

| # | Trang | Triệu chứng | Fix |
|---|---|---|---|
| 1 | `/costing` | Pagination NaN — `data?.total_pages` undefined | Migrate đầy đủ qua `useCursorList` + `LoadMoreButton` |
| 2 | `/cutting-dispatch` (banner REMNANT_BYPASSED) | `Array.from(...).map()` trên object → runtime error | Unwrap envelope ở `inventoryApi.listAuditLogByAction` (limit=100) |
| 3 | Work-order detail tab "Lịch sử quét" | List scan trống / lỗi | Unwrap envelope ở `barcodeApi.listScans` (limit=100) |

## Lý do làm 2 fix khác nhau

- **`/costing`** có pagination UI thật → buộc phải migrate đầy đủ. Đổi `useCosting` sang wrap `useCursorList`, drop `page` ra khỏi filter, swap `<DataPagination>` cho `<LoadMoreButton>`. Tiêu đề chuyển sang dạng "Đã tải (N+)".
- **Audit-log banner** và **scan history** là display-only, consumer chỉ cần một flat array để render — fix tối ưu là unwrap ngay ở API layer (`limit=100`), zero call-site change. Nếu sau này có dedicated viewer cần phân trang, migrate sang `useCursorList`.

## Test plan
- [x] `npx tsc --noEmit` pass
- [x] `npm run build` pass
- [ ] /costing: load → cuộn thấy 20 dòng → "Tải thêm" hoạt động → đổi filter tự reset cursor
- [ ] /cutting-dispatch: WO bypass có badge đỏ "REMNANT_BYPASSED" như cũ
- [ ] /work-orders/:id tab Lịch sử quét: 0 và >0 row đều hiện đúng

## Related
- Infra hook: PR #236 (#231 useCursorList) đã merge vào dev
- Migration sub-issues #232-#235 vẫn open (#235 costing thì đã ăn vào PR này)