### PR TITLE
feat(auth): persona helper + RoleGate + global 403 toast (#250 phase 1)

### DIFF
--- a/src/components/auth/role-gate.test.tsx
+++ b/src/components/auth/role-gate.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+const mockUsePersona = vi.fn()
+
+vi.mock('@/lib/auth/persona', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/auth/persona')>(
+    '@/lib/auth/persona',
+  )
+  return { ...actual, usePersona: () => mockUsePersona() }
+})
+
+import { RoleGate } from '@/components/auth/role-gate'
+
+describe('RoleGate', () => {
+  it('renders children when persona is in allow list', () => {
+    mockUsePersona.mockReturnValue('PLANNER')
+    render(
+      <RoleGate allow={['PLANNER', 'ADMIN']}>
+        <button>Approve</button>
+      </RoleGate>,
+    )
+    expect(screen.getByRole('button', { name: 'Approve' })).toBeInTheDocument()
+  })
+
+  it('renders nothing when persona is not allowed and no fallback', () => {
+    mockUsePersona.mockReturnValue('WORKER')
+    const { container } = render(
+      <RoleGate allow={['PLANNER', 'ADMIN']}>
+        <button>Approve</button>
+      </RoleGate>,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders fallback when persona is not allowed and fallback given', () => {
+    mockUsePersona.mockReturnValue('WORKER')
+    render(
+      <RoleGate allow={['ADMIN']} fallback={<span>Liên hệ quản lý</span>}>
+        <button>Force unseal</button>
+      </RoleGate>,
+    )
+    expect(screen.getByText('Liên hệ quản lý')).toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('uses min hierarchy when min prop is set', () => {
+    mockUsePersona.mockReturnValue('PLANNER')
+    render(
+      <RoleGate min="WORKER">
+        <span>Visible to all</span>
+      </RoleGate>,
+    )
+    expect(screen.getByText('Visible to all')).toBeInTheDocument()
+  })
+
+  it('hides when persona is null (logged out)', () => {
+    mockUsePersona.mockReturnValue(null)
+    const { container } = render(
+      <RoleGate allow={['WORKER', 'PLANNER', 'ADMIN']}>
+        <span>Anything</span>
+      </RoleGate>,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/components/auth/role-gate.tsx
+++ b/src/components/auth/role-gate.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { isAtLeast, usePersona, type Persona } from '@/lib/auth/persona'
+
+type RoleGateProps =
+  | {
+      /** List of personas allowed to see the children. */
+      allow: Persona[]
+      min?: never
+      fallback?: ReactNode
+      children: ReactNode
+    }
+  | {
+      /**
+       * Minimum persona — treats personas as a hierarchy
+       * (WORKER < PLANNER < ADMIN) and grants access to anyone at or above.
+       */
+      min: Persona
+      allow?: never
+      fallback?: ReactNode
+      children: ReactNode
+    }
+
+/**
+ * Render `children` only when the current user's persona is in `allow` (or
+ * at/above `min`). Renders `fallback` (default: nothing) otherwise.
+ *
+ * The gate hides the element rather than disabling it — workers should not
+ * see destructive controls greyed out, since the label itself can leak
+ * planner/admin operations.
+ */
+export function RoleGate({ allow, min, fallback = null, children }: RoleGateProps) {
+  const persona = usePersona()
+  const allowed = min
+    ? isAtLeast(persona, min)
+    : persona !== null && allow.includes(persona)
+  return <>{allowed ? children : fallback}</>
+}

--- a/src/lib/auth/persona.test.ts
+++ b/src/lib/auth/persona.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { isAtLeast, personaOf } from './persona'
+
+describe('personaOf', () => {
+  it('maps admin role to ADMIN persona', () => {
+    expect(personaOf('admin')).toBe('ADMIN')
+  })
+
+  it('maps planner and accountant to PLANNER persona', () => {
+    expect(personaOf('planner')).toBe('PLANNER')
+    expect(personaOf('accountant')).toBe('PLANNER')
+  })
+
+  it('maps shop-floor roles to WORKER persona', () => {
+    expect(personaOf('warehouse')).toBe('WORKER')
+    expect(personaOf('cnc')).toBe('WORKER')
+    expect(personaOf('cnc_manager')).toBe('WORKER')
+    expect(personaOf('foreman')).toBe('WORKER')
+  })
+
+  it('returns null for unknown / missing roles', () => {
+    expect(personaOf('marketing')).toBeNull()
+    expect(personaOf('')).toBeNull()
+    expect(personaOf(null)).toBeNull()
+    expect(personaOf(undefined)).toBeNull()
+  })
+})
+
+describe('isAtLeast', () => {
+  it('respects WORKER < PLANNER < ADMIN ordering', () => {
+    expect(isAtLeast('ADMIN', 'WORKER')).toBe(true)
+    expect(isAtLeast('PLANNER', 'WORKER')).toBe(true)
+    expect(isAtLeast('WORKER', 'WORKER')).toBe(true)
+
+    expect(isAtLeast('PLANNER', 'PLANNER')).toBe(true)
+    expect(isAtLeast('ADMIN', 'PLANNER')).toBe(true)
+    expect(isAtLeast('WORKER', 'PLANNER')).toBe(false)
+
+    expect(isAtLeast('ADMIN', 'ADMIN')).toBe(true)
+    expect(isAtLeast('PLANNER', 'ADMIN')).toBe(false)
+    expect(isAtLeast('WORKER', 'ADMIN')).toBe(false)
+  })
+
+  it('returns false when persona is null', () => {
+    expect(isAtLeast(null, 'WORKER')).toBe(false)
+  })
+})

--- a/src/lib/auth/persona.ts
+++ b/src/lib/auth/persona.ts
@@ -1,0 +1,34 @@
+import { useSyncExternalStore } from 'react'
+import { getCurrentRoleFromCookie, type AppRole } from './authorization'
+
+export type Persona = 'WORKER' | 'PLANNER' | 'ADMIN'
+
+const PERSONA_BY_ROLE: Record<AppRole, Persona> = {
+  admin: 'ADMIN',
+  planner: 'PLANNER',
+  accountant: 'PLANNER',
+  warehouse: 'WORKER',
+  cnc: 'WORKER',
+  cnc_manager: 'WORKER',
+  foreman: 'WORKER',
+}
+
+export function personaOf(role: string | null | undefined): Persona | null {
+  if (!role) return null
+  return PERSONA_BY_ROLE[role as AppRole] ?? null
+}
+
+export function isAtLeast(persona: Persona | null, min: Persona): boolean {
+  if (!persona) return false
+  const order: Record<Persona, number> = { WORKER: 1, PLANNER: 2, ADMIN: 3 }
+  return order[persona] >= order[min]
+}
+
+export function usePersona(): Persona | null {
+  const role = useSyncExternalStore(
+    () => () => {},
+    () => getCurrentRoleFromCookie(),
+    () => null,
+  )
+  return personaOf(role)
+}

--- a/src/lib/providers.tsx
+++ b/src/lib/providers.tsx
@@ -1,8 +1,27 @@
 'use client'
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  MutationCache,
+  QueryCache,
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query'
 import { useState } from 'react'
+import { toast } from 'sonner'
+import { ApiClientError } from '@/lib/api/client'
 import { RealtimeProvider } from '@/lib/realtime/provider'
+
+/**
+ * Surface 403 errors as a single Vietnamese toast instead of letting every
+ * call site write its own copy. Network-level 403 means BE rejected the
+ * action — usually a planner-only / admin-only operation reached through a
+ * stale UI. Per-mutation `onError` handlers can still override.
+ */
+function showForbiddenToast(err: unknown) {
+  if (err instanceof ApiClientError && err.status === 403) {
+    toast.error('Bạn không đủ quyền cho hành động này')
+  }
+}
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -16,6 +35,8 @@ export function Providers({ children }: { children: React.ReactNode }) {
             refetchOnWindowFocus: false,
           },
         },
+        queryCache: new QueryCache({ onError: showForbiddenToast }),
+        mutationCache: new MutationCache({ onError: showForbiddenToast }),
       }),
   )
 


### PR DESCRIPTION
Refs #250 — Phase A infra. Sub-issues that wrap UI elements ship as those pages land.

## Vì sao tách phase
DoD của #250 liệt kê 8 chỗ phải `<RoleGate>`: container kanban, split-screen loading, exception queue, at-risk dashboard, Excel upload, force-unseal, cancel-approved-plan. Toàn bộ là component **chưa tồn tại** trong codebase (#238, #239, #243, #246, #247, #248). Pre-wrap = lint/build đỏ. PR này ship infra; mỗi PR Phase A sau cứ import `<RoleGate>` mà dùng.

## Changes

### `src/lib/auth/persona.ts`
- `Persona = 'WORKER' | 'PLANNER' | 'ADMIN'`
- `personaOf(role)` mirror đúng map BE #309 (admin → ADMIN; planner/accountant → PLANNER; cnc/cnc_manager/foreman/warehouse → WORKER)
- `isAtLeast(persona, min)` — hierarchy WORKER < PLANNER < ADMIN
- `usePersona()` hook — đọc từ cookie `auth_role` qua `useSyncExternalStore` (cùng pattern `useCurrentRole` đang dùng ở `bottom-nav.tsx`)

### `src/components/auth/role-gate.tsx`
- 2 dạng API: `<RoleGate allow={['PLANNER','ADMIN']}>` hoặc `<RoleGate min=\"PLANNER\">`
- Discriminated union enforces XOR ở compile time
- **Hide, không disable** — workers không thấy admin verb dù greyed-out (chống leak intent)
- `fallback` prop optional cho trường hợp cần placeholder

### `src/lib/providers.tsx`
- `QueryCache` + `MutationCache` onError → toast Vietnamese duy nhất khi BE trả 403 (\"Bạn không đủ quyền cho hành động này\")
- Per-mutation `onError` vẫn override được — giữ tương thích ngược

### Tests
- 11 case: persona mapping (4 role thật + null/empty), isAtLeast 9 cặp, RoleGate 5 case (allow hit, allow miss no fallback, allow miss with fallback, min hierarchy, logged-out null)

## Out-of-scope (ship khi PR Phase A khác lên)
- Wrap drag-drop ở container kanban → ship cùng #238
- Wrap transfer modal → cùng #239
- Wrap approve/reject → cùng #248
- Wrap boost-priority → cùng #243
- Wrap upload zone → cùng #246
- Force-unseal + cancel-approved-plan → khi entity tồn tại
- Layout guard `(office)` / `(admin)` route group → 2 group này chưa có; thêm khi pivot pages tổ chức rõ
- Login redirect persona-aware → đã có `getDefaultRouteForRole` ở `use-auth.ts`, cần verify khi WORKER persona có route landing kiosk; tách PR riêng nếu cần

## Test plan
- [x] `npx tsc --noEmit` pass
- [x] `npm run test:unit -- src/lib/auth/persona.test.ts src/components/auth/role-gate.test.tsx` — 11/11
- [x] `npm run build` pass
- [ ] Manual smoke: login bằng admin / planner / warehouse, gọi 1 endpoint 403 từ devtools → toast hiện đúng 1 lần