### PR TITLE
chore: ignore local docs/PROJECT-STATUS.md snapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ docs/demo-prototype-script.md
 docs/*demo-script*.md
 docs/customer-*.md
 docs/*-customer-*.md
+
+# Local cross-session FE status snapshot — never push (contains internal status notes)
+docs/PROJECT-STATUS.md


### PR DESCRIPTION
## Summary
Add a gitignore rule for `docs/PROJECT-STATUS.md` so each developer keeps a local cross-session snapshot of FE sprint status / PR list / next plan without committing it. Used by Claude Code (and humans) at session start to bootstrap context without re-reading the entire tree.

## Test plan
- [x] `git status` after creating the file shows it ignored.
- [x] No build / test impact (gitignore-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)